### PR TITLE
feat: API improvements, competitor scouting, and lineup fix

### DIFF
--- a/rehoboam/api.py
+++ b/rehoboam/api.py
@@ -129,6 +129,52 @@ class KickbaseAPI:
         except Exception:
             return []
 
+    def refresh_token(self) -> bool:
+        """Refresh auth token without re-login. Falls back to full login on failure."""
+        if not self.client.refresh_tkn:
+            return False
+        try:
+            return self.client.refresh_token(self.client.refresh_tkn)
+        except Exception:
+            return False
+
+    def get_budget(self, league: League) -> dict:
+        """Get budget only (lightweight, no squad fetch)"""
+        try:
+            return self.client.get_budget(league.id)
+        except Exception as e:
+            raise Exception(f"Failed to fetch budget: {e}") from e
+
+    def get_competition_matchdays(self, competition_id: str = "1") -> dict:
+        """Get matchday schedule for DGW detection"""
+        try:
+            return self.client.get_competition_matchdays(competition_id)
+        except Exception as e:
+            raise Exception(f"Failed to fetch matchdays: {e}") from e
+
+    def get_competition_players(
+        self, competition_id: str = "1", position: str = "", sorting: str = ""
+    ) -> dict:
+        """Browse all players in a competition"""
+        try:
+            return self.client.get_competition_players(competition_id, position, sorting)
+        except Exception as e:
+            raise Exception(f"Failed to fetch competition players: {e}") from e
+
+    def get_manager_squad(self, league: League, manager_id: str) -> dict:
+        """View a competitor's squad"""
+        try:
+            return self.client.get_manager_squad(league.id, manager_id)
+        except Exception as e:
+            raise Exception(f"Failed to fetch manager squad: {e}") from e
+
+    def get_league_ranking(self, league: League) -> dict:
+        """Get league ranking/standings"""
+        try:
+            return self.client.get_league_ranking(league.id)
+        except Exception as e:
+            raise Exception(f"Failed to fetch league ranking: {e}") from e
+
     @property
     def user(self) -> User:
         """Get the logged-in user"""

--- a/rehoboam/auto_trader.py
+++ b/rehoboam/auto_trader.py
@@ -72,6 +72,14 @@ class AutoTrader:
         self.learner = BidLearner()
         self.activity_feed_learner = ActivityFeedLearner()
 
+    def get_quick_budget(self, league) -> int | None:
+        """Lightweight budget check using the budget-only endpoint."""
+        try:
+            data = self.api.get_budget(league)
+            return data.get("b", data.get("budget", None))
+        except Exception:
+            return None
+
     def _reset_daily_limits_if_needed(self):
         """Reset daily limits at midnight"""
         today = datetime.now().date()
@@ -926,7 +934,7 @@ class AutoTrader:
     def _set_optimal_lineup(self, league, errors: list[str]):
         """Calculate and set the optimal starting 11 via API"""
         from .expected_points import calculate_expected_points
-        from .formation import get_formation_string, select_best_eleven
+        from .formation import get_formation_string, order_for_lineup, select_best_eleven
         from .value_history import ValueHistoryCache
 
         console.print("\n[bold cyan]📋 Setting Optimal Lineup[/bold cyan]")
@@ -958,12 +966,13 @@ class AutoTrader:
                 except Exception:
                     ep_scores[player.id] = 0
 
-            # Select best 11 and derive formation
+            # Select best 11, order by position for API (GK→DEF→MID→FWD)
             best_eleven = select_best_eleven(squad, ep_scores)
-            formation = get_formation_string(best_eleven)
-            player_ids = [p.id for p in best_eleven]
+            ordered = order_for_lineup(best_eleven)
+            formation = get_formation_string(ordered)
+            player_ids = [p.id for p in ordered]
 
-            names = [f"{p.first_name[0]}. {p.last_name}" for p in best_eleven]
+            names = [f"{p.first_name[0]}. {p.last_name}" for p in ordered]
             console.print(f"[dim]Formation: {formation} | {', '.join(names)}[/dim]")
 
             if self.dry_run:

--- a/rehoboam/cli.py
+++ b/rehoboam/cli.py
@@ -803,7 +803,7 @@ def lineup(
     """Show optimal starting 11 for next matchday based on expected points"""
     from .compact_display import CompactDisplay
     from .expected_points import calculate_expected_points
-    from .formation import get_formation_string, select_best_eleven
+    from .formation import get_formation_string, order_for_lineup, select_best_eleven
     from .matchup_analyzer import MatchupAnalyzer
     from .value_history import ValueHistoryCache
 
@@ -914,8 +914,9 @@ def lineup(
 
     # Apply lineup via API if --set flag is used
     if set_lineup:
-        formation = get_formation_string(best_eleven)
-        player_ids = [p.id for p in best_eleven]
+        ordered = order_for_lineup(best_eleven)
+        formation = get_formation_string(ordered)
+        player_ids = [p.id for p in ordered]
         console.print(
             f"\n[bold yellow]Setting lineup: {formation} ({len(player_ids)} players)[/bold yellow]"
         )
@@ -924,6 +925,48 @@ def lineup(
             console.print("[bold green]Lineup set successfully![/bold green]")
         except Exception as e:
             console.print(f"[bold red]Failed to set lineup: {e}[/bold red]")
+
+
+@app.command()
+def players(
+    position: str = typer.Option("", "--position", "-p", help="Filter: GK, DEF, MID, FWD"),
+    top: int = typer.Option(20, "--top", "-t", help="Number of players to show"),
+):
+    """Browse all Bundesliga players sorted by average points"""
+    api = get_api()
+    api.login()
+
+    pos_filter = {"GK": "1", "DEF": "2", "MID": "3", "FWD": "4"}.get(position.upper(), "")
+
+    try:
+        data = api.get_competition_players(position=pos_filter)
+    except Exception as e:
+        console.print(f"[red]Failed to fetch players: {e}[/red]")
+        raise typer.Exit(code=1) from e
+
+    items = data.get("it", data.get("p", []))
+    # Sort by average points descending
+    items.sort(key=lambda p: p.get("ap", 0), reverse=True)
+
+    pos_map = {1: "GK", 2: "DEF", 3: "MID", 4: "FWD"}
+
+    console.print(f"\n[bold cyan]Top {top} Bundesliga Players by Avg Points[/bold cyan]")
+    if position:
+        console.print(f"[dim]Filtered: {position.upper()}[/dim]")
+    console.print()
+
+    console.print(f"{'#':>3}  {'Pos':4s} {'Name':25s} {'Avg':>5s} {'Pts':>6s} {'Value':>12s}")
+    console.print("─" * 62)
+
+    for i, p in enumerate(items[:top], 1):
+        pos = pos_map.get(p.get("pos", 0), "?")
+        name = p.get("n", p.get("fn", "?"))
+        avg = p.get("ap", 0)
+        pts = p.get("tp", p.get("p", 0))
+        mv = p.get("mv", 0)
+        console.print(f"{i:>3}  {pos:4s} {name:25s} {avg:>5.0f} {pts:>6} €{mv:>11,}")
+
+    console.print()
 
 
 @app.command()
@@ -1012,6 +1055,7 @@ def sync_activity_feed(
 def competitors(
     league_index: int = typer.Option(0, "--league", "-l", help="League index (0 for first league)"),
     competitor_name: str = typer.Option(None, "--name", "-n", help="Analyze specific competitor"),
+    squads: bool = typer.Option(False, "--squads", "-s", help="Show competitor squad compositions"),
 ):
     """Analyze competitor bidding patterns and threats"""
     from .activity_feed_learner import ActivityFeedLearner
@@ -1026,6 +1070,10 @@ def competitors(
 
     league = leagues[league_index]
     console.print(f"\n[bold cyan]Analyzing competitors in: {league.name}[/bold cyan]")
+
+    if squads:
+        _display_competitor_squads(api, league)
+        return
 
     learner = ActivityFeedLearner()
 
@@ -1053,6 +1101,39 @@ def competitors(
     else:
         # Display full competitor threat analysis
         learner.display_competitor_analysis()
+
+
+def _display_competitor_squads(api, league):
+    """Display all competitors' squad compositions"""
+    try:
+        ranking = api.get_league_ranking(league)
+    except Exception as e:
+        console.print(f"[red]Failed to get ranking: {e}[/red]")
+        return
+
+    managers = ranking.get("it", ranking.get("us", []))
+    my_id = api.user.id
+
+    for manager in managers:
+        mgr_id = manager.get("i", manager.get("id", ""))
+        mgr_name = manager.get("n", manager.get("name", "Unknown"))
+
+        if mgr_id == my_id:
+            continue
+
+        console.print(f"\n[bold yellow]{mgr_name}[/bold yellow]")
+        try:
+            squad_data = api.get_manager_squad(league, mgr_id)
+            players = squad_data.get("it", [])
+            pos_map = {1: "GK", 2: "DEF", 3: "MID", 4: "FWD"}
+            for p in sorted(players, key=lambda x: x.get("pos", 0)):
+                pos = pos_map.get(p.get("pos", 0), "?")
+                name = p.get("n", p.get("fn", "?"))
+                avg = p.get("ap", 0)
+                mv = p.get("mv", 0)
+                console.print(f"  {pos:4s} {name:20s} avg:{avg:>4.0f}  €{mv:>12,}")
+        except Exception as e:
+            console.print(f"  [dim]Could not fetch: {e}[/dim]")
 
 
 @app.command()

--- a/rehoboam/formation.py
+++ b/rehoboam/formation.py
@@ -137,6 +137,16 @@ def get_formation_string(players: list) -> str:
     return f"{counts['Defender']}-{counts['Midfielder']}-{counts['Forward']}"
 
 
+def order_for_lineup(players: list) -> list:
+    """
+    Order players by position for the set_lineup API: GK → DEF → MID → FWD.
+    The API assigns players to formation slots by index, so the order must
+    match the formation pattern.
+    """
+    position_order = {"Goalkeeper": 0, "Defender": 1, "Midfielder": 2, "Forward": 3}
+    return sorted(players, key=lambda p: position_order.get(p.position, 9))
+
+
 def validate_trade(current_squad: list, players_out: list, players_in: list) -> dict[str, any]:
     """
     Validate an N-for-M trade

--- a/rehoboam/kickbase_client.py
+++ b/rehoboam/kickbase_client.py
@@ -171,6 +171,7 @@ class KickbaseV4Client:
     def __init__(self):
         self.token: str | None = None
         self.token_expire: str | None = None
+        self.refresh_tkn: str | None = None
         self.user: User | None = None
         self.leagues: list[League] = []
         self.session = requests.Session()
@@ -195,9 +196,10 @@ class KickbaseV4Client:
         if response.status_code == 200:
             data = response.json()
 
-            # Store authentication token
+            # Store authentication token and refresh token
             self.token = data.get("tkn")
             self.token_expire = data.get("tknex")
+            self.refresh_tkn = data.get("rtkn")
 
             # Update session headers with token
             if self.token:
@@ -677,4 +679,117 @@ class KickbaseV4Client:
         else:
             raise Exception(
                 f"Failed to fetch player market value history: {response.status_code} - {response.text}"
+            )
+
+    # ── New endpoints ──────────────────────────────────────────────
+
+    def refresh_token(self, refresh_token: str) -> bool:
+        """
+        Refresh authentication token without re-login
+        POST /v4/user/refreshtokens
+        """
+        url = f"{self.BASE_URL}/v4/user/refreshtokens"
+        payload = {"rtkn": refresh_token}
+
+        response = self.session.post(url, json=payload)
+
+        if response.status_code == 200:
+            data = response.json()
+            self.token = data.get("tkn")
+            self.token_expire = data.get("tknex")
+            self.refresh_tkn = data.get("rtkn", refresh_token)
+            if self.token:
+                self.session.headers.update({"Authorization": f"Bearer {self.token}"})
+            return True
+        else:
+            return False
+
+    def get_budget(self, league_id: str) -> dict[str, Any]:
+        """
+        Get budget only (lightweight)
+        GET /v4/leagues/{league_id}/me/budget
+        """
+        url = f"{self.BASE_URL}/v4/leagues/{league_id}/me/budget"
+
+        response = self.session.get(url)
+
+        if response.status_code == 200:
+            return response.json()
+        else:
+            raise Exception(f"Failed to fetch budget: {response.status_code} - {response.text}")
+
+    def get_competition_matchdays(self, competition_id: str = "1") -> dict[str, Any]:
+        """
+        Get matchday schedule for a competition (e.g. Bundesliga)
+        GET /v4/competitions/{competition_id}/matchdays
+
+        Use to detect double gameweeks (teams playing twice in one matchday).
+        """
+        url = f"{self.BASE_URL}/v4/competitions/{competition_id}/matchdays"
+
+        response = self.session.get(url)
+
+        if response.status_code == 200:
+            return response.json()
+        else:
+            raise Exception(f"Failed to fetch matchdays: {response.status_code} - {response.text}")
+
+    def get_competition_players(
+        self, competition_id: str = "1", position: str = "", sorting: str = ""
+    ) -> dict[str, Any]:
+        """
+        Browse all players in a competition sorted by stats
+        GET /v4/competitions/{competition_id}/players
+
+        Args:
+            competition_id: Competition ID (1 = Bundesliga)
+            position: Filter by position (optional)
+            sorting: Sort field (optional)
+        """
+        url = f"{self.BASE_URL}/v4/competitions/{competition_id}/players"
+        params = {}
+        if position:
+            params["position"] = position
+        if sorting:
+            params["sorting"] = sorting
+
+        response = self.session.get(url, params=params)
+
+        if response.status_code == 200:
+            return response.json()
+        else:
+            raise Exception(
+                f"Failed to fetch competition players: {response.status_code} - {response.text}"
+            )
+
+    def get_manager_squad(self, league_id: str, manager_id: str) -> dict[str, Any]:
+        """
+        View a competitor's squad
+        GET /v4/leagues/{league_id}/managers/{manager_id}/squad
+        """
+        url = f"{self.BASE_URL}/v4/leagues/{league_id}/managers/{manager_id}/squad"
+
+        response = self.session.get(url)
+
+        if response.status_code == 200:
+            return response.json()
+        else:
+            raise Exception(
+                f"Failed to fetch manager squad: {response.status_code} - {response.text}"
+            )
+
+    def get_league_ranking(self, league_id: str) -> dict[str, Any]:
+        """
+        Get league ranking/standings
+        GET /v4/leagues/{league_id}/ranking
+        """
+        url = f"{self.BASE_URL}/v4/leagues/{league_id}/ranking"
+
+        response = self.session.get(url)
+
+        if response.status_code == 200:
+            return response.json()
+        else:
+            raise Exception(
+                f"Failed to fetch league ranking: {response.status_code} - {response.text}"
             )

--- a/rehoboam/matchup_analyzer.py
+++ b/rehoboam/matchup_analyzer.py
@@ -84,6 +84,46 @@ class MatchupAnalyzer:
 
     def __init__(self):
         self.team_cache: dict[str, TeamStrength] = {}
+        self._dgw_teams: set[str] | None = None  # Cache of team IDs with DGW
+
+    def load_dgw_from_matchdays(self, matchdays_data: dict[str, Any]) -> set[str]:
+        """
+        Detect DGW teams from competition matchday schedule.
+        Call once per session with data from GET /v4/competitions/{id}/matchdays.
+
+        Returns set of team IDs that have double gameweeks.
+        """
+        dgw_teams: set[str] = set()
+        items = matchdays_data.get("it", matchdays_data.get("mds", []))
+
+        # Group matches by matchday, count per team
+        for matchday in items:
+            md_id = str(matchday.get("id", matchday.get("mdid", "")))
+            matches = matchday.get("m", matchday.get("matches", []))
+            if not md_id or not matches:
+                continue
+
+            team_counts: dict[str, int] = {}
+            for match in matches:
+                t1 = str(match.get("t1i", match.get("t1", "")))
+                t2 = str(match.get("t2i", match.get("t2", "")))
+                if t1:
+                    team_counts[t1] = team_counts.get(t1, 0) + 1
+                if t2:
+                    team_counts[t2] = team_counts.get(t2, 0) + 1
+
+            for team_id, count in team_counts.items():
+                if count >= 2:
+                    dgw_teams.add(team_id)
+
+        self._dgw_teams = dgw_teams
+        return dgw_teams
+
+    def is_dgw_team(self, team_id: str) -> bool:
+        """Check if a team has a DGW based on loaded matchday data."""
+        if self._dgw_teams is None:
+            return False
+        return team_id in self._dgw_teams
 
     def detect_double_gameweek(self, player_details: dict[str, Any]) -> DoubleGameweekInfo:
         """

--- a/rehoboam/scheduler.py
+++ b/rehoboam/scheduler.py
@@ -99,6 +99,15 @@ class TradingScheduler:
 
         logger.info("✓ Initialization complete")
 
+    def _ensure_authenticated(self):
+        """Refresh token or re-login if needed"""
+        if self.api.refresh_token():
+            logger.info("✓ Token refreshed")
+        else:
+            logger.info("Token refresh failed, re-logging in...")
+            self.api.login()
+            logger.info("✓ Re-logged in successfully")
+
     def _run_trading_session(self):
         """Run a single trading session"""
         if not self.api or not self.auto_trader:
@@ -106,6 +115,9 @@ class TradingScheduler:
             return
 
         try:
+            # Ensure auth is valid before each session
+            self._ensure_authenticated()
+
             # Get first league
             leagues = self.api.get_leagues()
             if not leagues:

--- a/rehoboam/scoring/collector.py
+++ b/rehoboam/scoring/collector.py
@@ -70,8 +70,13 @@ class DataCollector:
                     missing.append("opponent_strength")
 
             # DGW detection — players with 2+ matches in one matchday score ~1.8x
+            # Try per-player detection first, fall back to competition-level data
             dgw_info = self.matchup_analyzer.detect_double_gameweek(player_details)
             is_dgw = dgw_info.is_dgw
+            if not is_dgw:
+                team_id = player_details.get("tid", "")
+                if team_id:
+                    is_dgw = self.matchup_analyzer.is_dgw_team(team_id)
 
         return PlayerData(
             player=player,

--- a/rehoboam/scoring/models.py
+++ b/rehoboam/scoring/models.py
@@ -72,6 +72,7 @@ class BuyRecommendation:
     reason: str
     recommended_bid: int | None = None
     sell_plan: "SellPlan | None" = None  # Paired sell plan when buy exceeds budget
+    metadata: dict | None = None
 
 
 @dataclass
@@ -97,6 +98,7 @@ class TradePair:
     net_cost: int
     ep_gain: float
     recommended_bid: int | None = None
+    metadata: dict | None = None
 
 
 @dataclass

--- a/rehoboam/trader.py
+++ b/rehoboam/trader.py
@@ -2615,6 +2615,40 @@ class Trader:
 
             return perf_data, player_details
 
+        # --- 2b. Collect competitor-owned player IDs for uncontested scoring ---
+        competitor_player_ids: set[str] = set()
+        try:
+            ranking = self.api.get_league_ranking(league)
+            managers = ranking.get("it", ranking.get("us", []))
+            my_id = self.api.user.id
+            for mgr in managers:
+                mgr_id = mgr.get("i", mgr.get("id", ""))
+                if mgr_id == my_id:
+                    continue
+                try:
+                    mgr_squad = self.api.get_manager_squad(league, mgr_id)
+                    for p in mgr_squad.get("it", []):
+                        pid = p.get("i", p.get("id", ""))
+                        if pid:
+                            competitor_player_ids.add(pid)
+                except Exception:
+                    pass
+            if competitor_player_ids and self.verbose:
+                console.print(
+                    f"[dim]Competitor scouting: {len(competitor_player_ids)} players owned by rivals[/dim]"
+                )
+        except Exception:
+            pass  # Competitor scouting is best-effort
+
+        # --- 2c. Load competition matchday schedule for DGW detection ---
+        try:
+            matchdays = self.api.get_competition_matchdays()
+            dgw_teams = self.matchup_analyzer.load_dgw_from_matchdays(matchdays)
+            if dgw_teams and self.verbose:
+                console.print(f"[dim]DGW teams detected: {len(dgw_teams)} teams[/dim]")
+        except Exception:
+            pass  # DGW detection is best-effort; per-player detection still works
+
         # --- 3. Score all players ---
         collector = DataCollector(matchup_analyzer=self.matchup_analyzer)
 
@@ -2743,6 +2777,14 @@ class Trader:
 
         lineup_map = engine.select_lineup(squad_scores)
 
+        # Mark uncontested buy recommendations (no competitor owns the player)
+        for rec in buy_recs:
+            rec.metadata = getattr(rec, "metadata", {}) or {}
+            rec.metadata["uncontested"] = rec.player.id not in competitor_player_ids
+        for pair in trade_pairs:
+            pair.metadata = getattr(pair, "metadata", {}) or {}
+            pair.metadata["uncontested"] = pair.buy_player.id not in competitor_player_ids
+
         return {
             "buy_recs": buy_recs,
             "trade_pairs": trade_pairs,
@@ -2753,6 +2795,7 @@ class Trader:
             "squad_size": squad_size,
             "squad_players": squad_player_map,
             "market_players": market_player_map,
+            "competitor_player_ids": competitor_player_ids,
         }
 
     def run_ep_analysis(self, league: League) -> None:


### PR DESCRIPTION
## Summary
- **DGW detection**: Competition-level matchday schedule loaded once per session as fallback for per-player detection
- **Competitor scouting**: Fetches rival squads, marks uncontested market players, new `--squads` flag on competitors command
- **Token refresh**: Daemon refreshes tokens before each session instead of relying on single login
- **Budget endpoint**: Lightweight `/me/budget` for quick budget checks
- **Player search**: New `rehoboam players` command to browse all Bundesliga players by avg points
- **Lineup fix**: Players must be ordered GK→DEF→MID→FWD to match formation slot indices — was causing only 5/11 slots to fill

## Test plan
- [x] All 140 tests pass
- [x] Lineup fix verified: all 11 slots filled, `b: 0` (no empty penalties)
- [x] Pre-commit hooks pass (black, ruff, bandit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)