### PR TITLE
fix: handle empty first_name in lineup display

### DIFF
--- a/rehoboam/auto_trader.py
+++ b/rehoboam/auto_trader.py
@@ -972,7 +972,10 @@ class AutoTrader:
             formation = get_formation_string(ordered)
             player_ids = [p.id for p in ordered]
 
-            names = [f"{p.first_name[0]}. {p.last_name}" for p in ordered]
+            names = [
+                f"{p.first_name[0]}. {p.last_name}" if p.first_name else p.last_name
+                for p in ordered
+            ]
             console.print(f"[dim]Formation: {formation} | {', '.join(names)}[/dim]")
 
             if self.dry_run:


### PR DESCRIPTION
## Summary
- Players with empty `first_name` caused `IndexError: string index out of range` in `_set_optimal_lineup`, aborting the entire lineup-setting flow before the API call was made
- Now falls back to just the last name when `first_name` is empty

## Test plan
- [ ] Run `rehoboam auto` with a squad containing a player with an empty first name
- [ ] Verify lineup is set successfully and formation displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)