### PR TITLE
fix: pin Black version to fix CI formatting failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install black ruff bandit[toml]
+          pip install "black>=25.1,<26" ruff bandit[toml]
 
       - name: Check code formatting with Black
         run: black --check --line-length=100 rehoboam/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
 
   # Python code formatting with Black
   - repo: https://github.com/psf/black
-    rev: 24.3.0
+    rev: 25.1.0
     hooks:
       - id: black
         name: Format code with Black


### PR DESCRIPTION
## Summary

- Pin Black to 25.x in both pre-commit hook and CI workflow
- Pre-commit had Black 24.3.0, CI installed latest (26.x) — they formatted differently, causing every CI run to fail

## Test plan

- [x] `pre-commit run black --all-files` passes
- [x] All 147 tests pass
- [ ] CI pipeline passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)