### PR TITLE
feat: EP scoring improvements — DGW, form, fixtures, filters, sell plans

### DIFF
--- a/rehoboam/compact_display.py
+++ b/rehoboam/compact_display.py
@@ -1,7 +1,6 @@
 """Compact, action-oriented display for analyze command"""
 
 from rich.console import Console
-from rich.panel import Panel
 from rich.table import Table
 
 console = Console()
@@ -1016,147 +1015,6 @@ class CompactDisplay:
                         f"\n[dim]💡 Tip: Selling top 3 expendable players frees {top_3_recovery / 1_000_000:.1f}M budget[/dim]"
                     )
 
-    def display_ep_action_plan(
-        self,
-        buy_candidates: list,
-        sell_candidates: list,
-        squad_summary: dict,
-        current_budget: int,
-    ):
-        """Display EP-based action plan.
-
-        Args:
-            buy_candidates: List of (MarginalEPResult, BidRecommendation, PlayerScore) tuples,
-                            sorted by marginal EP gain descending.
-            sell_candidates: List of SellRecommendation.
-            squad_summary: Dict with squad_size, budget, best_11_ep, formation.
-            current_budget: Current budget in euros.
-        """
-        console.print("\n" + "=" * 60)
-        console.print("[bold cyan]EP ACTION PLAN[/bold cyan]")
-        console.print("=" * 60)
-
-        # Budget negative warning
-        if current_budget < 0:
-            deficit = abs(current_budget)
-            console.print(
-                f"\n[bold red on white]"
-                f" BUDGET NEGATIVE (-{deficit:,})"
-                f" -- ZERO POINTS AT KICKOFF IF NOT FIXED! "
-                f"[/bold red on white]\n"
-            )
-
-        # Squad summary panel
-        squad_size = squad_summary.get("squad_size", 0)
-        best_11_ep = squad_summary.get("best_11_ep", 0.0)
-        formation = squad_summary.get("formation", "")
-
-        summary_parts = [
-            f"Squad: {squad_size}/15",
-            f"Budget: {current_budget:,}",
-            f"Best-11 EP: {best_11_ep:.0f}",
-        ]
-        if formation:
-            summary_parts.append(f"Formation: {formation}")
-        console.print(Panel(" | ".join(summary_parts), style="cyan"))
-
-        # BUY CANDIDATES table
-        if buy_candidates:
-            console.print(
-                f"\n[bold green]BUY CANDIDATES "
-                f"({len(buy_candidates)} by EP gain)[/bold green]\n"
-            )
-
-            buy_table = Table(show_header=True, header_style="bold green", box=None)
-            buy_table.add_column("Player", style="cyan", no_wrap=True)
-            buy_table.add_column("Pos", style="blue", width=3)
-            buy_table.add_column("EP", justify="right", style="yellow", width=5)
-            buy_table.add_column("EP Gain", justify="right", style="green", width=8)
-            buy_table.add_column("Price", justify="right", width=12)
-            buy_table.add_column("Bid", justify="right", width=12)
-            buy_table.add_column("Sell Plan", style="dim", width=20)
-            buy_table.add_column("Net Cost", justify="right", width=12)
-
-            for marginal, bid_rec, score in buy_candidates:
-                # Reconstruct player name from score — we stored it during collection
-                player_name = getattr(score, "_player_name", None)
-                if not player_name:
-                    player_name = score.player_id[:12]  # fallback
-                pos = getattr(score, "_position", "")[:2] if hasattr(score, "_position") else ""
-
-                ep_str = f"{score.expected_points:.0f}"
-                gain_str = f"+{marginal.marginal_ep_gain:.1f}"
-
-                price_str = f"{score.current_price:,}"
-                bid_str = f"{bid_rec.recommended_bid:,}" if bid_rec.recommended_bid > 0 else "-"
-
-                # Sell plan summary
-                sell_plan_str = "-"
-                net_cost = bid_rec.recommended_bid
-                if bid_rec.sell_plan and bid_rec.sell_plan.players_to_sell:
-                    names = [e.player_name.split()[-1] for e in bid_rec.sell_plan.players_to_sell]
-                    sell_plan_str = "Sell " + ", ".join(names[:2])
-                    if len(names) > 2:
-                        sell_plan_str += f" +{len(names) - 2}"
-                    net_cost = bid_rec.recommended_bid - bid_rec.sell_plan.total_recovery
-
-                net_str = f"{net_cost:,}" if net_cost != 0 else "0"
-
-                buy_table.add_row(
-                    player_name,
-                    pos,
-                    ep_str,
-                    gain_str,
-                    price_str,
-                    bid_str,
-                    sell_plan_str,
-                    net_str,
-                )
-
-            console.print(buy_table)
-        else:
-            console.print("\n[bold yellow]NO BUY CANDIDATES[/bold yellow]")
-            console.print("[dim]No market players would improve your best-11 EP[/dim]")
-
-        # SELL CANDIDATES table (non-protected, sorted by expendability)
-        non_protected = [s for s in sell_candidates if not s.is_protected]
-        if non_protected:
-            console.print(
-                f"\n[bold red]EXPENDABLE PLAYERS " f"({len(non_protected)} ranked)[/bold red]\n"
-            )
-
-            sell_table = Table(show_header=True, header_style="bold red", box=None)
-            sell_table.add_column("Player", style="cyan", no_wrap=True)
-            sell_table.add_column("Pos", style="blue", width=3)
-            sell_table.add_column("EP", justify="right", style="yellow", width=5)
-            sell_table.add_column("Expendability", justify="right", width=13)
-            sell_table.add_column("Value", justify="right", width=12)
-            sell_table.add_column("Status", width=12)
-
-            for sell_rec in non_protected[:8]:
-                ps = sell_rec.score
-                player_name = getattr(ps, "_player_name", ps.player_id[:12])
-                pos = getattr(ps, "_position", "")[:2] if hasattr(ps, "_position") else ""
-
-                ep_str = f"{ps.expected_points:.0f}"
-                exp_str = f"{sell_rec.expendability:.0f}"
-                val_str = f"{ps.market_value:,}"
-
-                # Status: bench or starting
-                is_bench = "bench player" in sell_rec.reason
-                status_str = "[dim]Bench[/dim]" if is_bench else "[green]Starting 11[/green]"
-
-                sell_table.add_row(player_name, pos, ep_str, exp_str, val_str, status_str)
-
-            console.print(sell_table)
-
-        console.print("\n" + "=" * 60)
-        console.print(
-            "[dim]EP = Expected Points for next matchday | "
-            "EP Gain = improvement to best-11 total[/dim]"
-        )
-        console.print("=" * 60 + "\n")
-
     def display_lineup(self, best_eleven: list, bench: list, expected_points_map: dict):
         """
         Display the optimal starting 11 for next matchday based on expected points.
@@ -1503,6 +1361,13 @@ class CompactDisplay:
                 player.position[:2] if hasattr(player, "position") and player.position else "-"
             )
 
+            # Build reason with sell plan info if present
+            reason = rec.reason[:50] if rec.reason else "-"
+            if hasattr(rec, "sell_plan") and rec.sell_plan and rec.sell_plan.players_to_sell:
+                sell_names = [e.player_name.split()[-1] for e in rec.sell_plan.players_to_sell]
+                recovery = rec.sell_plan.total_recovery
+                reason = f"Sell {'+'.join(sell_names)} (€{recovery:,})"
+
             table.add_row(
                 name,
                 pos_str,
@@ -1510,7 +1375,7 @@ class CompactDisplay:
                 badge,
                 price_str,
                 bid_str,
-                rec.reason[:50] if rec.reason else "-",
+                reason,
             )
 
         console.print(table)

--- a/rehoboam/config.py
+++ b/rehoboam/config.py
@@ -18,6 +18,10 @@ POSITION_MINIMUMS = {
 # over an existing squad player
 MIN_UPGRADE_THRESHOLD = 10.0
 
+# Maximum lineup probability (1-5) to consider buying a player.
+# 1 = starter, 2 = rotation, 3 = bench; 4+ = unlikely to play
+MAX_LINEUP_PROB_FOR_BUY = 3
+
 
 # Find .env file - look in current directory first, then in home directory
 def find_env_file() -> Path:

--- a/rehoboam/matchup_analyzer.py
+++ b/rehoboam/matchup_analyzer.py
@@ -261,6 +261,30 @@ class MatchupAnalyzer:
             difficulty_score=50.0,  # Default medium difficulty
         )
 
+    def get_next_matchups(self, player_details: dict[str, Any], n: int = 3) -> list[MatchupInfo]:
+        """Return up to *n* upcoming MatchupInfo objects from mdsum."""
+        matchups = player_details.get("mdsum", [])
+        player_team_id = player_details.get("tid", "")
+        upcoming = [m for m in matchups if m.get("mdst") == 0]
+
+        results: list[MatchupInfo] = []
+        for match in upcoming[:n]:
+            t1_id = match.get("t1", "")
+            t2_id = match.get("t2", "")
+            is_home = t1_id == player_team_id
+            opponent_id = t2_id if is_home else t1_id
+            results.append(
+                MatchupInfo(
+                    opponent_id=opponent_id,
+                    opponent_name=f"Team {opponent_id}",
+                    is_home=is_home,
+                    match_date=match.get("md", ""),
+                    opponent_rank=None,
+                    difficulty_score=50.0,
+                )
+            )
+        return results
+
     def calculate_matchup_difficulty(
         self, player_team: TeamStrength, opponent_team: TeamStrength
     ) -> float:

--- a/rehoboam/scoring/collector.py
+++ b/rehoboam/scoring/collector.py
@@ -34,6 +34,7 @@ class DataCollector:
             PlayerData with resolved strengths and a list of any missing fields.
         """
         missing: list[str] = []
+        is_dgw = False
 
         if performance is None:
             missing.append("performance")
@@ -43,21 +44,34 @@ class DataCollector:
         team_strength = None
         opponent_strength = None
 
+        upcoming_opponent_strengths = []
+
         if player_details:
             team_id = player_details.get("tid", "")
             if team_id and team_id in team_profiles:
                 team_strength = self.matchup_analyzer.get_team_strength(team_profiles[team_id])
 
-            next_matchup = self.matchup_analyzer.get_next_matchup(player_details)
-            if next_matchup and next_matchup.opponent_id:
-                if next_matchup.opponent_id in team_profiles:
+            # Resolve next 3 opponents for multi-fixture lookahead
+            next_matchups = self.matchup_analyzer.get_next_matchups(player_details, n=3)
+            for matchup in next_matchups:
+                if matchup.opponent_id and matchup.opponent_id in team_profiles:
+                    opp_str = self.matchup_analyzer.get_team_strength(
+                        team_profiles[matchup.opponent_id]
+                    )
+                    upcoming_opponent_strengths.append(opp_str)
+
+            # Primary opponent (backward compat) = first from the list
+            if next_matchups and next_matchups[0].opponent_id:
+                if next_matchups[0].opponent_id in team_profiles:
                     opponent_strength = self.matchup_analyzer.get_team_strength(
-                        team_profiles[next_matchup.opponent_id]
+                        team_profiles[next_matchups[0].opponent_id]
                     )
                 else:
                     missing.append("opponent_strength")
-            # If there is no next matchup at all, opponent_strength is simply
-            # unavailable rather than "missing" — we do not flag it.
+
+            # DGW detection — players with 2+ matches in one matchday score ~1.8x
+            dgw_info = self.matchup_analyzer.detect_double_gameweek(player_details)
+            is_dgw = dgw_info.is_dgw
 
         return PlayerData(
             player=player,
@@ -65,6 +79,7 @@ class DataCollector:
             player_details=player_details,
             team_strength=team_strength,
             opponent_strength=opponent_strength,
-            is_dgw=False,  # DGW detection is a separate feature
+            is_dgw=is_dgw,
             missing=missing,
+            upcoming_opponent_strengths=upcoming_opponent_strengths,
         )

--- a/rehoboam/scoring/decision.py
+++ b/rehoboam/scoring/decision.py
@@ -10,11 +10,13 @@ from rehoboam.formation import select_best_eleven
 from rehoboam.kickbase_client import MarketPlayer
 
 from .models import (
+    BuyRecommendation,
     MarginalEPResult,
     PlayerScore,
     SellPlan,
     SellPlanEntry,
     SellRecommendation,
+    TradePair,
 )
 
 
@@ -244,13 +246,257 @@ class DecisionEngine:
             reasoning=reasoning,
         )
 
+    def recommend_buys(
+        self,
+        market_scores: list[PlayerScore],
+        squad_scores: list[PlayerScore],
+        roster_context: dict,
+        budget: float,
+        market_players: dict[str, MarketPlayer],
+        is_emergency: bool = False,
+        top_n: int = 5,
+        squad_players: dict[str, MarketPlayer] | None = None,
+    ) -> list[BuyRecommendation]:
+        """Rank market players by marginal EP gain to the squad.
+
+        For each market player above the EP threshold, calculates how much
+        they would improve the best-11 total EP if added to the squad.
+        Players over budget get a paired sell plan instead of being filtered out.
+
+        Returns the top *top_n* recommendations sorted by marginal EP gain.
+        """
+        lineup_map = self.select_lineup(squad_scores)
+
+        # Compute best-11 IDs for sell plan generation
+        squad_list = list(squad_players.values()) if squad_players else []
+        if squad_list:
+            best_11 = select_best_eleven(squad_list, lineup_map)
+            best_11_ids = {p.id for p in best_11}
+        else:
+            best_11_ids = set()
+
+        recs: list[BuyRecommendation] = []
+        for ps in market_scores:
+            player = market_players.get(ps.player_id)
+            if not player:
+                continue
+
+            # Filter by minimum EP threshold
+            min_ep = 10.0 if is_emergency else self.min_ep_to_buy
+            if ps.expected_points < min_ep:
+                continue
+
+            # Skip players unlikely to start (prob 4-5)
+            from rehoboam.config import MAX_LINEUP_PROB_FOR_BUY
+
+            if (
+                ps.lineup_probability is not None
+                and ps.lineup_probability > MAX_LINEUP_PROB_FOR_BUY
+            ):
+                continue
+
+            # Hard-block players with severely declining minutes
+            if ps.minutes_trend == "decreasing" and ps.minutes_bonus <= -15.0:
+                continue
+
+            # Calculate marginal EP gain using a simplified approach:
+            # Find the weakest player in the position and compare
+            same_pos_scores = [s for s in squad_scores if s.position == player.position]
+            if same_pos_scores:
+                weakest_ep = min(s.expected_points for s in same_pos_scores)
+                marginal = ps.expected_points - weakest_ep
+                replaces_id = next(
+                    (s.player_id for s in same_pos_scores if s.expected_points == weakest_ep),
+                    None,
+                )
+            else:
+                # No one at this position — fills a gap
+                marginal = ps.expected_points
+                replaces_id = None
+
+            marginal = max(0.0, marginal)
+
+            # Determine roster impact
+            pos_counts: dict[str, int] = {}
+            for s in squad_scores:
+                pos_counts[s.position] = pos_counts.get(s.position, 0) + 1
+
+            pos_min = POSITION_MINIMUMS.get(player.position, 0)
+            current_count = pos_counts.get(player.position, 0)
+
+            if current_count < pos_min:
+                roster_impact = "fills_gap"
+                roster_bonus = 10.0
+            elif marginal > self.min_ep_upgrade:
+                roster_impact = "upgrade"
+                roster_bonus = 5.0
+            else:
+                roster_impact = "additional"
+                roster_bonus = 0.0
+
+            # Build reason string
+            reason_parts = [f"EP {ps.expected_points:.1f}"]
+            if marginal > 0:
+                reason_parts.append(f"+{marginal:.1f} marginal")
+            if roster_impact == "fills_gap":
+                reason_parts.append("fills gap")
+            elif replaces_id:
+                reason_parts.append("upgrades pos")
+
+            # Only recommend if marginal gain meets threshold (or emergency)
+            if not is_emergency and marginal < self.min_ep_upgrade and roster_impact != "fills_gap":
+                continue
+
+            recs.append(
+                BuyRecommendation(
+                    score=ps,
+                    player=player,
+                    marginal_ep_gain=marginal,
+                    effective_ep=ps.expected_points,
+                    replaces_player_id=replaces_id,
+                    replaces_player_name=None,
+                    roster_impact=roster_impact,
+                    roster_bonus=roster_bonus,
+                    reason="; ".join(reason_parts),
+                )
+            )
+
+        # For over-budget buys, generate sell plans instead of filtering
+        final_recs: list[BuyRecommendation] = []
+        for rec in recs:
+            if rec.player.price <= budget:
+                final_recs.append(rec)
+            elif squad_list:
+                # Player costs more than budget — generate sell plan
+                sell_plan = self.build_sell_plan(
+                    bid_amount=rec.player.price,
+                    current_budget=int(budget),
+                    squad=squad_list,
+                    squad_scores=squad_scores,
+                    best_11_ids=best_11_ids,
+                    displaced_player_id=rec.replaces_player_id,
+                )
+                if sell_plan.is_viable:
+                    rec.sell_plan = sell_plan
+                    final_recs.append(rec)
+            # else: skip — no squad data to generate sell plan
+
+        # Sort by marginal EP gain (primary), then by raw EP (secondary)
+        final_recs.sort(key=lambda r: (r.marginal_ep_gain, r.score.expected_points), reverse=True)
+        return final_recs[:top_n]
+
+    def build_trade_pairs(
+        self,
+        market_scores: list[PlayerScore],
+        squad_scores: list[PlayerScore],
+        roster_context: dict,
+        budget: float,
+        market_players: dict[str, MarketPlayer],
+        squad_players: dict[str, MarketPlayer],
+        top_n: int = 5,
+    ) -> list[TradePair]:
+        """Build sell->buy trade pairs for a full squad (15/15).
+
+        For each promising market player, finds the best squad member to sell
+        and calculates net cost and EP gain.
+        """
+        # Get sell candidates sorted by expendability
+        sell_recs = self.recommend_sells(
+            squad_scores=squad_scores,
+            roster_context=roster_context,
+            squad_players=squad_players,
+        )
+        sellable = [r for r in sell_recs if not r.is_protected]
+
+        pairs: list[TradePair] = []
+        used_sell_ids: set[str] = set()
+
+        # Score and sort market candidates by EP
+        candidates = sorted(market_scores, key=lambda s: s.expected_points, reverse=True)
+
+        for ps in candidates:
+            buy_player = market_players.get(ps.player_id)
+            if not buy_player:
+                continue
+            if ps.expected_points < self.min_ep_to_buy:
+                continue
+
+            # Skip players unlikely to start or with collapsing minutes
+            from rehoboam.config import MAX_LINEUP_PROB_FOR_BUY
+
+            if (
+                ps.lineup_probability is not None
+                and ps.lineup_probability > MAX_LINEUP_PROB_FOR_BUY
+            ):
+                continue
+            if ps.minutes_trend == "decreasing" and ps.minutes_bonus <= -15.0:
+                continue
+
+            # Find best sell target: same position preferred, then most expendable
+            best_sell: SellRecommendation | None = None
+            for sr in sellable:
+                if sr.score.player_id in used_sell_ids:
+                    continue
+                sell_mp = sr.player
+                if sell_mp is None:
+                    continue
+                # Prefer same-position swaps
+                if sell_mp.position == buy_player.position:
+                    best_sell = sr
+                    break
+            # Fallback: most expendable not yet used
+            if best_sell is None:
+                for sr in sellable:
+                    if sr.score.player_id in used_sell_ids:
+                        continue
+                    if sr.player is not None:
+                        best_sell = sr
+                        break
+
+            if best_sell is None or best_sell.player is None:
+                continue
+
+            sell_mp = best_sell.player
+            sell_value = int(sell_mp.market_value * 0.95)
+            net_cost = buy_player.price - sell_value
+            ep_gain = ps.expected_points - best_sell.score.expected_points
+
+            # Only recommend if EP gain is positive
+            if ep_gain < self.min_ep_upgrade:
+                continue
+
+            # Check affordability (budget + sell recovery)
+            if net_cost > budget:
+                continue
+
+            used_sell_ids.add(best_sell.score.player_id)
+
+            pairs.append(
+                TradePair(
+                    buy_player=buy_player,
+                    sell_player=sell_mp,
+                    buy_score=ps,
+                    sell_score=best_sell.score,
+                    net_cost=net_cost,
+                    ep_gain=ep_gain,
+                )
+            )
+
+            if len(pairs) >= top_n:
+                break
+
+        pairs.sort(key=lambda p: p.ep_gain, reverse=True)
+        return pairs[:top_n]
+
     def recommend_sells(
         self,
-        squad: list[MarketPlayer],
         squad_scores: list[PlayerScore],
-        best_11_ids: set[str],
+        roster_context: dict,
+        squad_players: dict[str, MarketPlayer],
     ) -> list[SellRecommendation]:
         """Rank all squad players by expendability (highest = most expendable).
+
+        Computes best-11 internally from squad_scores, then scores each player.
 
         Formula::
 
@@ -261,16 +507,22 @@ class DecisionEngine:
         Returns a sorted list of :class:`~rehoboam.scoring.models.SellRecommendation`
         (most expendable first).
         """
-        score_map = {s.player_id: s for s in squad_scores}
+        # Compute best-11 IDs from squad scores + squad players
+        score_map = self.select_lineup(squad_scores)
+        squad_list = list(squad_players.values())
+        best_11 = select_best_eleven(squad_list, score_map)
+        best_11_ids = {p.id for p in best_11}
 
         # Count positions to detect position minimums
         position_counts: dict[str, int] = {}
-        for p in squad:
+        for p in squad_list:
             position_counts[p.position] = position_counts.get(p.position, 0) + 1
 
+        score_lookup = {s.player_id: s for s in squad_scores}
+
         recommendations: list[SellRecommendation] = []
-        for player in squad:
-            ps = score_map.get(player.id)
+        for player in squad_list:
+            ps = score_lookup.get(player.id)
             ep = ps.expected_points if ps else 0.0
             in_best_11 = player.id in best_11_ids
 
@@ -297,6 +549,7 @@ class DecisionEngine:
             recommendations.append(
                 SellRecommendation(
                     score=ps if ps is not None else _dummy_score(player.id, ep),
+                    player=player,
                     expendability=expendability,
                     is_protected=is_protected,
                     protection_reason=protection_reason,
@@ -341,4 +594,8 @@ def _dummy_score(player_id: str, ep: float) -> PlayerScore:
         notes=[],
         current_price=0,
         market_value=0,
+        average_points=0.0,
+        position="",
+        lineup_probability=None,
+        minutes_trend=None,
     )

--- a/rehoboam/scoring/models.py
+++ b/rehoboam/scoring/models.py
@@ -37,6 +37,10 @@ class PlayerScore:
     notes: list[str]
     current_price: int
     market_value: int
+    average_points: float = 0.0
+    position: str = ""
+    lineup_probability: int | None = None  # 1=starter, 2-3=rotation, 4-5=unlikely
+    minutes_trend: str | None = None  # "increasing" | "decreasing" | "stable"
 
 
 @dataclass
@@ -50,6 +54,7 @@ class PlayerData:
     opponent_strength: TeamStrength | None
     is_dgw: bool
     missing: list[str] = field(default_factory=list)
+    upcoming_opponent_strengths: list[TeamStrength] = field(default_factory=list)
 
 
 @dataclass
@@ -57,11 +62,16 @@ class BuyRecommendation:
     """EP-based buy recommendation."""
 
     score: PlayerScore
+    player: MarketPlayer
     marginal_ep_gain: float
+    effective_ep: float  # Expected points used for ranking
     replaces_player_id: str | None
     replaces_player_name: str | None
     roster_impact: str  # "fills_gap", "upgrade", "additional"
+    roster_bonus: float  # Numeric bonus for bidding strategy
     reason: str
+    recommended_bid: int | None = None
+    sell_plan: "SellPlan | None" = None  # Paired sell plan when buy exceeds budget
 
 
 @dataclass
@@ -69,6 +79,7 @@ class SellRecommendation:
     """EP-based sell recommendation."""
 
     score: PlayerScore
+    player: MarketPlayer | None
     expendability: float  # 0-100 (higher = more expendable)
     is_protected: bool
     protection_reason: str | None
@@ -79,10 +90,13 @@ class SellRecommendation:
 class TradePair:
     """Sell->Buy swap recommendation."""
 
-    buy: BuyRecommendation
-    sell: SellRecommendation
+    buy_player: MarketPlayer
+    sell_player: MarketPlayer
+    buy_score: PlayerScore
+    sell_score: PlayerScore
     net_cost: int
     ep_gain: float
+    recommended_bid: int | None = None
 
 
 @dataclass

--- a/rehoboam/scoring/scorer.py
+++ b/rehoboam/scoring/scorer.py
@@ -112,6 +112,34 @@ def _extract_minutes_trend(performance: dict) -> tuple[str | None, float | None]
         return None, None
 
 
+def _extract_recent_form(performance: dict, window: int = 5) -> float | None:
+    """Average points over the last *window* matches played.
+
+    Returns:
+        Average points over recent matches, or None if fewer than 2 matches.
+    """
+    try:
+        seasons = performance.get("it", [])
+        if not seasons:
+            return None
+
+        seasons_sorted = sorted(seasons, key=lambda s: s.get("ti", ""), reverse=True)
+        current_season = seasons_sorted[0] if seasons_sorted else None
+        if not current_season:
+            return None
+
+        matches = current_season.get("ph", [])
+        matches_played = [m for m in matches if m.get("p", 0) != 0 or m.get("t", 0) > 0]
+
+        if len(matches_played) < 2:
+            return None
+
+        recent = matches_played[-window:]
+        return sum(m.get("p", 0) for m in recent) / len(recent)
+    except Exception:
+        return None
+
+
 def _grade_data_quality(
     games_played: int,
     has_fixture: bool,
@@ -218,32 +246,49 @@ def score_player(data: PlayerData) -> PlayerScore:
 
     # ------------------------------------------------------------------
     # 4. Fixture bonus  (-10 to +15)
+    #    Weighted average over next 3 fixtures: 50% / 30% / 20%.
+    #    Falls back to single opponent if multi-fixture data unavailable.
     # ------------------------------------------------------------------
     fixture_bonus: float = 0.0
     has_fixture = False
     next_opponent: str | None = None
 
-    if data.team_strength and data.opponent_strength:
+    def _diff_to_bonus(diff: float) -> float:
+        if diff >= 40:
+            return 15.0
+        elif diff >= 20:
+            return 8.0
+        elif diff >= 5:
+            return 3.0
+        elif diff >= -5:
+            return 0.0
+        elif diff >= -20:
+            return -5.0
+        else:
+            return -10.0
+
+    if data.team_strength and data.upcoming_opponent_strengths:
+        has_fixture = True
+        next_opponent = data.upcoming_opponent_strengths[0].team_name
+        # Weighted average: next match 50%, second 30%, third 20%
+        weights = [0.50, 0.30, 0.20]
+        total_diff = 0.0
+        total_weight = 0.0
+        for i, opp in enumerate(data.upcoming_opponent_strengths[:3]):
+            w = weights[i] if i < len(weights) else 0.0
+            total_diff += w * (data.team_strength.strength_score - opp.strength_score)
+            total_weight += w
+        diff = total_diff / total_weight if total_weight > 0 else 0.0
+        fixture_bonus = _diff_to_bonus(diff)
+    elif data.team_strength and data.opponent_strength:
+        # Fallback: single opponent (backward compat)
         has_fixture = True
         next_opponent = data.opponent_strength.team_name
-        # Positive when player's team is stronger than the opponent
         diff = data.team_strength.strength_score - data.opponent_strength.strength_score
-        # Map diff (-100 to +100) → bonus (-10 to +15)
-        if diff >= 40:
-            fixture_bonus = 15.0
-        elif diff >= 20:
-            fixture_bonus = 8.0
-        elif diff >= 5:
-            fixture_bonus = 3.0
-        elif diff >= -5:
-            fixture_bonus = 0.0
-        elif diff >= -20:
-            fixture_bonus = -5.0
-        else:
-            fixture_bonus = -10.0
+        fixture_bonus = _diff_to_bonus(diff)
 
     # ------------------------------------------------------------------
-    # 5. Minutes trend bonus  (-10 to +10)
+    # 5. Minutes trend bonus  (-15 to +10)
     # ------------------------------------------------------------------
     minutes_trend, avg_minutes = _extract_minutes_trend(data.performance or {})
 
@@ -251,7 +296,11 @@ def score_player(data: PlayerData) -> PlayerScore:
     if minutes_trend == "increasing":
         minutes_bonus = 10.0
     elif minutes_trend == "decreasing":
-        minutes_bonus = -10.0
+        if avg_minutes is not None and avg_minutes < 30:
+            minutes_bonus = -15.0
+            notes.append(f"Minutes collapsing: avg {avg_minutes:.0f}min, trend decreasing")
+        else:
+            minutes_bonus = -10.0
     elif minutes_trend == "stable":
         if avg_minutes is not None and avg_minutes < 30:
             minutes_bonus = -8.0
@@ -260,19 +309,33 @@ def score_player(data: PlayerData) -> PlayerScore:
 
     # ------------------------------------------------------------------
     # 6. Form bonus  (-10 to +10)
+    #    Uses last-5-games average vs season average to detect streaks.
+    #    Falls back to season ratio if per-match data is unavailable.
     # ------------------------------------------------------------------
     form_bonus: float = 0.0
-    if avg_pts > 0:
+    recent_avg = _extract_recent_form(data.performance or {}, window=5)
+
+    if recent_avg is not None and avg_pts > 0:
+        form_ratio = recent_avg / avg_pts
+        if form_ratio > 1.5:
+            form_bonus = 10.0
+            notes.append(f"Hot streak: recent avg {recent_avg:.0f} vs season {avg_pts:.0f}")
+        elif form_ratio > 1.15:
+            form_bonus = 5.0
+        elif form_ratio < 0.5:
+            form_bonus = -10.0
+            notes.append(f"Cold slump: recent avg {recent_avg:.0f} vs season {avg_pts:.0f}")
+        elif form_ratio < 0.75:
+            form_bonus = -5.0
+    elif avg_pts > 0:
+        # Fallback: season ratio when per-match data unavailable
         ratio = current_pts / avg_pts
         if ratio > 2.0:
             form_bonus = 10.0
         elif ratio > 1.3:
             form_bonus = 5.0
         elif ratio < 0.5:
-            if current_pts == 0:
-                form_bonus = -10.0
-            else:
-                form_bonus = -5.0
+            form_bonus = -10.0 if current_pts == 0 else -5.0
     else:
         if current_pts == 0:
             form_bonus = -10.0
@@ -325,6 +388,10 @@ def score_player(data: PlayerData) -> PlayerScore:
         is_dgw=data.is_dgw,
         next_opponent=next_opponent,
         notes=notes,
-        current_price=player.price,
+        current_price=getattr(player, "price", player.market_value),
         market_value=player.market_value,
+        average_points=avg_pts,
+        position=player.position or "",
+        lineup_probability=data.player_details.get("prob") if data.player_details else None,
+        minutes_trend=minutes_trend,
     )

--- a/rehoboam/trader.py
+++ b/rehoboam/trader.py
@@ -2614,12 +2614,11 @@ class Trader:
             if player_details:
                 tid = player_details.get("tid", "")
                 _get_team_profile_cached(tid)
-                # Also cache opponent team if available
-                from .matchup_analyzer import MatchupAnalyzer as _MA  # noqa: F401
-
-                next_matchup = self.matchup_analyzer.get_next_matchup(player_details)
-                if next_matchup and next_matchup.opponent_id:
-                    _get_team_profile_cached(next_matchup.opponent_id)
+                # Cache next 3 opponents for multi-fixture lookahead
+                next_matchups = self.matchup_analyzer.get_next_matchups(player_details, n=3)
+                for m in next_matchups:
+                    if m.opponent_id:
+                        _get_team_profile_cached(m.opponent_id)
             else:
                 # Fall back to team_id on player object
                 _get_team_profile_cached(getattr(player, "team_id", ""))
@@ -2687,10 +2686,8 @@ class Trader:
 
         # --- 5. Make decisions ---
         engine = DecisionEngine(
-            min_avg_points_to_buy=20.0,
-            min_avg_points_emergency=10.0,
-            min_expected_points_to_buy=getattr(self.settings, "min_expected_points_to_buy", 30.0),
-            min_ep_upgrade_threshold=getattr(self.settings, "min_ep_upgrade_threshold", 10.0),
+            min_ep_to_buy=getattr(self.settings, "min_expected_points_to_buy", 30.0),
+            min_ep_upgrade=getattr(self.settings, "min_ep_upgrade_threshold", 10.0),
         )
 
         if squad_size >= 15:
@@ -2714,6 +2711,7 @@ class Trader:
                 market_players=market_player_map,
                 is_emergency=is_emergency,
                 top_n=8 if is_emergency else 5,
+                squad_players=squad_player_map,
             )
             trade_pairs = []
 

--- a/tests/test_scoring/test_decision.py
+++ b/tests/test_scoring/test_decision.py
@@ -30,6 +30,7 @@ def _make_score(player_id, ep, position="Midfielder", price=5_000_000, market_va
         notes=[],
         current_price=price,
         market_value=market_value,
+        position=position,
     )
 
 
@@ -198,10 +199,10 @@ class TestRecommendSells:
             squad.append(_make_player(f"fwd{i}", "Forward"))
             squad_scores.append(_make_score(f"fwd{i}", 45.0 if i == 0 else 20.0, "Forward"))
 
-        best_11_ids = {"gk1", "def0", "def1", "def2", "mid0", "mid1", "mid2", "mid3", "fwd0"}
+        squad_players = {p.id: p for p in squad}
         engine = DecisionEngine()
         recommendations = engine.recommend_sells(
-            squad=squad, squad_scores=squad_scores, best_11_ids=best_11_ids
+            squad_scores=squad_scores, roster_context={}, squad_players=squad_players
         )
 
         # bench players (fwd1, fwd2) should be more expendable than starter fwd0
@@ -216,9 +217,10 @@ class TestRecommendSells:
         squad = [_make_player("gk1", "Goalkeeper")]
         squad_scores = [_make_score("gk1", 40.0, "Goalkeeper")]
 
+        squad_players = {p.id: p for p in squad}
         engine = DecisionEngine()
         recommendations = engine.recommend_sells(
-            squad=squad, squad_scores=squad_scores, best_11_ids={"gk1"}
+            squad_scores=squad_scores, roster_context={}, squad_players=squad_players
         )
 
         gk_rec = next(r for r in recommendations if r.score.player_id == "gk1")


### PR DESCRIPTION
## Summary
- **Wire DGW detection**: 1.8x multiplier was hardcoded off — now calls `detect_double_gameweek()` so DGW players score up to 180 EP
- **Recent form window**: Last 5 games vs season average detects hot streaks (+10) and cold slumps (-10)
- **Multi-fixture lookahead**: Weights next 3 opponents (50/30/20%) instead of just the next one
- **Lineup probability filter**: Blocks buying players with prob 4-5 (unlikely to start)
- **Minutes trend hard-block**: Players with collapsing minutes (<30 avg + decreasing trend) blocked from buy recs
- **Aggressive buys with sell plans**: Expensive players no longer filtered — paired with sell plans to fund the purchase
- **Bug fix**: `DecisionEngine` constructor kwargs, missing methods, and `Player`/`MarketPlayer` compatibility

## Test plan
- [x] All 140 tests pass (`pytest tests/`)
- [x] `rehoboam analyze` runs end-to-end with correct output
- [x] `rehoboam analyze -v` shows no squad scoring errors
- [x] Over-budget buys show paired sell plans (e.g., Engelhardt with "Sell Martel")
- [x] Pre-commit hooks pass (black, ruff, bandit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)