### PR TITLE
feat: EP-first scoring pipeline for buy/sell/lineup decisions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,9 @@ deploy/package/
 deploy/*.zip
 output.json
 
+# Worktrees
+.worktrees/
+
 # Web frontend (Node.js)
 web/node_modules/
 web/dist/

--- a/rehoboam/cli.py
+++ b/rehoboam/cli.py
@@ -142,6 +142,11 @@ def analyze(
         factor_weight_learner=factor_learner,
     )
 
+    # EP pipeline (default) — routes through scoring/collector → scorer → decision
+    if not detailed:
+        trader.run_ep_analysis(league)
+        return
+
     # Analyze market (suppress verbose output unless requested)
     if not verbose:
         import sys
@@ -158,12 +163,6 @@ def analyze(
     # Get team info early for budget display
     team_info = trader.api.get_team_info(league)
     current_budget = team_info.get("budget", 0)
-
-    # Use compact display by default, detailed only if requested
-    if not detailed:
-        # COMPACT MODE - Action plan focused display
-        trader.display_compact_action_plan(league, market_analyses, current_budget)
-        return
 
     # DETAILED MODE - Full analysis (original behavior)
     # SECTION 1: Market Opportunities

--- a/rehoboam/compact_display.py
+++ b/rehoboam/compact_display.py
@@ -5,6 +5,9 @@ from rich.table import Table
 
 console = Console()
 
+# Imported lazily in display_ep_action_plan to avoid circular imports at module level
+# from rehoboam.scoring.models import BuyRecommendation, SellRecommendation, TradePair, PlayerScore
+
 
 class CompactDisplay:
     """Compact display for trading analysis"""
@@ -1142,3 +1145,288 @@ class CompactDisplay:
             "[dim]Expected points based on avg performance, form, fixtures, and lineup probability[/dim]"
         )
         console.print("═" * 80 + "\n")
+
+    # ------------------------------------------------------------------
+    # EP-first action plan (new pipeline)
+    # ------------------------------------------------------------------
+
+    def display_ep_action_plan(
+        self,
+        buy_recs: list,
+        sell_recs: list,
+        trade_pairs: list,
+        squad_scores: list,
+        lineup_map: dict,
+        budget: int,
+        squad_size: int,
+    ) -> None:
+        """
+        Display an EP-first action plan produced by the scoring pipeline.
+
+        Args:
+            buy_recs: List of BuyRecommendation (squad < 15)
+            sell_recs: List of SellRecommendation
+            trade_pairs: List of TradePair (squad == 15)
+            squad_scores: List of PlayerScore for all squad members
+            lineup_map: Dict mapping player_id -> EP float for lineup display
+            budget: Current budget in raw units (e.g. cents/whole €)
+            squad_size: Current squad size
+        """
+        # ── Header ──────────────────────────────────────────────────────
+        console.print("\n" + "═" * 80)
+        console.print("[bold cyan]⚡  EP ACTION PLAN[/bold cyan]")
+        console.print("═" * 80)
+
+        budget_color = "green" if budget >= 0 else "red"
+        budget_m = budget / 1_000_000
+        console.print(
+            f"[bold]Budget:[/bold] [{budget_color}]€{budget_m:.1f}M[/{budget_color}]"
+            f"  |  [bold]Squad:[/bold] {squad_size}/15"
+        )
+
+        if budget < 0:
+            console.print(
+                f"\n[bold red on white]"
+                f" 🚨 BUDGET NEGATIVE (€{budget_m:.1f}M)"
+                f" — ZERO POINTS AT KICKOFF IF NOT FIXED! "
+                f"[/bold red on white]"
+            )
+            console.print("[red]→ Sell recommendations below to recover budget[/red]")
+
+        console.print()
+
+        # ── Lineup section ───────────────────────────────────────────────
+        if squad_scores:
+            self._display_ep_lineup(squad_scores, lineup_map)
+
+        # ── Buy / Trade section ──────────────────────────────────────────
+        if squad_size >= 15:
+            if trade_pairs:
+                console.print(
+                    f"\n[bold green]🔄 TRADE MOVES ({len(trade_pairs)} EP-improving swaps)[/bold green]"
+                )
+                console.print("[dim]Squad full (15/15) — sell first, then buy[/dim]\n")
+                self._display_ep_trade_table(trade_pairs)
+            else:
+                console.print("\n[bold yellow]🟡 NO TRADE RECOMMENDATIONS[/bold yellow]")
+                console.print(
+                    "[dim]No market players offer a significant EP improvement right now[/dim]\n"
+                )
+        else:
+            if buy_recs:
+                console.print(
+                    f"\n[bold green]🟢 BUY RECOMMENDATIONS ({len(buy_recs)} players)[/bold green]"
+                )
+                console.print("[dim]Ranked by expected matchday points[/dim]\n")
+                self._display_ep_buy_table(buy_recs)
+            else:
+                console.print("\n[bold yellow]🟡 NO BUY RECOMMENDATIONS TODAY[/bold yellow]")
+                console.print("[dim]No market players meet EP quality standards right now[/dim]\n")
+
+        # ── Sell / squad candidates section ─────────────────────────────
+        if sell_recs:
+            console.print(f"\n[bold red]🔴 SELL CANDIDATES ({len(sell_recs)} players)[/bold red]")
+            console.print("[dim]Lowest-EP squad members — consider selling[/dim]\n")
+            self._display_ep_sell_table(sell_recs)
+        else:
+            console.print("\n[bold green]✓ NO URGENT SELLS[/bold green]")
+            console.print("[dim]Your squad looks solid based on expected points[/dim]\n")
+
+        console.print("\n" + "═" * 80)
+        console.print(
+            "[dim]EP = Expected Points for next matchday "
+            "(form × fixture × lineup probability × DGW)[/dim]"
+        )
+        console.print("═" * 80 + "\n")
+
+    # ── EP helper display methods ────────────────────────────────────────
+
+    def _ep_quality_badge(self, grade: str) -> str:
+        """Return a compact data-quality badge string for a grade letter."""
+        badges = {
+            "A": "[bold green][A][/bold green]",
+            "B": "[green][B][/green]",
+            "C": "[yellow][C]⚠[/yellow]",
+            "F": "[red][F]⚠⚠[/red]",
+        }
+        return badges.get(grade, f"[dim][{grade}][/dim]")
+
+    def _ep_player_name(self, player, score) -> str:
+        """Return display name with optional DGW indicator."""
+        name = f"{player.first_name} {player.last_name}"
+        if getattr(score, "is_dgw", False):
+            name = f"⚡DGW {name}"
+        return name
+
+    def _display_ep_lineup(self, squad_scores: list, lineup_map: dict) -> None:
+        """Display optimal starters sorted by EP descending."""
+        console.print("[bold]⭐ OPTIMAL STARTING 11 (by EP)[/bold]\n")
+
+        # Sort all squad members by lineup_map EP, take top 11
+        scored = []
+        for ps in squad_scores:
+            ep_val = lineup_map.get(ps.player_id, ps.expected_points)
+            scored.append((ep_val, ps))
+        scored.sort(key=lambda x: x[0], reverse=True)
+
+        starters = scored[:11]
+        bench = scored[11:]
+
+        table = Table(show_header=True, header_style="bold cyan", box=None)
+        table.add_column("#", style="dim", width=3)
+        table.add_column("Player", style="cyan", no_wrap=True)
+        table.add_column("Pos", style="blue", width=3)
+        table.add_column("EP", justify="right", style="green", width=6)
+        table.add_column("Avg", justify="right", style="yellow", width=6)
+        table.add_column("Quality", justify="center", width=8)
+
+        for i, (ep_val, ps) in enumerate(starters, 1):
+            # Build player name with DGW badge
+            name = ps.player_id  # fallback: use ID if no name attribute
+            if hasattr(ps, "is_dgw") and ps.is_dgw:
+                name = f"⚡DGW {name}"
+
+            badge = self._ep_quality_badge(ps.data_quality.grade) if ps.data_quality else "-"
+            avg_str = f"{ps.average_points:.1f}" if ps.average_points else "-"
+            pos_str = ps.position[:2] if ps.position else "-"
+
+            table.add_row(
+                str(i),
+                name,
+                pos_str,
+                f"{ep_val:.1f}",
+                avg_str,
+                badge,
+            )
+
+        console.print(table)
+
+        if bench:
+            console.print("\n[bold]📋 BENCH[/bold] (sorted by EP)\n")
+            bench_table = Table(show_header=True, header_style="bold dim", box=None)
+            bench_table.add_column("Player", style="dim cyan", no_wrap=True)
+            bench_table.add_column("Pos", style="dim blue", width=3)
+            bench_table.add_column("EP", justify="right", style="dim green", width=6)
+            bench_table.add_column("Avg", justify="right", style="dim yellow", width=6)
+
+            for ep_val, ps in bench:
+                name = ps.player_id
+                if hasattr(ps, "is_dgw") and ps.is_dgw:
+                    name = f"⚡DGW {name}"
+                pos_str = ps.position[:2] if ps.position else "-"
+                avg_str = f"{ps.average_points:.1f}" if ps.average_points else "-"
+
+                bench_table.add_row(
+                    name,
+                    pos_str,
+                    f"{ep_val:.1f}",
+                    avg_str,
+                )
+
+            console.print(bench_table)
+
+    def _display_ep_buy_table(self, buy_recs: list) -> None:
+        """Display buy recommendations from the EP pipeline."""
+        table = Table(show_header=True, header_style="bold green", box=None)
+        table.add_column("Player", style="cyan", no_wrap=True)
+        table.add_column("Pos", style="blue", width=3)
+        table.add_column("EP", justify="right", style="green", width=6)
+        table.add_column("Quality", justify="center", width=8)
+        table.add_column("Price", justify="right", style="yellow", width=8)
+        table.add_column("Reason", style="dim")
+
+        for rec in buy_recs:
+            player = rec.player
+            score = rec.score
+            name = self._ep_player_name(player, score)
+            badge = self._ep_quality_badge(score.data_quality.grade) if score.data_quality else "-"
+            price_m = score.current_price / 1_000_000 if score.current_price else 0
+            price_str = f"€{price_m:.1f}M"
+            pos_str = (
+                player.position[:2] if hasattr(player, "position") and player.position else "-"
+            )
+
+            table.add_row(
+                name,
+                pos_str,
+                f"{rec.effective_ep:.1f}",
+                badge,
+                price_str,
+                rec.reason[:50] if rec.reason else "-",
+            )
+
+        console.print(table)
+
+    def _display_ep_trade_table(self, trade_pairs: list) -> None:
+        """Display trade pair recommendations (sell -> buy) from the EP pipeline."""
+        table = Table(show_header=True, header_style="bold green", box=None)
+        table.add_column("Sell Player (EP)", style="red", no_wrap=True)
+        table.add_column("", style="dim", width=2)
+        table.add_column("Buy Player (EP)", style="cyan", no_wrap=True)
+        table.add_column("EP Gain", justify="right", style="green", width=8)
+        table.add_column("Net Cost", justify="right", width=9)
+
+        for pair in trade_pairs:
+            sell_name = self._ep_player_name(pair.sell_player, pair.sell_score)
+            buy_name = self._ep_player_name(pair.buy_player, pair.buy_score)
+
+            sell_ep = pair.sell_score.expected_points
+            buy_ep = pair.buy_score.expected_points
+
+            sell_col = f"{sell_name}\n({sell_ep:.1f} EP)"
+            buy_col = f"{buy_name}\n({buy_ep:.1f} EP)"
+
+            ep_gain = pair.ep_gain
+            gain_color = "green" if ep_gain > 0 else "red"
+            gain_str = f"[{gain_color}]{ep_gain:+.1f}[/{gain_color}]"
+
+            net = pair.net_cost
+            net_m = net / 1_000_000
+            if net <= 0:
+                net_str = f"[green]€{net_m:+.1f}M[/green]"
+            else:
+                net_str = f"[red]€{net_m:+.1f}M[/red]"
+
+            table.add_row(sell_col, "→", buy_col, gain_str, net_str)
+
+        console.print(table)
+
+    def _display_ep_sell_table(self, sell_recs: list) -> None:
+        """Display sell recommendations from the EP pipeline."""
+        table = Table(show_header=True, header_style="bold red", box=None)
+        table.add_column("Player", style="cyan", no_wrap=True)
+        table.add_column("Pos", style="blue", width=3)
+        table.add_column("EP", justify="right", style="red", width=6)
+        table.add_column("Avg", justify="right", style="yellow", width=6)
+        table.add_column("Quality", justify="center", width=8)
+        table.add_column("Value", justify="right", style="magenta", width=8)
+        table.add_column("Status", justify="center", width=12)
+
+        for rec in sell_recs:
+            player = rec.player
+            score = rec.score
+            name = self._ep_player_name(player, score)
+            pos_str = (
+                player.position[:2] if hasattr(player, "position") and player.position else "-"
+            )
+            badge = self._ep_quality_badge(score.data_quality.grade) if score.data_quality else "-"
+            mv_m = score.market_value / 1_000_000 if score.market_value else 0
+            avg_str = f"{score.average_points:.1f}" if score.average_points else "-"
+
+            if rec.is_protected:
+                reason = rec.protection_reason or "Protected"
+                status_str = f"[yellow]🔒 {reason[:10]}[/yellow]"
+            else:
+                status_str = "[green]SELL[/green]"
+
+            table.add_row(
+                name,
+                pos_str,
+                f"{score.expected_points:.1f}",
+                avg_str,
+                badge,
+                f"€{mv_m:.1f}M",
+                status_str,
+            )
+
+        console.print(table)

--- a/rehoboam/compact_display.py
+++ b/rehoboam/compact_display.py
@@ -1345,7 +1345,7 @@ class CompactDisplay:
         table.add_column("EP", justify="right", style="green", width=6)
         table.add_column("Quality", justify="center", width=8)
         table.add_column("Price", justify="right", style="yellow", width=8)
-        table.add_column("Bid", justify="right", style="bold yellow", width=8)
+        table.add_column("Bid", justify="right", style="bold yellow", width=12)
         table.add_column("Reason", style="dim")
 
         for rec in buy_recs:
@@ -1355,8 +1355,8 @@ class CompactDisplay:
             badge = self._ep_quality_badge(score.data_quality.grade) if score.data_quality else "-"
             price_m = score.current_price / 1_000_000 if score.current_price else 0
             price_str = f"€{price_m:.1f}M"
-            bid_m = rec.recommended_bid / 1_000_000 if rec.recommended_bid else price_m
-            bid_str = f"€{bid_m:.1f}M"
+            bid = rec.recommended_bid if rec.recommended_bid else score.current_price
+            bid_str = f"€{bid:,}"
             pos_str = (
                 player.position[:2] if hasattr(player, "position") and player.position else "-"
             )
@@ -1381,7 +1381,7 @@ class CompactDisplay:
         table.add_column("Buy Player (EP)", style="cyan", no_wrap=True)
         table.add_column("EP Gain", justify="right", style="green", width=8)
         table.add_column("Net Cost", justify="right", width=9)
-        table.add_column("Bid", justify="right", style="bold yellow", width=8)
+        table.add_column("Bid", justify="right", style="bold yellow", width=12)
 
         for pair in trade_pairs:
             sell_name = self._ep_player_name(pair.sell_player, pair.sell_score)
@@ -1404,8 +1404,8 @@ class CompactDisplay:
             else:
                 net_str = f"[red]€{net_m:+.1f}M[/red]"
 
-            bid_m = pair.recommended_bid / 1_000_000 if pair.recommended_bid else 0
-            bid_str = f"€{bid_m:.1f}M"
+            bid = pair.recommended_bid if pair.recommended_bid else pair.buy_player.price
+            bid_str = f"€{bid:,}"
 
             table.add_row(sell_col, "→", buy_col, gain_str, net_str, bid_str)
 

--- a/rehoboam/compact_display.py
+++ b/rehoboam/compact_display.py
@@ -1345,6 +1345,7 @@ class CompactDisplay:
         table.add_column("EP", justify="right", style="green", width=6)
         table.add_column("Quality", justify="center", width=8)
         table.add_column("Price", justify="right", style="yellow", width=8)
+        table.add_column("Bid", justify="right", style="bold yellow", width=8)
         table.add_column("Reason", style="dim")
 
         for rec in buy_recs:
@@ -1354,6 +1355,8 @@ class CompactDisplay:
             badge = self._ep_quality_badge(score.data_quality.grade) if score.data_quality else "-"
             price_m = score.current_price / 1_000_000 if score.current_price else 0
             price_str = f"€{price_m:.1f}M"
+            bid_m = rec.recommended_bid / 1_000_000 if rec.recommended_bid else price_m
+            bid_str = f"€{bid_m:.1f}M"
             pos_str = (
                 player.position[:2] if hasattr(player, "position") and player.position else "-"
             )
@@ -1364,6 +1367,7 @@ class CompactDisplay:
                 f"{rec.effective_ep:.1f}",
                 badge,
                 price_str,
+                bid_str,
                 rec.reason[:50] if rec.reason else "-",
             )
 
@@ -1377,6 +1381,7 @@ class CompactDisplay:
         table.add_column("Buy Player (EP)", style="cyan", no_wrap=True)
         table.add_column("EP Gain", justify="right", style="green", width=8)
         table.add_column("Net Cost", justify="right", width=9)
+        table.add_column("Bid", justify="right", style="bold yellow", width=8)
 
         for pair in trade_pairs:
             sell_name = self._ep_player_name(pair.sell_player, pair.sell_score)
@@ -1399,7 +1404,10 @@ class CompactDisplay:
             else:
                 net_str = f"[red]€{net_m:+.1f}M[/red]"
 
-            table.add_row(sell_col, "→", buy_col, gain_str, net_str)
+            bid_m = pair.recommended_bid / 1_000_000 if pair.recommended_bid else 0
+            bid_str = f"€{bid_m:.1f}M"
+
+            table.add_row(sell_col, "→", buy_col, gain_str, net_str, bid_str)
 
         console.print(table)
 

--- a/rehoboam/compact_display.py
+++ b/rehoboam/compact_display.py
@@ -1159,6 +1159,7 @@ class CompactDisplay:
         lineup_map: dict,
         budget: int,
         squad_size: int,
+        squad_players: dict | None = None,
     ) -> None:
         """
         Display an EP-first action plan produced by the scoring pipeline.
@@ -1171,7 +1172,9 @@ class CompactDisplay:
             lineup_map: Dict mapping player_id -> EP float for lineup display
             budget: Current budget in raw units (e.g. cents/whole €)
             squad_size: Current squad size
+            squad_players: Dict mapping player_id -> MarketPlayer for name lookup
         """
+        self._squad_players = squad_players or {}
         # ── Header ──────────────────────────────────────────────────────
         console.print("\n" + "═" * 80)
         console.print("[bold cyan]⚡  EP ACTION PLAN[/bold cyan]")
@@ -1225,9 +1228,13 @@ class CompactDisplay:
 
         # ── Sell / squad candidates section ─────────────────────────────
         if sell_recs:
-            console.print(f"\n[bold red]🔴 SELL CANDIDATES ({len(sell_recs)} players)[/bold red]")
+            # Show only the bottom 5 sell candidates, not the entire squad
+            display_sells = sell_recs[:5]
+            console.print(
+                f"\n[bold red]🔴 SELL CANDIDATES ({len(display_sells)} lowest-EP players)[/bold red]"
+            )
             console.print("[dim]Lowest-EP squad members — consider selling[/dim]\n")
-            self._display_ep_sell_table(sell_recs)
+            self._display_ep_sell_table(display_sells)
         else:
             console.print("\n[bold green]✓ NO URGENT SELLS[/bold green]")
             console.print("[dim]Your squad looks solid based on expected points[/dim]\n")
@@ -1282,7 +1289,11 @@ class CompactDisplay:
 
         for i, (ep_val, ps) in enumerate(starters, 1):
             # Build player name with DGW badge
-            name = ps.player_id  # fallback: use ID if no name attribute
+            player = self._squad_players.get(ps.player_id)
+            if player:
+                name = f"{player.first_name} {player.last_name}"
+            else:
+                name = ps.player_id
             if hasattr(ps, "is_dgw") and ps.is_dgw:
                 name = f"⚡DGW {name}"
 
@@ -1310,7 +1321,8 @@ class CompactDisplay:
             bench_table.add_column("Avg", justify="right", style="dim yellow", width=6)
 
             for ep_val, ps in bench:
-                name = ps.player_id
+                player = self._squad_players.get(ps.player_id)
+                name = f"{player.first_name} {player.last_name}" if player else ps.player_id
                 if hasattr(ps, "is_dgw") and ps.is_dgw:
                     name = f"⚡DGW {name}"
                 pos_str = ps.position[:2] if ps.position else "-"

--- a/rehoboam/compact_display.py
+++ b/rehoboam/compact_display.py
@@ -1265,27 +1265,6 @@ class CompactDisplay:
             name = f"⚡DGW {name}"
         return name
 
-    def _ep_breakdown(self, ps) -> str:
-        """Return a compact string showing EP component scores."""
-        parts = [f"base={ps.base_points:.0f}"]
-        if ps.consistency_bonus:
-            parts.append(f"cons={ps.consistency_bonus:+.0f}")
-        if ps.lineup_bonus:
-            parts.append(f"line={ps.lineup_bonus:+.0f}")
-        if ps.fixture_bonus:
-            parts.append(f"fix={ps.fixture_bonus:+.0f}")
-        if ps.form_bonus:
-            parts.append(f"form={ps.form_bonus:+.0f}")
-        if ps.minutes_bonus:
-            parts.append(f"min={ps.minutes_bonus:+.0f}")
-        if ps.dgw_multiplier != 1.0:
-            parts.append(f"×{ps.dgw_multiplier}")
-        if ps.data_quality and ps.data_quality.grade == "F":
-            parts.append("×0.5(F)")
-        if ps.notes:
-            parts.append(f"[{', '.join(ps.notes)}]")
-        return " ".join(parts)
-
     def _display_ep_lineup(self, squad_scores: list, lineup_map: dict) -> None:
         """Display optimal starters sorted by EP descending."""
         console.print("[bold]⭐ OPTIMAL STARTING 11 (by EP)[/bold]\n")
@@ -1307,7 +1286,6 @@ class CompactDisplay:
         table.add_column("EP", justify="right", style="green", width=6)
         table.add_column("Avg", justify="right", style="yellow", width=6)
         table.add_column("Quality", justify="center", width=8)
-        table.add_column("Breakdown", style="dim")
 
         for i, (ep_val, ps) in enumerate(starters, 1):
             # Build player name with DGW badge
@@ -1322,7 +1300,6 @@ class CompactDisplay:
             badge = self._ep_quality_badge(ps.data_quality.grade) if ps.data_quality else "-"
             avg_str = f"{ps.average_points:.1f}" if ps.average_points else "-"
             pos_str = ps.position[:2] if ps.position else "-"
-            breakdown = self._ep_breakdown(ps)
 
             table.add_row(
                 str(i),
@@ -1331,7 +1308,6 @@ class CompactDisplay:
                 f"{ep_val:.1f}",
                 avg_str,
                 badge,
-                breakdown,
             )
 
         console.print(table)

--- a/rehoboam/compact_display.py
+++ b/rehoboam/compact_display.py
@@ -1265,6 +1265,27 @@ class CompactDisplay:
             name = f"⚡DGW {name}"
         return name
 
+    def _ep_breakdown(self, ps) -> str:
+        """Return a compact string showing EP component scores."""
+        parts = [f"base={ps.base_points:.0f}"]
+        if ps.consistency_bonus:
+            parts.append(f"cons={ps.consistency_bonus:+.0f}")
+        if ps.lineup_bonus:
+            parts.append(f"line={ps.lineup_bonus:+.0f}")
+        if ps.fixture_bonus:
+            parts.append(f"fix={ps.fixture_bonus:+.0f}")
+        if ps.form_bonus:
+            parts.append(f"form={ps.form_bonus:+.0f}")
+        if ps.minutes_bonus:
+            parts.append(f"min={ps.minutes_bonus:+.0f}")
+        if ps.dgw_multiplier != 1.0:
+            parts.append(f"×{ps.dgw_multiplier}")
+        if ps.data_quality and ps.data_quality.grade == "F":
+            parts.append("×0.5(F)")
+        if ps.notes:
+            parts.append(f"[{', '.join(ps.notes)}]")
+        return " ".join(parts)
+
     def _display_ep_lineup(self, squad_scores: list, lineup_map: dict) -> None:
         """Display optimal starters sorted by EP descending."""
         console.print("[bold]⭐ OPTIMAL STARTING 11 (by EP)[/bold]\n")
@@ -1286,6 +1307,7 @@ class CompactDisplay:
         table.add_column("EP", justify="right", style="green", width=6)
         table.add_column("Avg", justify="right", style="yellow", width=6)
         table.add_column("Quality", justify="center", width=8)
+        table.add_column("Breakdown", style="dim")
 
         for i, (ep_val, ps) in enumerate(starters, 1):
             # Build player name with DGW badge
@@ -1300,6 +1322,7 @@ class CompactDisplay:
             badge = self._ep_quality_badge(ps.data_quality.grade) if ps.data_quality else "-"
             avg_str = f"{ps.average_points:.1f}" if ps.average_points else "-"
             pos_str = ps.position[:2] if ps.position else "-"
+            breakdown = self._ep_breakdown(ps)
 
             table.add_row(
                 str(i),
@@ -1308,6 +1331,7 @@ class CompactDisplay:
                 f"{ep_val:.1f}",
                 avg_str,
                 badge,
+                breakdown,
             )
 
         console.print(table)

--- a/rehoboam/config.py
+++ b/rehoboam/config.py
@@ -99,6 +99,14 @@ class Settings(BaseSettings):
         default=15.0,
         description="Minimum value score difference to consider a replacement an upgrade",
     )
+    min_expected_points_to_buy: float = Field(
+        default=30.0,
+        description="Minimum expected points (0-180 scale) to consider buying a player",
+    )
+    min_ep_upgrade_threshold: float = Field(
+        default=10.0,
+        description="Minimum EP gain to consider a trade pair worthwhile",
+    )
     min_points_to_keep: int = Field(
         default=50,
         description="DEPRECATED - Bot now recommends sales based on value analysis, not raw points",

--- a/rehoboam/scoring/__init__.py
+++ b/rehoboam/scoring/__init__.py
@@ -1,0 +1,19 @@
+"""EP-first scoring pipeline for matchday point optimization."""
+
+from .models import (
+    BuyRecommendation,
+    DataQuality,
+    PlayerData,
+    PlayerScore,
+    SellRecommendation,
+    TradePair,
+)
+
+__all__ = [
+    "BuyRecommendation",
+    "DataQuality",
+    "PlayerData",
+    "PlayerScore",
+    "SellRecommendation",
+    "TradePair",
+]

--- a/rehoboam/scoring/__init__.py
+++ b/rehoboam/scoring/__init__.py
@@ -1,5 +1,7 @@
 """EP-first scoring pipeline for matchday point optimization."""
 
+from .collector import DataCollector
+from .decision import DecisionEngine
 from .models import (
     BuyRecommendation,
     DataQuality,
@@ -8,12 +10,16 @@ from .models import (
     SellRecommendation,
     TradePair,
 )
+from .scorer import score_player
 
 __all__ = [
     "BuyRecommendation",
+    "DataCollector",
     "DataQuality",
+    "DecisionEngine",
     "PlayerData",
     "PlayerScore",
     "SellRecommendation",
     "TradePair",
+    "score_player",
 ]

--- a/rehoboam/scoring/collector.py
+++ b/rehoboam/scoring/collector.py
@@ -1,0 +1,65 @@
+"""DataCollector — assembles PlayerData from pre-fetched API data."""
+
+from ..kickbase_client import MarketPlayer
+from ..matchup_analyzer import DoubleGameweekInfo, MatchupAnalyzer
+from .models import PlayerData
+
+
+class DataCollector:
+    """Assembles and validates data for scoring. Does NOT call the API."""
+
+    def __init__(self, matchup_analyzer: MatchupAnalyzer):
+        self.matchup_analyzer = matchup_analyzer
+
+    def collect(
+        self,
+        player: MarketPlayer,
+        performance: dict | None,
+        player_details: dict | None,
+        team_profiles: dict[str, dict],
+    ) -> PlayerData:
+        """Assemble PlayerData from pre-fetched data, flagging what's missing."""
+        missing = []
+
+        if performance is None:
+            missing.append("performance")
+        if player_details is None:
+            missing.append("player_details")
+
+        # DGW detection
+        dgw_info = DoubleGameweekInfo(is_dgw=False)
+        if player_details:
+            dgw_info = self.matchup_analyzer.detect_double_gameweek(player_details)
+
+        # Team strength
+        team_strength = None
+        team_profile = team_profiles.get(player.team_id)
+        if team_profile:
+            team_strength = self.matchup_analyzer.get_team_strength(team_profile)
+        else:
+            missing.append("team_strength")
+
+        # Opponent strength (from next matchup)
+        opponent_strength = None
+        if player_details:
+            next_matchup = self.matchup_analyzer.get_next_matchup(player_details)
+            if next_matchup:
+                opponent_profile = team_profiles.get(next_matchup.opponent_id)
+                if opponent_profile:
+                    opponent_strength = self.matchup_analyzer.get_team_strength(opponent_profile)
+                else:
+                    missing.append("opponent_strength")
+            else:
+                missing.append("opponent_strength")
+        else:
+            missing.append("opponent_strength")
+
+        return PlayerData(
+            player=player,
+            performance=performance,
+            player_details=player_details,
+            team_strength=team_strength,
+            opponent_strength=opponent_strength,
+            dgw_info=dgw_info,
+            missing=missing,
+        )

--- a/rehoboam/scoring/decision.py
+++ b/rehoboam/scoring/decision.py
@@ -20,6 +20,8 @@ class DecisionEngine:
         self.min_expected_points_to_buy = min_expected_points_to_buy
         self.min_ep_upgrade_threshold = min_ep_upgrade_threshold
 
+    MAX_PLAYERS_PER_TEAM = 3
+
     def recommend_buys(
         self,
         market_scores: list[PlayerScore],
@@ -32,6 +34,13 @@ class DecisionEngine:
     ) -> list[BuyRecommendation]:
         """Recommend players to buy, sorted by effective EP."""
         min_avg = self.min_avg_points_emergency if is_emergency else self.min_avg_points_to_buy
+
+        # Count players per team in current squad
+        squad_team_counts: dict[str, int] = {}
+        for sq in squad_scores:
+            if sq.team_id:
+                squad_team_counts[sq.team_id] = squad_team_counts.get(sq.team_id, 0) + 1
+
         recs = []
 
         for score in market_scores:
@@ -45,6 +54,9 @@ class DecisionEngine:
             if score.current_price > budget:
                 continue
             if score.status != 0:
+                continue
+            # Team limit: max 3 players from same team
+            if squad_team_counts.get(score.team_id, 0) >= self.MAX_PLAYERS_PER_TEAM:
                 continue
 
             player = market_players.get(score.player_id)

--- a/rehoboam/scoring/decision.py
+++ b/rehoboam/scoring/decision.py
@@ -1,7 +1,7 @@
 """DecisionEngine — buy/sell/lineup/trade-pair decisions from PlayerScore."""
 
 from ..analyzer import RosterContext
-from ..kickbase_client import MarketPlayer
+from ..kickbase_client import MarketPlayer, Player
 from .models import BuyRecommendation, PlayerScore, SellRecommendation, TradePair
 
 
@@ -77,7 +77,7 @@ class DecisionEngine:
         self,
         squad_scores: list[PlayerScore],
         roster_context: dict[str, RosterContext],
-        squad_players: dict[str, MarketPlayer],
+        squad_players: dict[str, MarketPlayer | Player],
     ) -> list[SellRecommendation]:
         """Recommend players to sell, sorted by lowest EP first."""
         recs = []
@@ -115,7 +115,7 @@ class DecisionEngine:
         roster_context: dict[str, RosterContext],
         budget: int,
         market_players: dict[str, MarketPlayer],
-        squad_players: dict[str, MarketPlayer],
+        squad_players: dict[str, MarketPlayer | Player],
         top_n: int = 5,
     ) -> list[TradePair]:
         """Build sell->buy swap pairs with positive EP gain."""

--- a/rehoboam/scoring/decision.py
+++ b/rehoboam/scoring/decision.py
@@ -1,0 +1,170 @@
+"""DecisionEngine — buy/sell/lineup/trade-pair decisions from PlayerScore."""
+
+from ..analyzer import RosterContext
+from ..kickbase_client import MarketPlayer
+from .models import BuyRecommendation, PlayerScore, SellRecommendation, TradePair
+
+
+class DecisionEngine:
+    """Makes buy/sell/lineup decisions from PlayerScore lists."""
+
+    def __init__(
+        self,
+        min_avg_points_to_buy: float = 20.0,
+        min_avg_points_emergency: float = 10.0,
+        min_expected_points_to_buy: float = 30.0,
+        min_ep_upgrade_threshold: float = 10.0,
+    ):
+        self.min_avg_points_to_buy = min_avg_points_to_buy
+        self.min_avg_points_emergency = min_avg_points_emergency
+        self.min_expected_points_to_buy = min_expected_points_to_buy
+        self.min_ep_upgrade_threshold = min_ep_upgrade_threshold
+
+    def recommend_buys(
+        self,
+        market_scores: list[PlayerScore],
+        squad_scores: list[PlayerScore],
+        roster_context: dict[str, RosterContext],
+        budget: int,
+        market_players: dict[str, MarketPlayer],
+        is_emergency: bool = False,
+        top_n: int = 5,
+    ) -> list[BuyRecommendation]:
+        """Recommend players to buy, sorted by effective EP."""
+        min_avg = self.min_avg_points_emergency if is_emergency else self.min_avg_points_to_buy
+        recs = []
+
+        for score in market_scores:
+            # Quality gates
+            if score.data_quality.grade == "F":
+                continue
+            if score.average_points < min_avg:
+                continue
+            if score.expected_points < self.min_expected_points_to_buy:
+                continue
+            if score.current_price > budget:
+                continue
+            if score.status != 0:
+                continue
+
+            player = market_players.get(score.player_id)
+            if not player:
+                continue
+
+            # Roster bonus
+            roster_bonus = 0.0
+            reason = "additional"
+            ctx = roster_context.get(score.position)
+            if ctx and ctx.is_below_minimum:
+                roster_bonus = 10.0
+                reason = "fills_gap"
+            elif ctx and not ctx.is_below_minimum:
+                reason = "upgrade"
+
+            recs.append(
+                BuyRecommendation(
+                    player=player,
+                    score=score,
+                    roster_bonus=roster_bonus,
+                    reason=reason,
+                )
+            )
+
+        recs.sort(key=lambda r: r.effective_ep, reverse=True)
+        return recs[:top_n]
+
+    def recommend_sells(
+        self,
+        squad_scores: list[PlayerScore],
+        roster_context: dict[str, RosterContext],
+        squad_players: dict[str, MarketPlayer],
+    ) -> list[SellRecommendation]:
+        """Recommend players to sell, sorted by lowest EP first."""
+        recs = []
+
+        for score in squad_scores:
+            player = squad_players.get(score.player_id)
+            if not player:
+                continue
+
+            # Check position protection — try score.position first, then player.position
+            is_protected = False
+            protection_reason = None
+            ctx = roster_context.get(score.position) or roster_context.get(player.position)
+            if ctx and ctx.current_count <= ctx.minimum_count:
+                is_protected = True
+                protection_reason = f"Min {score.position}"
+
+            recs.append(
+                SellRecommendation(
+                    player=player,
+                    score=score,
+                    is_protected=is_protected,
+                    protection_reason=protection_reason,
+                    budget_recovery=score.market_value,
+                )
+            )
+
+        recs.sort(key=lambda r: r.score.expected_points)
+        return recs
+
+    def build_trade_pairs(
+        self,
+        market_scores: list[PlayerScore],
+        squad_scores: list[PlayerScore],
+        roster_context: dict[str, RosterContext],
+        budget: int,
+        market_players: dict[str, MarketPlayer],
+        squad_players: dict[str, MarketPlayer],
+        top_n: int = 5,
+    ) -> list[TradePair]:
+        """Build sell->buy swap pairs with positive EP gain."""
+        # Get unprotected sell candidates sorted by lowest EP
+        sells = self.recommend_sells(squad_scores, roster_context, squad_players)
+        sellable = [s for s in sells if not s.is_protected]
+
+        # Get buy candidates (relaxed budget — selling frees money)
+        buys = self.recommend_buys(
+            market_scores,
+            squad_scores,
+            roster_context,
+            budget=budget + max((s.budget_recovery for s in sellable), default=0),
+            market_players=market_players,
+            top_n=20,
+        )
+
+        pairs = []
+        used_sells = set()
+        used_buys = set()
+
+        for buy_rec in buys:
+            for sell_rec in sellable:
+                if sell_rec.score.player_id in used_sells:
+                    continue
+                if buy_rec.score.player_id in used_buys:
+                    break
+
+                ep_gain = buy_rec.score.expected_points - sell_rec.score.expected_points
+                net_cost = buy_rec.score.current_price - sell_rec.score.market_value
+
+                if ep_gain >= self.min_ep_upgrade_threshold and net_cost <= budget:
+                    pairs.append(
+                        TradePair(
+                            buy_player=buy_rec.player,
+                            sell_player=sell_rec.player,
+                            buy_score=buy_rec.score,
+                            sell_score=sell_rec.score,
+                        )
+                    )
+                    used_sells.add(sell_rec.score.player_id)
+                    used_buys.add(buy_rec.score.player_id)
+                    break
+
+        return pairs[:top_n]
+
+    def select_lineup(
+        self,
+        squad_scores: list[PlayerScore],
+    ) -> dict[str, float]:
+        """Return {player_id: expected_points} for formation.select_best_eleven()."""
+        return {s.player_id: s.expected_points for s in squad_scores}

--- a/rehoboam/scoring/decision.py
+++ b/rehoboam/scoring/decision.py
@@ -123,12 +123,14 @@ class DecisionEngine:
         sells = self.recommend_sells(squad_scores, roster_context, squad_players)
         sellable = [s for s in sells if not s.is_protected]
 
-        # Get buy candidates (relaxed budget — selling frees money)
+        # Get buy candidates with relaxed budget to find all candidates
+        # (actual affordability checked per-pair below)
+        max_sell_recovery = max((s.budget_recovery for s in sellable), default=0)
         buys = self.recommend_buys(
             market_scores,
             squad_scores,
             roster_context,
-            budget=budget + max((s.budget_recovery for s in sellable), default=0),
+            budget=budget + max_sell_recovery,
             market_players=market_players,
             top_n=20,
         )
@@ -145,7 +147,8 @@ class DecisionEngine:
                     break
 
                 ep_gain = buy_rec.score.expected_points - sell_rec.score.expected_points
-                net_cost = buy_rec.score.current_price - sell_rec.score.market_value
+                # Check affordability using THIS sell's recovery, not the max
+                net_cost = buy_rec.score.current_price - sell_rec.budget_recovery
 
                 if ep_gain >= self.min_ep_upgrade_threshold and net_cost <= budget:
                     pairs.append(

--- a/rehoboam/scoring/models.py
+++ b/rehoboam/scoring/models.py
@@ -40,6 +40,7 @@ class PlayerScore:
     position: str = ""
     average_points: float = 0.0
     status: int = 0
+    team_id: str = ""
 
 
 @dataclass

--- a/rehoboam/scoring/models.py
+++ b/rehoboam/scoring/models.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass, field
 
-from ..kickbase_client import MarketPlayer
+from ..kickbase_client import MarketPlayer, Player
 from ..matchup_analyzer import DoubleGameweekInfo, TeamStrength
 
 
@@ -46,7 +46,7 @@ class PlayerScore:
 class PlayerData:
     """Raw data bundle for scoring a player."""
 
-    player: MarketPlayer
+    player: MarketPlayer | Player
     performance: dict | None
     player_details: dict | None
     team_strength: TeamStrength | None
@@ -73,7 +73,7 @@ class BuyRecommendation:
 class SellRecommendation:
     """A recommended player to sell."""
 
-    player: MarketPlayer
+    player: MarketPlayer | Player
     score: PlayerScore
     is_protected: bool
     protection_reason: str | None
@@ -85,7 +85,7 @@ class TradePair:
     """A sell->buy swap recommendation."""
 
     buy_player: MarketPlayer
-    sell_player: MarketPlayer
+    sell_player: MarketPlayer | Player
     buy_score: PlayerScore
     sell_score: PlayerScore
 

--- a/rehoboam/scoring/models.py
+++ b/rehoboam/scoring/models.py
@@ -1,0 +1,98 @@
+"""Data models for the EP-first scoring pipeline."""
+
+from dataclasses import dataclass, field
+
+from ..kickbase_client import MarketPlayer
+from ..matchup_analyzer import DoubleGameweekInfo, TeamStrength
+
+
+@dataclass
+class DataQuality:
+    """Data quality assessment for a player's score."""
+
+    grade: str
+    games_played: int
+    consistency: float
+    has_fixture_data: bool
+    has_lineup_data: bool
+    warnings: list[str] = field(default_factory=list)
+
+
+@dataclass
+class PlayerScore:
+    """Unified expected points score for a player (0-180 scale)."""
+
+    player_id: str
+    expected_points: float
+    data_quality: DataQuality
+    base_points: float
+    consistency_bonus: float
+    lineup_bonus: float
+    fixture_bonus: float
+    form_bonus: float
+    minutes_bonus: float
+    dgw_multiplier: float
+    is_dgw: bool
+    next_opponent: str | None
+    notes: list[str] = field(default_factory=list)
+    current_price: int = 0
+    market_value: int = 0
+    position: str = ""
+    average_points: float = 0.0
+    status: int = 0
+
+
+@dataclass
+class PlayerData:
+    """Raw data bundle for scoring a player."""
+
+    player: MarketPlayer
+    performance: dict | None
+    player_details: dict | None
+    team_strength: TeamStrength | None
+    opponent_strength: TeamStrength | None
+    dgw_info: DoubleGameweekInfo
+    missing: list[str] = field(default_factory=list)
+
+
+@dataclass
+class BuyRecommendation:
+    """A recommended player to buy."""
+
+    player: MarketPlayer
+    score: PlayerScore
+    roster_bonus: float
+    reason: str
+
+    @property
+    def effective_ep(self) -> float:
+        return self.score.expected_points + self.roster_bonus
+
+
+@dataclass
+class SellRecommendation:
+    """A recommended player to sell."""
+
+    player: MarketPlayer
+    score: PlayerScore
+    is_protected: bool
+    protection_reason: str | None
+    budget_recovery: int
+
+
+@dataclass
+class TradePair:
+    """A sell->buy swap recommendation."""
+
+    buy_player: MarketPlayer
+    sell_player: MarketPlayer
+    buy_score: PlayerScore
+    sell_score: PlayerScore
+
+    @property
+    def net_cost(self) -> int:
+        return self.buy_score.current_price - self.sell_score.market_value
+
+    @property
+    def ep_gain(self) -> float:
+        return self.buy_score.expected_points - self.sell_score.expected_points

--- a/rehoboam/scoring/models.py
+++ b/rehoboam/scoring/models.py
@@ -63,6 +63,7 @@ class BuyRecommendation:
     score: PlayerScore
     roster_bonus: float
     reason: str
+    recommended_bid: int = 0
 
     @property
     def effective_ep(self) -> float:
@@ -88,6 +89,7 @@ class TradePair:
     sell_player: MarketPlayer | Player
     buy_score: PlayerScore
     sell_score: PlayerScore
+    recommended_bid: int = 0
 
     @property
     def net_cost(self) -> int:

--- a/rehoboam/scoring/scorer.py
+++ b/rehoboam/scoring/scorer.py
@@ -3,7 +3,7 @@
 score_player(PlayerData) -> PlayerScore — no API calls, no side effects.
 """
 
-from .models import DataQuality
+from .models import DataQuality, PlayerData, PlayerScore
 
 
 def extract_games_and_consistency(
@@ -148,4 +148,173 @@ def grade_data_quality(
         has_fixture_data=has_fixture_data,
         has_lineup_data=has_lineup_data,
         warnings=warnings,
+    )
+
+
+def _extract_recent_avg(performance_data: dict | None, last_n: int = 5) -> float | None:
+    """Extract average points from the last N matches where the player played."""
+    if not performance_data:
+        return None
+    try:
+        seasons = performance_data.get("it", [])
+        if not seasons:
+            return None
+        seasons_sorted = sorted(seasons, key=lambda s: s.get("ti", ""), reverse=True)
+        matches = seasons_sorted[0].get("ph", [])
+        played = [m for m in matches if not ("t" in m and m["t"] == 0 and m.get("p", 0) == 0)]
+        if not played:
+            return None
+        recent = played[-last_n:]  # Last N matches
+        return sum(m.get("p", 0) for m in recent) / len(recent)
+    except Exception:
+        return None
+
+
+def score_player(data: PlayerData) -> PlayerScore:
+    """Score a player based on expected matchday points.
+
+    Pure function — no API calls, no side effects.
+    Scale is 0-180 (not 0-100) to preserve DGW advantage.
+    """
+    player = data.player
+    avg_points = player.average_points
+    notes: list[str] = []
+
+    # 1. Base points (0-40) — PRIMARY DRIVER
+    base_points = min(avg_points * 2, 40)
+
+    # 2. Consistency bonus (-5 to +15)
+    games_played, consistency = extract_games_and_consistency(data.performance)
+
+    consistency_bonus = 0.0
+    if data.performance:
+        if consistency >= 0.7:
+            consistency_bonus = 15.0
+            notes.append("Very consistent")
+        elif consistency >= 0.3:
+            consistency_bonus = consistency * 15
+        else:
+            consistency_bonus = -5.0
+            notes.append("Inconsistent")
+
+    # 3. Lineup probability (-20 to +20)
+    lineup_bonus = 0.0
+    has_lineup_data = False
+    if data.player_details:
+        has_lineup_data = True
+        prob = data.player_details.get("prob", 5)
+        if prob == 1:
+            lineup_bonus = 20.0
+            notes.append("Starter")
+        elif prob == 2:
+            lineup_bonus = 10.0
+            notes.append("Rotation")
+        elif prob == 3:
+            lineup_bonus = 0.0
+            notes.append("Bench")
+        elif prob >= 4:
+            lineup_bonus = -20.0
+            notes.append("Unlikely to play")
+
+    # 4. Fixture bonus (-10 to +15)
+    fixture_bonus = 0.0
+    has_fixture_data = data.team_strength is not None
+    next_opponent = None
+
+    if data.team_strength and data.opponent_strength:
+        # Difficulty based on relative strength
+        strength_diff = data.opponent_strength.strength_score - data.team_strength.strength_score
+        raw_bonus = -strength_diff / 5  # Scale: 50pt diff -> ±10 bonus
+        fixture_bonus = max(-10.0, min(15.0, raw_bonus))
+        next_opponent = data.opponent_strength.team_name
+
+        if fixture_bonus >= 5:
+            notes.append("Easy fixture")
+        elif fixture_bonus <= -5:
+            notes.append("Hard fixture")
+
+    # 5. Form bonus (-10 to +10) — recent matches vs season average
+    form_bonus = 0.0
+    recent_avg = _extract_recent_avg(data.performance, last_n=5)
+    if recent_avg is not None and avg_points > 0:
+        form_ratio = recent_avg / avg_points
+        if form_ratio > 2.0:
+            form_bonus = 10.0
+            notes.append("Hot streak")
+        elif form_ratio > 1.3:
+            form_bonus = 5.0
+        elif form_ratio < 0.5 and recent_avg > 0:
+            form_bonus = -5.0
+            notes.append("Below average")
+        elif recent_avg == 0:
+            form_bonus = -10.0
+            notes.append("Not scoring")
+    elif avg_points == 0:
+        form_bonus = -10.0
+        notes.append("Not scoring")
+
+    # 6. Minutes bonus (-10 to +10)
+    minutes_bonus = 0.0
+    if data.performance:
+        trend, avg_min, is_sub = extract_minutes_analysis(data.performance)
+        if trend == "increasing":
+            minutes_bonus = 10.0
+            notes.append("Minutes increasing")
+        elif trend == "decreasing":
+            minutes_bonus = -10.0
+            notes.append("Minutes decreasing")
+        elif trend == "stable" and avg_min is not None and avg_min < 30:
+            minutes_bonus = -8.0
+            notes.append("Rarely plays")
+
+    # Sum components
+    raw_total = (
+        base_points + consistency_bonus + lineup_bonus + fixture_bonus + form_bonus + minutes_bonus
+    )
+
+    # DGW multiplier
+    dgw_multiplier = 1.8 if data.dgw_info.is_dgw else 1.0
+    if data.dgw_info.is_dgw:
+        notes.append("DOUBLE GAMEWEEK")
+
+    total = raw_total * dgw_multiplier
+
+    # Data quality grading
+    data_quality = grade_data_quality(
+        games_played=games_played,
+        consistency=consistency,
+        has_fixture_data=has_fixture_data,
+        has_lineup_data=has_lineup_data,
+    )
+
+    # Grade F penalty: halve the score, but only when we have performance data
+    # showing the player has played very few games. When there is no performance
+    # data at all, grade F means "unknown" not "poor" — don't penalize.
+    if data_quality.grade == "F" and data.performance is not None:
+        total *= 0.5
+
+    # Clamp to 0-180
+    total = max(0, min(180, total))
+
+    price = getattr(player, "price", player.market_value)
+
+    return PlayerScore(
+        player_id=player.id,
+        expected_points=round(total, 1),
+        data_quality=data_quality,
+        base_points=base_points,
+        consistency_bonus=round(consistency_bonus, 1),
+        lineup_bonus=lineup_bonus,
+        fixture_bonus=round(fixture_bonus, 1),
+        form_bonus=form_bonus,
+        minutes_bonus=minutes_bonus,
+        dgw_multiplier=dgw_multiplier,
+        is_dgw=data.dgw_info.is_dgw,
+        next_opponent=next_opponent,
+        notes=notes,
+        current_price=price,
+        market_value=player.market_value,
+        position=player.position,
+        average_points=avg_points,
+        status=player.status,
     )

--- a/rehoboam/scoring/scorer.py
+++ b/rehoboam/scoring/scorer.py
@@ -1,0 +1,151 @@
+"""Pure scoring function for the EP-first pipeline.
+
+score_player(PlayerData) -> PlayerScore — no API calls, no side effects.
+"""
+
+from .models import DataQuality
+
+
+def extract_games_and_consistency(
+    performance_data: dict | None,
+) -> tuple[int, float]:
+    """Extract games played and consistency score from performance data.
+
+    Returns:
+        (games_played, consistency_score 0-1 where 1 = very consistent)
+    """
+    if not performance_data:
+        return 0, 0.0
+
+    try:
+        seasons = performance_data.get("it", [])
+        if not seasons:
+            return 0, 0.0
+
+        seasons_sorted = sorted(seasons, key=lambda s: s.get("ti", ""), reverse=True)
+        current_season = seasons_sorted[0]
+        matches = current_season.get("ph", [])
+
+        # Only count matches where player actually played.
+        # Exclude only when minutes are explicitly recorded as 0 (didn't play).
+        # If no "t" key, assume the match counts (minutes not tracked).
+        matches_played = [
+            m for m in matches if not ("t" in m and m["t"] == 0 and m.get("p", 0) == 0)
+        ]
+        games_played = len(matches_played)
+
+        if games_played == 0:
+            return 0, 0.0
+        if games_played == 1:
+            return 1, 0.5
+
+        match_points = [m.get("p", 0) for m in matches_played]
+        mean_points = sum(match_points) / games_played
+        if mean_points == 0:
+            return games_played, 0.0
+
+        variance = sum((p - mean_points) ** 2 for p in match_points) / games_played
+        std_dev = variance**0.5
+        cv = std_dev / mean_points if mean_points > 0 else 1.0
+
+        # CV 0 = perfect consistency (1.0), CV 1.5+ = very inconsistent (0.0)
+        consistency = max(0.0, 1.0 - (cv / 1.5))
+        return games_played, consistency
+
+    except Exception:
+        return 0, 0.0
+
+
+def extract_minutes_analysis(
+    performance_data: dict | None,
+) -> tuple[str | None, float | None, bool | None]:
+    """Extract minutes trend, average minutes, and substitution pattern.
+
+    Returns:
+        (minutes_trend, avg_minutes, is_substitute_pattern)
+    """
+    if not performance_data:
+        return None, None, None
+
+    try:
+        seasons = performance_data.get("it", [])
+        if not seasons:
+            return None, None, None
+
+        seasons_sorted = sorted(seasons, key=lambda s: s.get("ti", ""), reverse=True)
+        current_season = seasons_sorted[0]
+        matches = current_season.get("ph", [])
+
+        minutes_data = [m.get("t") for m in matches if m.get("t") is not None]
+        if len(minutes_data) < 2:
+            return None, None, None
+
+        avg_minutes = sum(minutes_data) / len(minutes_data)
+
+        # Trend: compare first half vs second half
+        minutes_trend = "stable"
+        if len(minutes_data) >= 4:
+            half = len(minutes_data) // 2
+            first_avg = sum(minutes_data[:half]) / half
+            second_avg = sum(minutes_data[half:]) / (len(minutes_data) - half)
+            diff_pct = ((second_avg - first_avg) / max(first_avg, 1)) * 100
+
+            if diff_pct > 15:
+                minutes_trend = "increasing"
+            elif diff_pct < -15:
+                minutes_trend = "decreasing"
+
+        # Substitute pattern
+        is_sub = avg_minutes < 60
+        if not is_sub and len(minutes_data) >= 3:
+            variance = sum((m - avg_minutes) ** 2 for m in minutes_data) / len(minutes_data)
+            if variance**0.5 > 25 and avg_minutes < 75:
+                is_sub = True
+
+        return minutes_trend, avg_minutes, is_sub
+
+    except Exception:
+        return None, None, None
+
+
+def grade_data_quality(
+    games_played: int,
+    consistency: float,
+    has_fixture_data: bool,
+    has_lineup_data: bool,
+) -> DataQuality:
+    """Assign a data quality grade based on available data."""
+    warnings = []
+
+    if games_played == 0:
+        warnings.append("No games played")
+    elif games_played <= 1:
+        warnings.append(f"Only {games_played} game played")
+    elif games_played <= 4:
+        warnings.append(f"Only {games_played} games played")
+
+    if not has_fixture_data:
+        warnings.append("No fixture data")
+    if not has_lineup_data:
+        warnings.append("No lineup data")
+
+    # Grade assignment
+    if games_played <= 1:
+        grade = "F"
+    elif games_played <= 4 or (not has_fixture_data and not has_lineup_data):
+        grade = "C"
+    elif games_played <= 9 or (has_fixture_data != has_lineup_data):
+        # 5-9 games, or has only one of fixture/lineup
+        grade = "B"
+    else:
+        # 10+ games with both fixture and lineup data
+        grade = "A"
+
+    return DataQuality(
+        grade=grade,
+        games_played=games_played,
+        consistency=consistency,
+        has_fixture_data=has_fixture_data,
+        has_lineup_data=has_lineup_data,
+        warnings=warnings,
+    )

--- a/rehoboam/scoring/scorer.py
+++ b/rehoboam/scoring/scorer.py
@@ -318,4 +318,5 @@ def score_player(data: PlayerData) -> PlayerScore:
         position=player.position,
         average_points=avg_points,
         status=status,
+        team_id=getattr(player, "team_id", ""),
     )

--- a/rehoboam/scoring/scorer.py
+++ b/rehoboam/scoring/scorer.py
@@ -297,6 +297,7 @@ def score_player(data: PlayerData) -> PlayerScore:
     total = max(0, min(180, total))
 
     price = getattr(player, "price", player.market_value)
+    status = getattr(player, "status", 0)  # Player (squad) has no status field
 
     return PlayerScore(
         player_id=player.id,
@@ -316,5 +317,5 @@ def score_player(data: PlayerData) -> PlayerScore:
         market_value=player.market_value,
         position=player.position,
         average_points=avg_points,
-        status=player.status,
+        status=status,
     )

--- a/rehoboam/scoring/scorer.py
+++ b/rehoboam/scoring/scorer.py
@@ -27,11 +27,9 @@ def extract_games_and_consistency(
         matches = current_season.get("ph", [])
 
         # Only count matches where player actually played.
-        # Exclude only when minutes are explicitly recorded as 0 (didn't play).
-        # If no "t" key, assume the match counts (minutes not tracked).
-        matches_played = [
-            m for m in matches if not ("t" in m and m["t"] == 0 and m.get("p", 0) == 0)
-        ]
+        # A player "played" if they scored points (even negative) OR had minutes > 0.
+        # This excludes upcoming/unplayed fixtures that have p=0 and no minutes.
+        matches_played = [m for m in matches if m.get("p", 0) != 0 or m.get("t", 0) > 0]
         games_played = len(matches_played)
 
         if games_played == 0:
@@ -76,7 +74,8 @@ def extract_minutes_analysis(
         current_season = seasons_sorted[0]
         matches = current_season.get("ph", [])
 
-        minutes_data = [m.get("t") for m in matches if m.get("t") is not None]
+        # Only include matches where player actually had minutes (exclude future/unplayed)
+        minutes_data = [m.get("t") for m in matches if m.get("t") is not None and m["t"] > 0]
         if len(minutes_data) < 2:
             return None, None, None
 
@@ -161,7 +160,7 @@ def _extract_recent_avg(performance_data: dict | None, last_n: int = 5) -> float
             return None
         seasons_sorted = sorted(seasons, key=lambda s: s.get("ti", ""), reverse=True)
         matches = seasons_sorted[0].get("ph", [])
-        played = [m for m in matches if not ("t" in m and m["t"] == 0 and m.get("p", 0) == 0)]
+        played = [m for m in matches if m.get("p", 0) != 0 or m.get("t", 0) > 0]
         if not played:
             return None
         recent = played[-last_n:]  # Last N matches

--- a/rehoboam/trader.py
+++ b/rehoboam/trader.py
@@ -2340,6 +2340,200 @@ class Trader:
         """
         return {a.player.id: a.value_score for a in analyses}
 
+    def run_ep_analysis(self, league: League) -> None:
+        """Run the EP-first scoring pipeline and display the action plan.
+
+        This is a new analysis path that routes through the scoring pipeline
+        (scoring/collector.py -> scoring/scorer.py -> scoring/decision.py).
+        It does NOT modify any existing methods — the trade command still uses
+        the old path.
+
+        Args:
+            league: League object
+        """
+        from .roster_analyzer import RosterAnalyzer
+        from .scoring.collector import DataCollector
+        from .scoring.decision import DecisionEngine
+        from .scoring.scorer import score_player
+
+        console.print("\n[bold cyan]EP Analysis (Expected Points Pipeline)[/bold cyan]\n")
+
+        # --- 1. Fetch squad and market ---
+        squad = self.api.get_squad(league)
+        squad_size = len(squad)
+        is_emergency = squad_size < self.settings.min_squad_size
+
+        market_players_list = self.api.get_market(league)
+        # Only Kickbase-owned players are buyable
+        kickbase_market = [p for p in market_players_list if p.is_kickbase_seller()]
+
+        team_info = self.api.get_team_info(league)
+        current_budget = team_info.get("budget", 0)
+
+        # --- 2. Collect performance + details + team profiles for every player ---
+        # Build a shared cache of team profiles keyed by team_id to avoid duplicate fetches.
+        team_profiles: dict[str, dict] = {}
+
+        def _get_team_profile_cached(team_id: str) -> dict | None:
+            if not team_id:
+                return None
+            if team_id not in team_profiles:
+                try:
+                    profile = self.api.client.get_team_profile(league.id, team_id)
+                    team_profiles[team_id] = profile
+                except Exception:
+                    team_profiles[team_id] = {}
+            return team_profiles[team_id] or None
+
+        def _fetch_player_data(player) -> tuple[dict | None, dict | None]:
+            """Fetch (performance, player_details) for a player, using cache."""
+            perf_data = None
+            try:
+                perf_data = self.history_cache.get_cached_performance(
+                    player_id=player.id, league_id=league.id, max_age_hours=6
+                )
+                if not perf_data:
+                    perf_data = self.api.client.get_player_performance(league.id, player.id)
+                    if perf_data:
+                        self.history_cache.cache_performance(player.id, league.id, perf_data)
+            except Exception:
+                if self.verbose:
+                    console.print(f"[dim]EP: perf fetch failed for {player.last_name}[/dim]")
+                perf_data = None
+
+            player_details = None
+            try:
+                player_details = self.api.client.get_player_details(league.id, player.id)
+            except Exception:
+                if self.verbose:
+                    console.print(f"[dim]EP: details fetch failed for {player.last_name}[/dim]")
+
+            # Pre-cache team profile so collector can use it
+            if player_details:
+                tid = player_details.get("tid", "")
+                _get_team_profile_cached(tid)
+                # Also cache opponent team if available
+                from .matchup_analyzer import MatchupAnalyzer as _MA  # noqa: F401
+
+                next_matchup = self.matchup_analyzer.get_next_matchup(player_details)
+                if next_matchup and next_matchup.opponent_id:
+                    _get_team_profile_cached(next_matchup.opponent_id)
+            else:
+                # Fall back to team_id on player object
+                _get_team_profile_cached(getattr(player, "team_id", ""))
+
+            return perf_data, player_details
+
+        # --- 3. Build DataCollector and score all players ---
+        collector = DataCollector(matchup_analyzer=self.matchup_analyzer)
+
+        market_scores: list = []
+        market_player_map: dict = {}
+
+        for player in kickbase_market:
+            try:
+                perf, details = _fetch_player_data(player)
+                player_data = collector.collect(
+                    player=player,
+                    performance=perf,
+                    player_details=details,
+                    team_profiles=team_profiles,
+                )
+                ps = score_player(player_data)
+                market_scores.append(ps)
+                market_player_map[player.id] = player
+            except Exception as e:
+                if self.verbose:
+                    console.print(f"[dim]EP: scoring failed for {player.last_name}: {e}[/dim]")
+
+        squad_scores: list = []
+        squad_player_map: dict = {}
+
+        for player in squad:
+            try:
+                perf, details = _fetch_player_data(player)
+                player_data = collector.collect(
+                    player=player,
+                    performance=perf,
+                    player_details=details,
+                    team_profiles=team_profiles,
+                )
+                ps = score_player(player_data)
+                squad_scores.append(ps)
+                squad_player_map[player.id] = player
+            except Exception as e:
+                if self.verbose:
+                    console.print(f"[dim]EP: scoring failed for {player.last_name}: {e}[/dim]")
+
+        # --- 4. Build roster context for position-aware decisions ---
+        roster_context: dict = {}
+        try:
+            player_stats = {}
+            for player in squad:
+                try:
+                    history = self.trend_service._get_raw_history(player.id, league.id)
+                    player_stats[player.id] = history
+                except Exception:
+                    player_stats[player.id] = None
+
+            player_values = self._enrich_squad_values(squad, league)
+            roster_analyzer = RosterAnalyzer()
+            roster_context = roster_analyzer.analyze_roster(squad, player_stats, player_values)
+        except Exception as e:
+            if self.verbose:
+                console.print(f"[yellow]EP: roster context failed: {e}[/yellow]")
+
+        # --- 5. Make decisions ---
+        engine = DecisionEngine(
+            min_avg_points_to_buy=20.0,
+            min_avg_points_emergency=10.0,
+            min_expected_points_to_buy=30.0,
+            min_ep_upgrade_threshold=10.0,
+        )
+
+        if squad_size >= 15:
+            # Full squad — show trade pairs instead of plain buys
+            buy_recs = []
+            trade_pairs = engine.build_trade_pairs(
+                market_scores=market_scores,
+                squad_scores=squad_scores,
+                roster_context=roster_context,
+                budget=current_budget,
+                market_players=market_player_map,
+                squad_players=squad_player_map,
+                top_n=5,
+            )
+        else:
+            buy_recs = engine.recommend_buys(
+                market_scores=market_scores,
+                squad_scores=squad_scores,
+                roster_context=roster_context,
+                budget=current_budget,
+                market_players=market_player_map,
+                is_emergency=is_emergency,
+                top_n=8 if is_emergency else 5,
+            )
+            trade_pairs = []
+
+        sell_recs = engine.recommend_sells(
+            squad_scores=squad_scores,
+            roster_context=roster_context,
+            squad_players=squad_player_map,
+        )
+
+        lineup_map = engine.select_lineup(squad_scores)
+
+        # --- 6. Display ---
+        self.compact_display.display_ep_action_plan(
+            buy_recs=buy_recs,
+            sell_recs=sell_recs,
+            trade_pairs=trade_pairs,
+            squad_scores=squad_scores,
+            lineup_map=lineup_map,
+            budget=current_budget,
+            squad_size=squad_size,
+        )
+
     def auto_trade(self, league: League, max_trades: int = 5):
         """Run automated trading cycle"""
         console.print("\n[bold cyan]Starting Automated Trading Cycle[/bold cyan]\n")

--- a/rehoboam/trader.py
+++ b/rehoboam/trader.py
@@ -2487,8 +2487,8 @@ class Trader:
         engine = DecisionEngine(
             min_avg_points_to_buy=20.0,
             min_avg_points_emergency=10.0,
-            min_expected_points_to_buy=30.0,
-            min_ep_upgrade_threshold=10.0,
+            min_expected_points_to_buy=getattr(self.settings, "min_expected_points_to_buy", 30.0),
+            min_ep_upgrade_threshold=getattr(self.settings, "min_ep_upgrade_threshold", 10.0),
         )
 
         if squad_size >= 15:
@@ -2532,6 +2532,7 @@ class Trader:
             lineup_map=lineup_map,
             budget=current_budget,
             squad_size=squad_size,
+            squad_players=squad_player_map,
         )
 
     def auto_trade(self, league: League, max_trades: int = 5):

--- a/rehoboam/trader.py
+++ b/rehoboam/trader.py
@@ -2521,6 +2521,38 @@ class Trader:
             squad_players=squad_player_map,
         )
 
+        # --- Compute bid amounts for buy recommendations ---
+        for rec in buy_recs:
+            try:
+                # Map EP (0-180) to value_score (0-100) for bidding strategy
+                ep_as_value_score = min(100.0, rec.score.expected_points * (100.0 / 180.0))
+                bid_rec = self.bidding.calculate_bid(
+                    asking_price=rec.player.price,
+                    market_value=rec.player.market_value,
+                    value_score=ep_as_value_score,
+                    confidence=0.7,
+                    average_points=rec.score.average_points,
+                    roster_impact=rec.roster_bonus,
+                )
+                rec.recommended_bid = bid_rec.recommended_bid
+            except Exception:
+                rec.recommended_bid = rec.player.price  # Fallback: bid asking price
+        for pair in trade_pairs:
+            try:
+                ep_as_value_score = min(100.0, pair.buy_score.expected_points * (100.0 / 180.0))
+                bid_rec = self.bidding.calculate_bid(
+                    asking_price=pair.buy_player.price,
+                    market_value=pair.buy_player.market_value,
+                    value_score=ep_as_value_score,
+                    confidence=0.7,
+                    average_points=pair.buy_score.average_points,
+                    is_replacement=True,
+                    replacement_sell_value=pair.sell_score.market_value,
+                )
+                pair.recommended_bid = bid_rec.recommended_bid
+            except Exception:
+                pair.recommended_bid = pair.buy_player.price
+
         lineup_map = engine.select_lineup(squad_scores)
 
         # --- 6. Display ---

--- a/tests/test_scoring/test_collector.py
+++ b/tests/test_scoring/test_collector.py
@@ -1,0 +1,81 @@
+"""Tests for DataCollector — assembles PlayerData from pre-fetched API data."""
+
+from rehoboam.kickbase_client import MarketPlayer
+from rehoboam.matchup_analyzer import MatchupAnalyzer
+from rehoboam.scoring.collector import DataCollector
+from rehoboam.scoring.models import PlayerData
+
+
+def _make_player(**overrides) -> MarketPlayer:
+    defaults = {
+        "id": "p1",
+        "first_name": "Test",
+        "last_name": "Player",
+        "position": "Midfielder",
+        "team_id": "t1",
+        "team_name": "Test FC",
+        "price": 5_000_000,
+        "market_value": 5_000_000,
+        "points": 100,
+        "average_points": 12.0,
+        "status": 0,
+    }
+    defaults.update(overrides)
+    return MarketPlayer(**defaults)
+
+
+class TestDataCollector:
+    def setup_method(self):
+        self.collector = DataCollector(matchup_analyzer=MatchupAnalyzer())
+
+    def test_collect_with_all_data(self):
+        player = _make_player()
+        performance = {"it": [{"ti": "2025", "ph": [{"p": 80, "t": 90}]}]}
+        player_details = {"prob": 1, "st": 0, "tid": "t1", "mdsum": []}
+        team_profiles = {
+            "t1": {"tid": "t1", "tn": "Test FC", "pl": 5, "tw": 10, "td": 3, "tl": 5},
+        }
+
+        pd = self.collector.collect(player, performance, player_details, team_profiles)
+        assert isinstance(pd, PlayerData)
+        assert pd.player.id == "p1"
+        assert pd.performance is not None
+        assert pd.player_details is not None
+        assert (
+            pd.missing == [] or "opponent_strength" in pd.missing
+        )  # opponent may be missing without matchup data
+
+    def test_collect_missing_performance(self):
+        player = _make_player()
+        pd = self.collector.collect(player, None, None, {})
+        assert "performance" in pd.missing
+        assert "player_details" in pd.missing
+
+    def test_collect_detects_dgw(self):
+        player = _make_player()
+        # Two matches in same matchday = DGW
+        player_details = {
+            "prob": 1,
+            "st": 0,
+            "tid": "t1",
+            "mdsum": [
+                {"mdid": "md1", "mdst": 0, "t1": "t1", "t2": "t2"},
+                {"mdid": "md1", "mdst": 0, "t1": "t3", "t2": "t1"},
+            ],
+        }
+        pd = self.collector.collect(player, None, player_details, {})
+        assert pd.dgw_info.is_dgw is True
+
+    def test_collect_no_dgw(self):
+        player = _make_player()
+        player_details = {
+            "prob": 1,
+            "st": 0,
+            "tid": "t1",
+            "mdsum": [
+                {"mdid": "md1", "mdst": 0, "t1": "t1", "t2": "t2"},
+                {"mdid": "md2", "mdst": 0, "t1": "t3", "t2": "t1"},
+            ],
+        }
+        pd = self.collector.collect(player, None, player_details, {})
+        assert pd.dgw_info.is_dgw is False

--- a/tests/test_scoring/test_decision.py
+++ b/tests/test_scoring/test_decision.py
@@ -1,0 +1,200 @@
+"""Tests for DecisionEngine — buy/sell/lineup/trade-pair from PlayerScore."""
+
+from rehoboam.analyzer import RosterContext
+from rehoboam.kickbase_client import MarketPlayer
+from rehoboam.scoring.decision import DecisionEngine
+from rehoboam.scoring.models import DataQuality, PlayerScore
+
+
+def _make_player(**overrides) -> MarketPlayer:
+    defaults = {
+        "id": "p1",
+        "first_name": "Test",
+        "last_name": "Player",
+        "position": "Midfielder",
+        "team_id": "t1",
+        "team_name": "Test FC",
+        "price": 5_000_000,
+        "market_value": 5_000_000,
+        "points": 100,
+        "average_points": 20.0,
+        "status": 0,
+    }
+    defaults.update(overrides)
+    return MarketPlayer(**defaults)
+
+
+def _make_score(
+    player_id: str = "p1",
+    ep: float = 60.0,
+    grade: str = "A",
+    avg_points: float = 20.0,
+    price: int = 5_000_000,
+    market_value: int = 5_000_000,
+    position: str = "Midfielder",
+    status: int = 0,
+) -> PlayerScore:
+    return PlayerScore(
+        player_id=player_id,
+        expected_points=ep,
+        data_quality=DataQuality(
+            grade=grade,
+            games_played=15,
+            consistency=0.8,
+            has_fixture_data=True,
+            has_lineup_data=True,
+            warnings=[],
+        ),
+        base_points=30.0,
+        consistency_bonus=10.0,
+        lineup_bonus=20.0,
+        fixture_bonus=0.0,
+        form_bonus=0.0,
+        minutes_bonus=0.0,
+        dgw_multiplier=1.0,
+        is_dgw=False,
+        next_opponent=None,
+        notes=[],
+        current_price=price,
+        market_value=market_value,
+        position=position,
+        average_points=avg_points,
+        status=status,
+    )
+
+
+def _make_roster_context(position: str, current_count: int, minimum_count: int) -> RosterContext:
+    return RosterContext(
+        position=position,
+        current_count=current_count,
+        minimum_count=minimum_count,
+        existing_players=[],
+        weakest_player=None,
+        is_below_minimum=current_count < minimum_count,
+        upgrade_potential=0.0,
+    )
+
+
+class TestRecommendBuys:
+    def test_sorts_by_ep_descending(self):
+        engine = DecisionEngine()
+        scores = [
+            _make_score("p1", ep=50.0, avg_points=20.0),
+            _make_score("p2", ep=80.0, avg_points=25.0),
+            _make_score("p3", ep=65.0, avg_points=22.0),
+        ]
+        players = {s.player_id: _make_player(id=s.player_id, average_points=20.0) for s in scores}
+        recs = engine.recommend_buys(scores, [], {}, 10_000_000, players)
+        assert recs[0].score.player_id == "p2"
+        assert recs[1].score.player_id == "p3"
+
+    def test_filters_grade_f(self):
+        engine = DecisionEngine()
+        scores = [
+            _make_score("p1", ep=80.0, grade="F", avg_points=20.0),
+            _make_score("p2", ep=60.0, grade="A", avg_points=20.0),
+        ]
+        players = {s.player_id: _make_player(id=s.player_id, average_points=20.0) for s in scores}
+        recs = engine.recommend_buys(scores, [], {}, 10_000_000, players)
+        assert len(recs) == 1
+        assert recs[0].score.player_id == "p2"
+
+    def test_filters_low_avg_points(self):
+        engine = DecisionEngine()
+        scores = [
+            _make_score("p1", ep=60.0, avg_points=15.0),  # Below 20 threshold
+        ]
+        players = {"p1": _make_player(id="p1", average_points=15.0)}
+        recs = engine.recommend_buys(scores, [], {}, 10_000_000, players)
+        assert len(recs) == 0
+
+    def test_filters_low_ep(self):
+        engine = DecisionEngine(min_expected_points_to_buy=30.0)
+        scores = [
+            _make_score("p1", ep=20.0, avg_points=20.0),  # Below 30 EP threshold
+        ]
+        players = {"p1": _make_player(id="p1", average_points=20.0)}
+        recs = engine.recommend_buys(scores, [], {}, 10_000_000, players)
+        assert len(recs) == 0
+
+    def test_fills_gap_bonus(self):
+        engine = DecisionEngine()
+        scores = [_make_score("p1", ep=60.0, avg_points=20.0, position="Goalkeeper")]
+        players = {"p1": _make_player(id="p1", position="Goalkeeper", average_points=20.0)}
+        roster_ctx = {"Goalkeeper": _make_roster_context("Goalkeeper", 0, 1)}
+        recs = engine.recommend_buys(scores, [], roster_ctx, 10_000_000, players)
+        assert recs[0].roster_bonus == 10.0
+        assert recs[0].reason == "fills_gap"
+
+    def test_respects_budget(self):
+        engine = DecisionEngine()
+        scores = [_make_score("p1", ep=80.0, price=10_000_000, avg_points=20.0)]
+        players = {"p1": _make_player(id="p1", price=10_000_000, average_points=20.0)}
+        recs = engine.recommend_buys(scores, [], {}, 5_000_000, players)
+        assert len(recs) == 0
+
+
+class TestRecommendSells:
+    def test_sorts_by_ep_ascending(self):
+        engine = DecisionEngine()
+        scores = [
+            _make_score("p1", ep=70.0),
+            _make_score("p2", ep=30.0),
+            _make_score("p3", ep=50.0),
+        ]
+        players = {s.player_id: _make_player(id=s.player_id) for s in scores}
+        recs = engine.recommend_sells(scores, {}, players)
+        assert recs[0].score.player_id == "p2"
+
+    def test_protects_position_minimum(self):
+        engine = DecisionEngine()
+        scores = [_make_score("p1", ep=20.0)]
+        players = {"p1": _make_player(id="p1", position="Goalkeeper")}
+        roster_ctx = {"Goalkeeper": _make_roster_context("Goalkeeper", 1, 1)}
+        recs = engine.recommend_sells(scores, roster_ctx, players)
+        assert recs[0].is_protected is True
+        assert recs[0].protection_reason is not None
+
+
+class TestBuildTradePairs:
+    def test_pairs_lowest_sell_with_highest_buy(self):
+        engine = DecisionEngine(min_ep_upgrade_threshold=10.0)
+        market_scores = [_make_score("m1", ep=80.0, price=8_000_000, avg_points=25.0)]
+        squad_scores = [_make_score("s1", ep=30.0, market_value=3_000_000)]
+        market_players = {"m1": _make_player(id="m1", price=8_000_000, average_points=25.0)}
+        squad_players = {"s1": _make_player(id="s1", market_value=3_000_000)}
+        pairs = engine.build_trade_pairs(
+            market_scores,
+            squad_scores,
+            {},
+            10_000_000,
+            market_players,
+            squad_players,
+        )
+        assert len(pairs) == 1
+        assert pairs[0].ep_gain == 50.0
+
+    def test_no_pair_below_threshold(self):
+        engine = DecisionEngine(min_ep_upgrade_threshold=10.0)
+        market_scores = [_make_score("m1", ep=35.0, avg_points=20.0)]
+        squad_scores = [_make_score("s1", ep=30.0)]
+        market_players = {"m1": _make_player(id="m1", average_points=20.0)}
+        squad_players = {"s1": _make_player(id="s1")}
+        pairs = engine.build_trade_pairs(
+            market_scores,
+            squad_scores,
+            {},
+            10_000_000,
+            market_players,
+            squad_players,
+        )
+        assert len(pairs) == 0
+
+
+class TestSelectLineup:
+    def test_returns_player_id_to_ep_dict(self):
+        engine = DecisionEngine()
+        scores = [_make_score(f"p{i}", ep=float(60 + i)) for i in range(15)]
+        result = engine.select_lineup(scores)
+        assert isinstance(result, dict)
+        assert all(isinstance(v, float) for v in result.values())

--- a/tests/test_scoring/test_decision.py
+++ b/tests/test_scoring/test_decision.py
@@ -133,6 +133,34 @@ class TestRecommendBuys:
         recs = engine.recommend_buys(scores, [], {}, 5_000_000, players)
         assert len(recs) == 0
 
+    def test_filters_team_at_max(self):
+        """Cannot buy from a team if squad already has 3 players from it."""
+        engine = DecisionEngine()
+        # Market player from team "t1"
+        market_scores = [
+            _make_score("m1", ep=80.0, avg_points=25.0),  # team_id defaults to ""
+        ]
+        # Override team_id on the market score
+        market_scores[0].team_id = "t1"
+        # Squad already has 3 from team "t1"
+        squad_scores = [_make_score(f"s{i}", ep=50.0, avg_points=20.0) for i in range(3)]
+        for s in squad_scores:
+            s.team_id = "t1"
+        players = {"m1": _make_player(id="m1", team_id="t1", average_points=25.0)}
+        recs = engine.recommend_buys(market_scores, squad_scores, {}, 10_000_000, players)
+        assert len(recs) == 0
+
+    def test_allows_team_below_max(self):
+        """Can buy from a team if squad has fewer than 3 players from it."""
+        engine = DecisionEngine()
+        market_scores = [_make_score("m1", ep=80.0, avg_points=25.0)]
+        market_scores[0].team_id = "t1"
+        squad_scores = [_make_score("s1", ep=50.0, avg_points=20.0)]
+        squad_scores[0].team_id = "t1"
+        players = {"m1": _make_player(id="m1", team_id="t1", average_points=25.0)}
+        recs = engine.recommend_buys(market_scores, squad_scores, {}, 10_000_000, players)
+        assert len(recs) == 1
+
 
 class TestRecommendSells:
     def test_sorts_by_ep_ascending(self):

--- a/tests/test_scoring/test_models.py
+++ b/tests/test_scoring/test_models.py
@@ -1,0 +1,220 @@
+"""Tests for scoring data models."""
+
+from rehoboam.kickbase_client import MarketPlayer
+from rehoboam.matchup_analyzer import DoubleGameweekInfo
+from rehoboam.scoring.models import (
+    BuyRecommendation,
+    DataQuality,
+    PlayerData,
+    PlayerScore,
+    TradePair,
+)
+
+
+def _make_player(**overrides) -> MarketPlayer:
+    defaults = {
+        "id": "p1",
+        "first_name": "Test",
+        "last_name": "Player",
+        "position": "Midfielder",
+        "team_id": "t1",
+        "team_name": "Test FC",
+        "price": 5_000_000,
+        "market_value": 5_000_000,
+        "points": 100,
+        "average_points": 12.0,
+        "status": 0,
+    }
+    defaults.update(overrides)
+    return MarketPlayer(**defaults)
+
+
+class TestDataQuality:
+    def test_grade_a(self):
+        dq = DataQuality(
+            grade="A",
+            games_played=12,
+            consistency=0.8,
+            has_fixture_data=True,
+            has_lineup_data=True,
+            warnings=[],
+        )
+        assert dq.grade == "A"
+        assert dq.warnings == []
+
+    def test_grade_f_has_warnings(self):
+        dq = DataQuality(
+            grade="F",
+            games_played=1,
+            consistency=0.5,
+            has_fixture_data=False,
+            has_lineup_data=False,
+            warnings=["Only 1 game played", "No fixture data"],
+        )
+        assert dq.grade == "F"
+        assert len(dq.warnings) == 2
+
+
+class TestPlayerScore:
+    def test_construction(self):
+        dq = DataQuality(
+            grade="A",
+            games_played=15,
+            consistency=0.9,
+            has_fixture_data=True,
+            has_lineup_data=True,
+            warnings=[],
+        )
+        ps = PlayerScore(
+            player_id="p1",
+            expected_points=75.0,
+            data_quality=dq,
+            base_points=30.0,
+            consistency_bonus=10.0,
+            lineup_bonus=20.0,
+            fixture_bonus=5.0,
+            form_bonus=5.0,
+            minutes_bonus=5.0,
+            dgw_multiplier=1.0,
+            is_dgw=False,
+            next_opponent="Bayern",
+            notes=["Starter"],
+            current_price=5_000_000,
+            market_value=6_000_000,
+        )
+        assert ps.expected_points == 75.0
+        assert ps.is_dgw is False
+
+    def test_dgw_player(self):
+        dq = DataQuality(
+            grade="B",
+            games_played=8,
+            consistency=0.6,
+            has_fixture_data=True,
+            has_lineup_data=False,
+            warnings=[],
+        )
+        ps = PlayerScore(
+            player_id="p2",
+            expected_points=126.0,
+            data_quality=dq,
+            base_points=40.0,
+            consistency_bonus=10.0,
+            lineup_bonus=20.0,
+            fixture_bonus=0.0,
+            form_bonus=0.0,
+            minutes_bonus=0.0,
+            dgw_multiplier=1.8,
+            is_dgw=True,
+            next_opponent=None,
+            notes=["DOUBLE GAMEWEEK"],
+            current_price=10_000_000,
+            market_value=10_000_000,
+        )
+        assert ps.is_dgw is True
+        assert ps.expected_points == 126.0
+
+
+class TestPlayerData:
+    def test_construction_with_missing(self):
+        player = _make_player()
+        pd = PlayerData(
+            player=player,
+            performance=None,
+            player_details=None,
+            team_strength=None,
+            opponent_strength=None,
+            dgw_info=DoubleGameweekInfo(is_dgw=False),
+            missing=["performance", "player_details"],
+        )
+        assert pd.performance is None
+        assert "performance" in pd.missing
+
+
+class TestBuyRecommendation:
+    def test_construction(self):
+        dq = DataQuality(
+            grade="A",
+            games_played=15,
+            consistency=0.9,
+            has_fixture_data=True,
+            has_lineup_data=True,
+            warnings=[],
+        )
+        score = PlayerScore(
+            player_id="p1",
+            expected_points=70.0,
+            data_quality=dq,
+            base_points=30.0,
+            consistency_bonus=10.0,
+            lineup_bonus=20.0,
+            fixture_bonus=5.0,
+            form_bonus=5.0,
+            minutes_bonus=0.0,
+            dgw_multiplier=1.0,
+            is_dgw=False,
+            next_opponent="Dortmund",
+            notes=[],
+            current_price=5_000_000,
+            market_value=5_000_000,
+        )
+        player = _make_player()
+        rec = BuyRecommendation(player=player, score=score, roster_bonus=10.0, reason="fills_gap")
+        assert rec.roster_bonus == 10.0
+        assert rec.effective_ep == 80.0
+
+
+class TestTradePair:
+    def test_net_cost(self):
+        dq = DataQuality(
+            grade="A",
+            games_played=15,
+            consistency=0.9,
+            has_fixture_data=True,
+            has_lineup_data=True,
+            warnings=[],
+        )
+        buy_score = PlayerScore(
+            player_id="p1",
+            expected_points=70.0,
+            data_quality=dq,
+            base_points=30.0,
+            consistency_bonus=10.0,
+            lineup_bonus=20.0,
+            fixture_bonus=5.0,
+            form_bonus=5.0,
+            minutes_bonus=0.0,
+            dgw_multiplier=1.0,
+            is_dgw=False,
+            next_opponent=None,
+            notes=[],
+            current_price=8_000_000,
+            market_value=8_000_000,
+        )
+        sell_score = PlayerScore(
+            player_id="p2",
+            expected_points=30.0,
+            data_quality=dq,
+            base_points=15.0,
+            consistency_bonus=5.0,
+            lineup_bonus=10.0,
+            fixture_bonus=0.0,
+            form_bonus=0.0,
+            minutes_bonus=0.0,
+            dgw_multiplier=1.0,
+            is_dgw=False,
+            next_opponent=None,
+            notes=[],
+            current_price=3_000_000,
+            market_value=3_000_000,
+        )
+        buy_player = _make_player(id="p1", price=8_000_000, market_value=8_000_000)
+        sell_player = _make_player(id="p2", price=3_000_000, market_value=3_000_000)
+        tp = TradePair(
+            buy_player=buy_player,
+            sell_player=sell_player,
+            buy_score=buy_score,
+            sell_score=sell_score,
+        )
+        assert tp.net_cost == 5_000_000
+        assert tp.ep_gain == 40.0

--- a/tests/test_scoring/test_scorer.py
+++ b/tests/test_scoring/test_scorer.py
@@ -64,8 +64,11 @@ class TestExtractGamesAndConsistency:
         assert consistency > 0.8
 
     def test_inconsistent_player(self):
-        # Wild swings — very inconsistent
-        perf = _make_performance([10, 120, 5, 150, 0, 200, 15, 100])
+        # Wild swings — very inconsistent (minutes provided so 0-point match counts)
+        perf = _make_performance(
+            [10, 120, 5, 150, 0, 200, 15, 100],
+            [90, 90, 90, 90, 90, 90, 90, 90],
+        )
         games, consistency = extract_games_and_consistency(perf)
         assert games == 8
         assert consistency < 0.4
@@ -75,6 +78,25 @@ class TestExtractGamesAndConsistency:
         perf = _make_performance([80, 0, 60, 0, 70], [90, 0, 85, 0, 88])
         games, consistency = extract_games_and_consistency(perf)
         assert games == 3  # Only 3 matches where player actually played
+
+    def test_excludes_unplayed_fixtures(self):
+        # Upcoming fixtures have no "t" key and p=0 — must be excluded
+        perf = {
+            "it": [
+                {
+                    "ti": "2025",
+                    "ph": [
+                        {"p": 80, "t": 90},
+                        {"p": 60, "t": 85},
+                        {"p": 70, "t": 88},
+                        {"p": 0},  # Upcoming fixture — no minutes key
+                        {"p": 0},  # Upcoming fixture
+                    ],
+                }
+            ]
+        }
+        games, consistency = extract_games_and_consistency(perf)
+        assert games == 3  # Only 3 real matches
 
 
 class TestExtractMinutesAnalysis:
@@ -279,8 +301,11 @@ class TestScorePlayer:
         assert "Hot streak" in ps.notes
 
     def test_form_not_scoring(self):
-        # Recent matches all zeros
-        perf = _make_performance([50, 60, 40, 0, 0, 0, 0, 0])
+        # Recent matches: player played full 90 but scored 0 points
+        perf = _make_performance(
+            [50, 60, 40, 0, 0, 0, 0, 0],
+            [90, 90, 90, 90, 90, 90, 90, 90],
+        )
         pd = _make_player_data(avg_points=15.0, points=150, performance=perf)
         ps = score_player(pd)
         assert ps.form_bonus == -10.0

--- a/tests/test_scoring/test_scorer.py
+++ b/tests/test_scoring/test_scorer.py
@@ -1,0 +1,293 @@
+"""Tests for the pure scoring function."""
+
+from rehoboam.kickbase_client import MarketPlayer
+from rehoboam.matchup_analyzer import DoubleGameweekInfo, TeamStrength
+from rehoboam.scoring.models import PlayerData, PlayerScore
+from rehoboam.scoring.scorer import (
+    extract_games_and_consistency,
+    extract_minutes_analysis,
+    grade_data_quality,
+    score_player,
+)
+
+
+def _make_player(**overrides) -> MarketPlayer:
+    defaults = {
+        "id": "p1",
+        "first_name": "Test",
+        "last_name": "Player",
+        "position": "Midfielder",
+        "team_id": "t1",
+        "team_name": "Test FC",
+        "price": 5_000_000,
+        "market_value": 5_000_000,
+        "points": 100,
+        "average_points": 12.0,
+        "status": 0,
+    }
+    defaults.update(overrides)
+    return MarketPlayer(**defaults)
+
+
+def _make_performance(match_points: list[int], match_minutes: list[int] | None = None) -> dict:
+    """Build a performance dict matching Kickbase API structure."""
+    matches = []
+    for i, pts in enumerate(match_points):
+        match = {"p": pts}
+        if match_minutes and i < len(match_minutes):
+            match["t"] = match_minutes[i]
+        matches.append(match)
+    return {"it": [{"ti": "2025", "ph": matches}]}
+
+
+class TestExtractGamesAndConsistency:
+    def test_no_data(self):
+        games, consistency = extract_games_and_consistency(None)
+        assert games == 0
+        assert consistency == 0.0
+
+    def test_empty_seasons(self):
+        games, consistency = extract_games_and_consistency({"it": []})
+        assert games == 0
+
+    def test_single_game(self):
+        perf = _make_performance([80])
+        games, consistency = extract_games_and_consistency(perf)
+        assert games == 1
+        assert consistency == 0.5  # Medium confidence for 1 game
+
+    def test_consistent_player(self):
+        # All scores around 60 — very consistent
+        perf = _make_performance([58, 62, 60, 61, 59, 60, 62, 58, 60, 61])
+        games, consistency = extract_games_and_consistency(perf)
+        assert games == 10
+        assert consistency > 0.8
+
+    def test_inconsistent_player(self):
+        # Wild swings — very inconsistent
+        perf = _make_performance([10, 120, 5, 150, 0, 200, 15, 100])
+        games, consistency = extract_games_and_consistency(perf)
+        assert games == 8
+        assert consistency < 0.4
+
+    def test_skips_zero_point_zero_minute_matches(self):
+        # Matches where player didn't play (0 points, 0 minutes)
+        perf = _make_performance([80, 0, 60, 0, 70], [90, 0, 85, 0, 88])
+        games, consistency = extract_games_and_consistency(perf)
+        assert games == 3  # Only 3 matches where player actually played
+
+
+class TestExtractMinutesAnalysis:
+    def test_no_data(self):
+        trend, avg, is_sub = extract_minutes_analysis(None)
+        assert trend is None
+
+    def test_increasing_minutes(self):
+        # First half: ~45 min, second half: ~85 min
+        perf = _make_performance(
+            [50] * 8,
+            [40, 45, 50, 42, 80, 85, 90, 88],
+        )
+        trend, avg, is_sub = extract_minutes_analysis(perf)
+        assert trend == "increasing"
+
+    def test_decreasing_minutes(self):
+        perf = _make_performance(
+            [50] * 8,
+            [90, 88, 85, 90, 40, 35, 30, 25],
+        )
+        trend, avg, is_sub = extract_minutes_analysis(perf)
+        assert trend == "decreasing"
+
+    def test_substitute_pattern(self):
+        perf = _make_performance([30] * 6, [25, 30, 20, 28, 22, 30])
+        trend, avg, is_sub = extract_minutes_analysis(perf)
+        assert is_sub is True
+        assert avg < 60
+
+
+class TestGradeDataQuality:
+    def test_grade_a(self):
+        dq = grade_data_quality(
+            games_played=12,
+            consistency=0.8,
+            has_fixture_data=True,
+            has_lineup_data=True,
+        )
+        assert dq.grade == "A"
+        assert dq.warnings == []
+
+    def test_grade_b_few_games(self):
+        dq = grade_data_quality(
+            games_played=7,
+            consistency=0.6,
+            has_fixture_data=True,
+            has_lineup_data=False,
+        )
+        assert dq.grade == "B"
+
+    def test_grade_c_sparse(self):
+        dq = grade_data_quality(
+            games_played=3,
+            consistency=0.5,
+            has_fixture_data=False,
+            has_lineup_data=False,
+        )
+        assert dq.grade == "C"
+        assert any("3 games" in w for w in dq.warnings)
+
+    def test_grade_f_no_games(self):
+        dq = grade_data_quality(
+            games_played=0,
+            consistency=0.0,
+            has_fixture_data=False,
+            has_lineup_data=False,
+        )
+        assert dq.grade == "F"
+        assert any("No games" in w or "0" in w for w in dq.warnings)
+
+    def test_grade_f_one_game(self):
+        dq = grade_data_quality(
+            games_played=1,
+            consistency=0.5,
+            has_fixture_data=True,
+            has_lineup_data=True,
+        )
+        assert dq.grade == "F"
+
+
+def _make_player_data(
+    avg_points: float = 12.0,
+    points: int = 100,
+    performance: dict | None = None,
+    player_details: dict | None = None,
+    team_strength: TeamStrength | None = None,
+    opponent_strength: TeamStrength | None = None,
+    is_dgw: bool = False,
+    status: int = 0,
+) -> PlayerData:
+    player = _make_player(average_points=avg_points, points=points, status=status)
+    return PlayerData(
+        player=player,
+        performance=performance,
+        player_details=player_details,
+        team_strength=team_strength,
+        opponent_strength=opponent_strength,
+        dgw_info=DoubleGameweekInfo(is_dgw=is_dgw, match_count=2 if is_dgw else 1),
+        missing=[],
+    )
+
+
+class TestScorePlayer:
+    def test_basic_scoring(self):
+        """Average player with no extra data scores based on avg_points only."""
+        pd = _make_player_data(avg_points=15.0, points=100)
+        ps = score_player(pd)
+        assert isinstance(ps, PlayerScore)
+        assert ps.base_points == 30.0  # min(15 * 2, 40)
+        assert ps.expected_points > 0
+
+    def test_high_avg_caps_at_40(self):
+        pd = _make_player_data(avg_points=25.0, points=200)
+        ps = score_player(pd)
+        assert ps.base_points == 40.0
+
+    def test_zero_avg_points(self):
+        pd = _make_player_data(avg_points=0.0, points=0)
+        ps = score_player(pd)
+        assert ps.expected_points >= 0  # Never negative after clamp
+
+    def test_starter_gets_lineup_bonus(self):
+        pd = _make_player_data(avg_points=15.0, player_details={"prob": 1})
+        ps = score_player(pd)
+        assert ps.lineup_bonus == 20.0
+
+    def test_unlikely_player_gets_penalty(self):
+        pd = _make_player_data(avg_points=15.0, player_details={"prob": 4})
+        ps = score_player(pd)
+        assert ps.lineup_bonus == -20.0
+
+    def test_dgw_multiplier(self):
+        pd_normal = _make_player_data(avg_points=15.0, is_dgw=False)
+        pd_dgw = _make_player_data(avg_points=15.0, is_dgw=True)
+        ps_normal = score_player(pd_normal)
+        ps_dgw = score_player(pd_dgw)
+        assert ps_dgw.dgw_multiplier == 1.8
+        assert ps_dgw.expected_points > ps_normal.expected_points
+        if ps_normal.expected_points > 0:
+            ratio = ps_dgw.expected_points / ps_normal.expected_points
+            assert 1.7 <= ratio <= 1.81
+
+    def test_dgw_note_added(self):
+        pd = _make_player_data(avg_points=15.0, is_dgw=True)
+        ps = score_player(pd)
+        assert "DOUBLE GAMEWEEK" in ps.notes
+
+    def test_scale_goes_above_100(self):
+        """Strong DGW player should score above 100 (scale is 0-180)."""
+        pd = _make_player_data(
+            avg_points=20.0,
+            points=200,
+            player_details={"prob": 1},
+            is_dgw=True,
+        )
+        ps = score_player(pd)
+        # base 40 + lineup 20 + form 10 = 70 min, * 1.8 = 126
+        assert ps.expected_points > 100
+
+    def test_clamped_at_180(self):
+        """Score should never exceed 180."""
+        pd = _make_player_data(
+            avg_points=30.0,
+            points=500,
+            player_details={"prob": 1},
+            is_dgw=True,
+        )
+        perf = _make_performance(
+            [100] * 15,  # Very consistent high scorer
+            [90] * 15,  # Always plays full game
+        )
+        pd.performance = perf
+        ps = score_player(pd)
+        assert ps.expected_points <= 180
+
+    def test_clamped_at_0(self):
+        """Score should never go below 0."""
+        pd = _make_player_data(
+            avg_points=0.0,
+            points=0,
+            player_details={"prob": 5},
+        )
+        ps = score_player(pd)
+        assert ps.expected_points >= 0
+
+    def test_grade_f_halves_score(self):
+        """Grade F players get their EP halved."""
+        pd_few = _make_player_data(avg_points=20.0, points=100)
+        pd_few.performance = _make_performance([100])  # 1 game
+        ps = score_player(pd_few)
+        assert ps.data_quality.grade == "F"
+        # Base would be 40, but halved due to grade F
+        # Exact value depends on other components but should be noticeably lower
+
+    def test_form_hot_streak(self):
+        # Recent 5 matches average 25 vs season avg 10 = 2.5x ratio
+        perf = _make_performance([5, 5, 5, 5, 5, 25, 30, 20, 25, 25])
+        pd = _make_player_data(avg_points=10.0, points=150, performance=perf)
+        ps = score_player(pd)
+        assert ps.form_bonus == 10.0
+        assert "Hot streak" in ps.notes
+
+    def test_form_not_scoring(self):
+        # Recent matches all zeros
+        perf = _make_performance([50, 60, 40, 0, 0, 0, 0, 0])
+        pd = _make_player_data(avg_points=15.0, points=150, performance=perf)
+        ps = score_player(pd)
+        assert ps.form_bonus == -10.0
+        assert "Not scoring" in ps.notes
+
+    def test_price_context_preserved(self):
+        pd = _make_player_data(avg_points=15.0)
+        ps = score_player(pd)
+        assert ps.current_price == 5_000_000
+        assert ps.market_value == 5_000_000

--- a/tests/test_scoring/test_scorer.py
+++ b/tests/test_scoring/test_scorer.py
@@ -291,3 +291,31 @@ class TestScorePlayer:
         ps = score_player(pd)
         assert ps.current_price == 5_000_000
         assert ps.market_value == 5_000_000
+
+    def test_works_with_squad_player(self):
+        """Player (from get_squad) has no 'price' or 'status' fields."""
+        from rehoboam.kickbase_client import Player
+
+        squad_player = Player(
+            id="sp1",
+            first_name="Squad",
+            last_name="Player",
+            position="Midfielder",
+            team_id="t1",
+            team_name="Test FC",
+            market_value=5_000_000,
+            points=100,
+            average_points=15.0,
+        )
+        pd = PlayerData(
+            player=squad_player,
+            performance=None,
+            player_details=None,
+            team_strength=None,
+            opponent_strength=None,
+            dgw_info=DoubleGameweekInfo(is_dgw=False),
+            missing=[],
+        )
+        ps = score_player(pd)
+        assert ps.current_price == 5_000_000  # Falls back to market_value
+        assert ps.status == 0  # Falls back to 0


### PR DESCRIPTION
## Summary

- Replaces market-value-driven `value_score` with expected matchday points (EP) as the primary metric for the `analyze` command
- New three-layer scoring pipeline: `DataCollector` → `score_player()` → `DecisionEngine`
- Pure function scorer on a 0-180 scale with components: base points, consistency, lineup probability, fixture difficulty, form, minutes trend, and DGW multiplier
- Buy/sell/trade-pair recommendations driven by EP instead of market value appreciation
- Enforces max 3 players per team (Kickbase rule)
- Shows exact bid amounts so user knows what to bid

## Key changes

- `rehoboam/scoring/` — New package with models, collector, scorer, and decision engine
- `rehoboam/compact_display.py` — EP-based action plan display with lineup, buys, sells, and trade pairs
- `rehoboam/trader.py` — `run_ep_analysis()` method wiring the full pipeline
- `rehoboam/cli.py` — `analyze` (default) now uses EP pipeline; `--detailed` keeps old value_score flow
- 55 new tests covering all scoring components and decision logic

## Test plan

- [x] 126 tests passing (55 new + 71 existing)
- [x] Pre-commit hooks passing (Black, Ruff, Bandit)
- [x] Manual testing with live Kickbase data
- [x] Verified fix for unplayed fixture filtering (was causing "Not scoring" for all players)

🤖 Generated with [Claude Code](https://claude.com/claude-code)