### PR TITLE
feat: unified EP bidding + profit flips + sell monitoring

### DIFF
--- a/rehoboam/auto_trader.py
+++ b/rehoboam/auto_trader.py
@@ -151,29 +151,41 @@ class AutoTrader:
             console.print(f"[yellow]Daily spend limit reached (€{self.max_daily_spend:,})[/yellow]")
             return results
 
-        # Find opportunities
-        opportunities = trader.find_profit_opportunities(league)
-
-        if not opportunities:
-            console.print("[dim]No profit opportunities found[/dim]")
+        # Get EP-scored recommendations (same pipeline as `rehoboam analyze`)
+        try:
+            ep_result = trader.get_ep_recommendations(league)
+            buy_recs = ep_result["buy_recs"]
+            trade_pairs = ep_result["trade_pairs"]
+        except Exception as e:
+            console.print(f"[red]EP pipeline failed: {e}[/red]")
             return results
 
-        # Recalculate buy prices with smart bidding (profit trades default to asking price)
-        for opp in opportunities:
-            try:
-                from .value_calculator import PlayerValue
+        # Merge buy_recs and trade_pairs into a unified opportunity list
+        from types import SimpleNamespace
 
-                value = PlayerValue.calculate(opp.player)
-                bid_rec = trader.bidding.calculate_bid(
-                    asking_price=opp.player.price,
-                    market_value=opp.player.market_value,
-                    value_score=value.value_score,
-                    confidence=min(value.value_score / 100.0, 0.95),
-                    trend_change_pct=None,  # ProfitOpportunity doesn't carry trend; uses conservative default
+        opportunities = []
+        for rec in buy_recs:
+            if rec.recommended_bid and rec.recommended_bid > 0:
+                opportunities.append(
+                    SimpleNamespace(
+                        player=rec.player,
+                        buy_price=rec.recommended_bid,
+                        reason=rec.reason,
+                    )
                 )
-                opp.buy_price = bid_rec.recommended_bid
-            except Exception:
-                pass  # Keep original price as fallback
+        for pair in trade_pairs:
+            if pair.recommended_bid and pair.recommended_bid > 0:
+                opportunities.append(
+                    SimpleNamespace(
+                        player=pair.buy_player,
+                        buy_price=pair.recommended_bid,
+                        reason=f"Trade: sell {pair.sell_player.last_name} for EP +{pair.ep_gain:.1f}",
+                    )
+                )
+
+        ep_opportunity_count = len(opportunities)
+        if not opportunities:
+            console.print("[dim]No EP-based opportunities found[/dim]")
 
         # Check active bids - we can have multiple bids simultaneously
         my_bids = self.api.get_my_bids(league)
@@ -279,7 +291,62 @@ class AutoTrader:
                 if not my_bid_amounts.get(opp.player.id, 0):
                     available_slots -= 1
 
-        console.print(f"\n[green]✓ Executed {executed_count} profit trades[/green]")
+        console.print(f"\n[green]✓ Executed {executed_count} EP trades[/green]")
+
+        # --- Phase 2: Profit flip opportunities for remaining slots ---
+        if available_slots > 0 and self.daily_spend < self.max_daily_spend:
+            console.print("\n[bold cyan]💰 Profit Flip Opportunities[/bold cyan]")
+
+            try:
+                profit_opps = trader.find_profit_opportunities(league)
+            except Exception as e:
+                console.print(f"[yellow]Profit opportunity search failed: {e}[/yellow]")
+                profit_opps = []
+
+            # Filter out players we already bid on (EP or existing)
+            ep_player_ids = {opp.player.id for opp in opportunities}
+            profit_opps = [o for o in profit_opps if o.player.id not in ep_player_ids]
+
+            if profit_opps:
+                console.print(f"[cyan]Found {len(profit_opps)} profit flip candidates[/cyan]")
+
+                for opp in profit_opps:
+                    if available_slots <= 0:
+                        break
+                    if self.daily_spend + opp.buy_price >= self.max_daily_spend:
+                        break
+
+                    # Skip if already have a bid
+                    current_bid = my_bid_amounts.get(opp.player.id, 0)
+                    if current_bid > 0:
+                        continue
+
+                    if opp.buy_price > flip_budget:
+                        continue
+
+                    from types import SimpleNamespace
+
+                    flip_opp = SimpleNamespace(
+                        player=opp.player,
+                        buy_price=opp.buy_price,
+                        reason=f"Flip: +{opp.expected_appreciation:.0f}% in {opp.hold_days}d",
+                    )
+                    result = self._execute_buy(league, flip_opp)
+                    results.append(result)
+
+                    if result.success:
+                        executed_count += 1
+                        self.daily_spend += opp.buy_price
+                        flip_budget -= opp.buy_price
+                        available_slots -= 1
+
+                console.print(
+                    f"[green]✓ Total executed: {executed_count} trades "
+                    f"({ep_opportunity_count} EP + {executed_count - ep_opportunity_count} flips)[/green]"
+                )
+            else:
+                console.print("[dim]No profit flip opportunities found[/dim]")
+
         return results
 
     def run_lineup_improvement_session(self, league) -> list[AutoTradeResult]:
@@ -308,86 +375,75 @@ class AutoTrader:
             console.print(f"[yellow]Daily spend limit reached (€{self.max_daily_spend:,})[/yellow]")
             return results
 
-        # Find trades
-        trades = trader.find_trade_opportunities(league)
-
-        if not trades:
-            console.print("[dim]No lineup improvement trades found[/dim]")
+        # Get EP recommendations (same pipeline as `rehoboam analyze`)
+        try:
+            ep_result = trader.get_ep_recommendations(league)
+            buy_recs = ep_result["buy_recs"]
+            trade_pairs = ep_result["trade_pairs"]
+        except Exception as e:
+            console.print(f"[red]EP pipeline failed: {e}[/red]")
             return results
 
-        # Check active bids - we can have multiple bids simultaneously
-        my_bids = self.api.get_my_bids(league)
+        # For lineup improvement, use trade pairs (sell→buy swaps) or top buy
+        from types import SimpleNamespace
 
-        # Build map of player_id -> our bid amount
-        my_bid_amounts = {p.id: p.user_offer_price for p in my_bids}
+        opportunities = []
+        for pair in trade_pairs:
+            if pair.recommended_bid and pair.recommended_bid > 0:
+                opportunities.append(
+                    SimpleNamespace(
+                        player=pair.buy_player,
+                        buy_price=pair.recommended_bid,
+                        reason=f"Lineup upgrade: sell {pair.sell_player.last_name} → buy {pair.buy_player.last_name} (EP +{pair.ep_gain:.1f})",
+                    )
+                )
+        for rec in buy_recs:
+            if rec.recommended_bid and rec.recommended_bid > 0:
+                opportunities.append(
+                    SimpleNamespace(
+                        player=rec.player,
+                        buy_price=rec.recommended_bid,
+                        reason=rec.reason,
+                    )
+                )
+
+        if not opportunities:
+            console.print("[dim]No EP-based lineup improvements found[/dim]")
+            return results
+
+        # Check active bids
+        my_bids = self.api.get_my_bids(league)
 
         if my_bids:
             console.print(f"[cyan]📊 Active bids: {len(my_bids)}[/cyan]")
 
-        # Calculate available squad slots (enforce 15-player limit)
+        # Calculate available squad slots
         squad = self.api.get_squad(league)
         current_squad_size = len(squad)
         active_bid_count = len(my_bids)
-        max_squad_size = 15
 
         console.print(
             f"[cyan]📋 Squad slots: {current_squad_size} players + {active_bid_count} active bids = {current_squad_size + active_bid_count}/15[/cyan]"
         )
 
-        # Get current budget
-        team_info = self.api.get_team_info(league)
-        current_budget = team_info.get("budget", 0)
-        team_value = team_info.get("team_value", 0)
-        max_debt = int(team_value * (self.settings.max_debt_pct_of_team_value / 100))
+        # Execute best opportunity (only 1 per session for safety)
+        opp = opportunities[0]
 
-        # Calculate effective budget (subtract pending bids)
-        pending_bid_total = sum(p.user_offer_price for p in my_bids)
-        available_budget = current_budget + max_debt - pending_bid_total
+        if self.daily_spend + opp.buy_price >= self.max_daily_spend:
+            console.print("[yellow]Would exceed daily spend limit, skipping[/yellow]")
+            return results
 
-        # Execute best trade (only 1 lineup trade per session for safety)
-        for trade in trades[:1]:  # Only top trade
-            if self.daily_spend + trade.required_budget >= self.max_daily_spend:
-                console.print("[yellow]Would exceed daily spend limit, skipping[/yellow]")
-                break
+        if current_squad_size + active_bid_count >= 15:
+            console.print("[yellow]No squad slots available (15-player limit)[/yellow]")
+            return results
 
-            # Check 15-player limit with net squad change from trade
-            net_squad_change = len(trade.players_in) - len(trade.players_out)
-            if current_squad_size + active_bid_count + net_squad_change > max_squad_size:
-                console.print(
-                    f"[yellow]Trade would exceed 15-player limit "
-                    f"({current_squad_size} + {active_bid_count} bids + {net_squad_change} net = "
-                    f"{current_squad_size + active_bid_count + net_squad_change})[/yellow]"
-                )
-                continue
+        # Execute the buy using same _execute_buy as profit session
+        result = self._execute_buy(league, opp)
+        results.append(result)
 
-            # Show if trade includes players we already have bids on
-            players_with_bids = [p for p in trade.players_in if p.id in my_bid_amounts]
-            if players_with_bids:
-                console.print(
-                    f"[yellow]⚠ Trade includes players you bid on: {', '.join(p.first_name + ' ' + p.last_name for p in players_with_bids)}[/yellow]"
-                )
-                console.print(
-                    "[dim]Bot will attempt trade anyway - you can have multiple bids[/dim]"
-                )
-
-            # Check if affordable
-            if trade.required_budget > available_budget:
-                console.print(
-                    f"[yellow]Cannot afford trade (needs €{trade.required_budget:,})[/yellow]"
-                )
-                continue
-
-            # Execute trade (buy all, then sell all)
-            trade_results = self._execute_lineup_trade(league, trade)
-            results.extend(trade_results)
-
-            if all(r.success for r in trade_results):
-                self.daily_spend += trade.required_budget
-                console.print("\n[green]✓ Executed lineup improvement trade[/green]")
-            else:
-                console.print("\n[red]✗ Lineup trade partially failed[/red]")
-
-            break  # Only one lineup trade per session
+        if result.success:
+            self.daily_spend += opp.buy_price
+            console.print("\n[green]✓ Executed lineup improvement trade[/green]")
 
         return results
 
@@ -595,6 +651,152 @@ class AutoTrader:
 
         return results
 
+    def run_profit_sell_monitoring(self, league) -> list[AutoTradeResult]:
+        """Check owned players for profit targets and sell to Kickbase.
+
+        Identifies non-starting players that have appreciated since purchase
+        and sells them instantly to Kickbase (~95% market value) to free budget.
+
+        Sell conditions:
+        - Profit >= 10%: take profit
+        - Held 7+ days and losing value: cut losses (stop-loss at -5%)
+        """
+        from .trader import Trader
+
+        results = []
+        trader = Trader(
+            self.api,
+            self.settings,
+            bid_learner=self.learner,
+            activity_feed_learner=self.activity_feed_learner,
+        )
+
+        console.print("\n[bold cyan]📈 Profit Sell Monitoring[/bold cyan]")
+
+        squad = self.api.get_squad(league)
+        if not squad:
+            console.print("[dim]No squad loaded[/dim]")
+            return results
+
+        # Get EP recommendations to identify best-11 (protected from selling)
+        try:
+            ep_result = trader.get_ep_recommendations(league)
+            squad_scores = ep_result["squad_scores"]
+            # Top 11 by EP are protected
+            sorted_by_ep = sorted(squad_scores, key=lambda s: s.expected_points, reverse=True)
+            best_11_ids = {s.player_id for s in sorted_by_ep[:11]}
+        except Exception:
+            # Fallback: protect all players if scoring fails
+            console.print("[yellow]Could not score squad — skipping sell monitoring[/yellow]")
+            return results
+
+        # Check if EP pipeline has buy replacements lined up
+        buy_recs = ep_result.get("buy_recs", [])
+        trade_pairs = ep_result.get("trade_pairs", [])
+        has_replacement = len(buy_recs) > 0 or len(trade_pairs) > 0
+
+        sell_candidates = []
+        for player in squad:
+            # Never sell best-11 starters
+            if player.id in best_11_ids:
+                continue
+
+            # Need buy_price to calculate profit
+            if not player.buy_price or player.buy_price <= 0:
+                continue
+
+            profit = player.market_value - player.buy_price
+            profit_pct = (profit / player.buy_price) * 100
+
+            # Always sell when profit target hit — take the money
+            if profit_pct >= 10.0:
+                sell_candidates.append(
+                    (player, profit_pct, f"Profit target hit: +{profit_pct:.1f}% (€{profit:,})")
+                )
+            # Only cut losses if there's a better player to buy
+            elif profit_pct <= -5.0 and has_replacement:
+                sell_candidates.append(
+                    (
+                        player,
+                        profit_pct,
+                        f"Stop-loss (replacement available): {profit_pct:.1f}% (€{profit:,})",
+                    )
+                )
+
+        if not sell_candidates:
+            console.print("[dim]No players meet sell criteria[/dim]")
+            return results
+
+        # Sort: highest profit first
+        sell_candidates.sort(key=lambda x: x[1], reverse=True)
+
+        console.print(f"[green]Found {len(sell_candidates)} player(s) to sell[/green]")
+
+        for player, profit_pct, reason in sell_candidates:
+            console.print(
+                f"\n[cyan]Selling {player.first_name} {player.last_name} to Kickbase "
+                f"(MV €{player.market_value:,}, bought €{player.buy_price:,}, "
+                f"{profit_pct:+.1f}%)[/cyan]"
+            )
+
+            if self.dry_run:
+                console.print("[yellow]DRY RUN: Sell not executed[/yellow]")
+                results.append(
+                    AutoTradeResult(
+                        success=True,
+                        player_name=f"{player.first_name} {player.last_name}",
+                        action="SELL",
+                        price=player.market_value,
+                        reason=reason,
+                        timestamp=time.time(),
+                    )
+                )
+                continue
+
+            try:
+                self.api.client.sell_to_kickbase(league.id, player.id)
+                console.print(f"[green]✓ Sold {player.first_name} {player.last_name}[/green]")
+
+                # Record flip outcome for learning
+                if self.learner:
+                    try:
+                        self.learner.record_flip_outcome(
+                            player_id=player.id,
+                            buy_price=player.buy_price,
+                            sell_price=player.market_value,
+                            profit_pct=profit_pct,
+                        )
+                    except Exception:
+                        pass
+
+                results.append(
+                    AutoTradeResult(
+                        success=True,
+                        player_name=f"{player.first_name} {player.last_name}",
+                        action="SELL",
+                        price=player.market_value,
+                        reason=reason,
+                        timestamp=time.time(),
+                    )
+                )
+            except Exception as e:
+                console.print(
+                    f"[red]✗ Failed to sell {player.first_name} {player.last_name}: {e}[/red]"
+                )
+                results.append(
+                    AutoTradeResult(
+                        success=False,
+                        player_name=f"{player.first_name} {player.last_name}",
+                        action="SELL",
+                        price=player.market_value,
+                        reason=reason,
+                        timestamp=time.time(),
+                        error=str(e),
+                    )
+                )
+
+        return results
+
     def run_full_session(self, league) -> AutoTradeSession:
         """
         Run a complete automated trading session
@@ -629,9 +831,18 @@ class AutoTrader:
 
         profit_results = []
         lineup_results = []
+        sell_results = []
         errors = []
 
-        # Step 0: Squad Optimization - Ensure best 11 and positive budget by gameday
+        # Step 0: Sell monitoring — realize profits on appreciated players
+        try:
+            sell_results = self.run_profit_sell_monitoring(league)
+        except Exception as e:
+            error_msg = f"Sell monitoring error: {str(e)}"
+            console.print(f"[red]{error_msg}[/red]")
+            errors.append(error_msg)
+
+        # Step 1: Squad Optimization - Ensure best 11 and positive budget by gameday
         console.print("\n[bold cyan]🎯 Squad Optimization[/bold cyan]")
         try:
             squad_optimization = self.optimize_and_execute_squad(league)
@@ -670,12 +881,9 @@ class AutoTrader:
             errors.append(error_msg)
 
         # Calculate totals
-        total_spent = sum(
-            r.price for r in profit_results + lineup_results if r.action == "BUY" and r.success
-        )
-        total_earned = sum(
-            r.price for r in profit_results + lineup_results if r.action == "SELL" and r.success
-        )
+        all_results = profit_results + lineup_results + sell_results
+        total_spent = sum(r.price for r in all_results if r.action == "BUY" and r.success)
+        total_earned = sum(r.price for r in all_results if r.action == "SELL" and r.success)
         net_change = total_earned - total_spent
 
         end_time = time.time()

--- a/rehoboam/profit_trader.py
+++ b/rehoboam/profit_trader.py
@@ -59,7 +59,9 @@ class ProfitTrader:
         market_players: list,
         current_budget: int,
         player_trends: dict[str, dict],
-        max_opportunities: int = 10,  # Increased from 5 to 10 since we can use debt
+        max_opportunities: int = 10,
+        team_value: int = 0,
+        max_debt_pct: float = 60.0,
     ) -> list[ProfitOpportunity]:
         """
         Find players to buy and flip for profit
@@ -69,6 +71,8 @@ class ProfitTrader:
             current_budget: Available budget
             player_trends: Dict mapping player_id -> trend analysis
             max_opportunities: Max opportunities to return
+            team_value: Total team value (for debt capacity calculation)
+            max_debt_pct: Max debt as percentage of team value
 
         Returns:
             List of ProfitOpportunity sorted by best profit potential
@@ -79,20 +83,23 @@ class ProfitTrader:
         affordable = 0
         has_trend_data = 0
         meets_threshold = 0
-        small_sample_filtered = 0  # Count players filtered due to small sample size
+        small_sample_filtered = 0
+
+        # Use debt capacity for affordability (can go negative to flip)
+        max_debt = int(team_value * (max_debt_pct / 100)) if team_value > 0 else 0
+        max_affordable = current_budget + max_debt
 
         for player in market_players:
             checked += 1
 
             # Skip injured/unavailable players
-            # Status codes: 0=healthy, 2/4/256=injured/unavailable
             if player.status != 0:
                 continue
 
             healthy += 1
 
-            # Must be affordable
-            if player.price > current_budget:
+            # Must be affordable (including debt capacity)
+            if player.price > max_affordable:
                 continue
 
             affordable += 1

--- a/rehoboam/trader.py
+++ b/rehoboam/trader.py
@@ -1440,6 +1440,8 @@ class Trader:
             current_budget=flip_budget,
             player_trends=player_trends,
             max_opportunities=max_opps,
+            team_value=team_value,
+            max_debt_pct=self.settings.max_debt_pct_of_team_value,
         )
 
         return opportunities
@@ -2542,23 +2544,17 @@ class Trader:
         """
         return {a.player.id: a.value_score for a in analyses}
 
-    def run_ep_analysis(self, league: League) -> None:
-        """Run the EP-first scoring pipeline and display the action plan.
+    def get_ep_recommendations(self, league: League) -> dict:
+        """Run the EP scoring pipeline and return structured recommendations.
 
-        This is a new analysis path that routes through the scoring pipeline
-        (scoring/collector.py -> scoring/scorer.py -> scoring/decision.py).
-        It does NOT modify any existing methods — the trade command still uses
-        the old path.
-
-        Args:
-            league: League object
+        Returns a dict with keys:
+            buy_recs, trade_pairs, sell_recs, squad_scores, lineup_map,
+            budget, squad_size, squad_players, market_players
         """
         from .roster_analyzer import RosterAnalyzer
         from .scoring.collector import DataCollector
         from .scoring.decision import DecisionEngine
         from .scoring.scorer import score_player
-
-        console.print("\n[bold cyan]EP Analysis (Expected Points Pipeline)[/bold cyan]\n")
 
         # --- 1. Fetch squad and market ---
         squad = self.api.get_squad(league)
@@ -2566,14 +2562,12 @@ class Trader:
         is_emergency = squad_size < self.settings.min_squad_size
 
         market_players_list = self.api.get_market(league)
-        # Only Kickbase-owned players are buyable
         kickbase_market = [p for p in market_players_list if p.is_kickbase_seller()]
 
         team_info = self.api.get_team_info(league)
         current_budget = team_info.get("budget", 0)
 
-        # --- 2. Collect performance + details + team profiles for every player ---
-        # Build a shared cache of team profiles keyed by team_id to avoid duplicate fetches.
+        # --- 2. Collect performance + details + team profiles ---
         team_profiles: dict[str, dict] = {}
 
         def _get_team_profile_cached(team_id: str) -> dict | None:
@@ -2588,7 +2582,6 @@ class Trader:
             return team_profiles[team_id] or None
 
         def _fetch_player_data(player) -> tuple[dict | None, dict | None]:
-            """Fetch (performance, player_details) for a player, using cache."""
             perf_data = None
             try:
                 perf_data = self.history_cache.get_cached_performance(
@@ -2610,22 +2603,19 @@ class Trader:
                 if self.verbose:
                     console.print(f"[dim]EP: details fetch failed for {player.last_name}[/dim]")
 
-            # Pre-cache team profile so collector can use it
             if player_details:
                 tid = player_details.get("tid", "")
                 _get_team_profile_cached(tid)
-                # Cache next 3 opponents for multi-fixture lookahead
                 next_matchups = self.matchup_analyzer.get_next_matchups(player_details, n=3)
                 for m in next_matchups:
                     if m.opponent_id:
                         _get_team_profile_cached(m.opponent_id)
             else:
-                # Fall back to team_id on player object
                 _get_team_profile_cached(getattr(player, "team_id", ""))
 
             return perf_data, player_details
 
-        # --- 3. Build DataCollector and score all players ---
+        # --- 3. Score all players ---
         collector = DataCollector(matchup_analyzer=self.matchup_analyzer)
 
         market_scores: list = []
@@ -2666,7 +2656,7 @@ class Trader:
                 if self.verbose:
                     console.print(f"[dim]EP: scoring failed for {player.last_name}: {e}[/dim]")
 
-        # --- 4. Build roster context for position-aware decisions ---
+        # --- 4. Build roster context ---
         roster_context: dict = {}
         try:
             player_stats = {}
@@ -2691,7 +2681,6 @@ class Trader:
         )
 
         if squad_size >= 15:
-            # Full squad — show trade pairs instead of plain buys
             buy_recs = []
             trade_pairs = engine.build_trade_pairs(
                 market_scores=market_scores,
@@ -2721,33 +2710,32 @@ class Trader:
             squad_players=squad_player_map,
         )
 
-        # --- Compute bid amounts for buy recommendations ---
+        # --- 6. Compute EP-based bid amounts ---
         for rec in buy_recs:
             try:
-                # Map EP (0-180) to value_score (0-100) for bidding strategy
-                ep_as_value_score = min(100.0, rec.score.expected_points * (100.0 / 180.0))
-                bid_rec = self.bidding.calculate_bid(
+                bid_rec = self.bidding.calculate_ep_bid(
                     asking_price=rec.player.price,
                     market_value=rec.player.market_value,
-                    value_score=ep_as_value_score,
+                    expected_points=rec.score.expected_points,
+                    marginal_ep_gain=rec.marginal_ep_gain,
                     confidence=0.7,
-                    average_points=rec.score.average_points,
-                    roster_impact=rec.roster_bonus,
+                    current_budget=int(current_budget),
+                    sell_plan=rec.sell_plan,
+                    player_id=rec.player.id,
                 )
                 rec.recommended_bid = bid_rec.recommended_bid
             except Exception:
-                rec.recommended_bid = rec.player.price  # Fallback: bid asking price
+                rec.recommended_bid = rec.player.price
         for pair in trade_pairs:
             try:
-                ep_as_value_score = min(100.0, pair.buy_score.expected_points * (100.0 / 180.0))
-                bid_rec = self.bidding.calculate_bid(
+                bid_rec = self.bidding.calculate_ep_bid(
                     asking_price=pair.buy_player.price,
                     market_value=pair.buy_player.market_value,
-                    value_score=ep_as_value_score,
+                    expected_points=pair.buy_score.expected_points,
+                    marginal_ep_gain=pair.ep_gain,
                     confidence=0.7,
-                    average_points=pair.buy_score.average_points,
-                    is_replacement=True,
-                    replacement_sell_value=pair.sell_score.market_value,
+                    current_budget=int(current_budget),
+                    player_id=pair.buy_player.id,
                 )
                 pair.recommended_bid = bid_rec.recommended_bid
             except Exception:
@@ -2755,16 +2743,33 @@ class Trader:
 
         lineup_map = engine.select_lineup(squad_scores)
 
-        # --- 6. Display ---
+        return {
+            "buy_recs": buy_recs,
+            "trade_pairs": trade_pairs,
+            "sell_recs": sell_recs,
+            "squad_scores": squad_scores,
+            "lineup_map": lineup_map,
+            "budget": current_budget,
+            "squad_size": squad_size,
+            "squad_players": squad_player_map,
+            "market_players": market_player_map,
+        }
+
+    def run_ep_analysis(self, league: League) -> None:
+        """Run the EP scoring pipeline and display the action plan."""
+        console.print("\n[bold cyan]EP Analysis (Expected Points Pipeline)[/bold cyan]\n")
+
+        result = self.get_ep_recommendations(league)
+
         self.compact_display.display_ep_action_plan(
-            buy_recs=buy_recs,
-            sell_recs=sell_recs,
-            trade_pairs=trade_pairs,
-            squad_scores=squad_scores,
-            lineup_map=lineup_map,
-            budget=current_budget,
-            squad_size=squad_size,
-            squad_players=squad_player_map,
+            buy_recs=result["buy_recs"],
+            sell_recs=result["sell_recs"],
+            trade_pairs=result["trade_pairs"],
+            squad_scores=result["squad_scores"],
+            lineup_map=result["lineup_map"],
+            budget=result["budget"],
+            squad_size=result["squad_size"],
+            squad_players=result["squad_players"],
         )
 
     def auto_trade(self, league: League, max_trades: int = 5):


### PR DESCRIPTION
## Summary
- **Unified bidding**: Both `analyze` and `auto` now use `calculate_ep_bid()` — what you see is what gets bid
- **Extracted `get_ep_recommendations()`**: Reusable method so auto trader uses the same EP scoring pipeline as analyze
- **Sell monitoring**: Runs first in every session — sells players at +10% profit, cuts losses at -5% only when a replacement is available
- **Profit flips restored**: After EP buys use priority slots, remaining slots filled with undervalued flip opportunities
- **Affordability fix**: `find_profit_opportunities()` now uses debt capacity instead of just current budget

Session flow: `sell monitoring → squad optimization → EP buys → profit flips → lineup improvement`

## Test plan
- [x] 140 tests pass
- [x] `rehoboam analyze` shows EP-based bid prices
- [x] `rehoboam auto --dry-run` shows matching bid prices
- [x] Sell monitoring correctly identifies profit/loss candidates
- [x] Stop-loss only triggers when replacement available
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)