### PR TITLE
feat: aggressive unified auto trader with trend-aware trading

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,11 +35,12 @@ The bot started as a market value trader (buy low, sell high). The `analyze` com
 Current state:
 
 - `analyze` command: EP-first pipeline — scores players by expected matchday points, recommends buys by marginal EP gain (how much they improve best-11), supports sell plans for going negative
+- `auto` command: Unified aggressive trading — single EP pipeline call, trade pairs compete with plain buys ranked by EP, matchday-aware aggressiveness (aggressive 5+d, moderate 2-4d, locked 0-1d), trend-aware profit selling, up to 10 trades/session (15 aggressive)
 - `trade` command: Still uses `value_score` for profit-trading (legacy path)
-- `SmartBidding`: Has both `calculate_bid()` (value-score-based, legacy) and `calculate_ep_bid()` (EP-based, used by analyze)
+- `SmartBidding`: Has both `calculate_bid()` (value-score-based, legacy) and `calculate_ep_bid()` (EP-based, used by analyze/auto). Trend data now wired through to EP bids.
 - `BidLearner`: Tracks matchday outcomes (actual vs predicted EP), feeds EP accuracy factor back into bidding
 - Double gameweek awareness: EP calculator supports DGW multiplier (1.8x), but DGW detection not yet wired
-- Budget-at-kickoff safety: Basic 24-48h buffer exists
+- Budget-at-kickoff safety: Basic 24-48h buffer exists, matchday-locked phase prevents trading 0-1 days before match
 
 ### Strategic Priorities (in order of impact)
 

--- a/rehoboam/auto_trader.py
+++ b/rehoboam/auto_trader.py
@@ -36,6 +36,32 @@ class AutoTradeSession:
     net_change: int
 
 
+@dataclass
+class MatchdayPhase:
+    """Trading aggressiveness based on how close the next match is."""
+
+    days_until_match: int | None  # None = unknown
+    phase: str  # "aggressive" | "moderate" | "locked"
+    max_trades: int
+    allow_flips: bool  # Profit flips only make sense with enough time to sell
+    reason: str
+
+
+@dataclass
+class EPSessionContext:
+    """Single-fetch context for the entire auto session."""
+
+    ep_result: dict
+    matchday_phase: MatchdayPhase
+    my_bids: list
+    my_bid_amounts: dict  # {player_id: bid_amount}
+    squad: list
+    current_budget: int
+    team_value: int
+    flip_budget: int
+    executed_trade_count: int = 0
+
+
 class AutoTrader:
     """Executes trades automatically based on bot recommendations"""
 
@@ -87,6 +113,86 @@ class AutoTrader:
             self.daily_spend = 0
             self.last_reset = today
             console.print("[cyan]Daily limits reset[/cyan]")
+
+    def _get_matchday_phase(self, days_until_match: int | None) -> MatchdayPhase:
+        """Determine trading aggressiveness based on days to next match."""
+        if days_until_match is not None and days_until_match <= 1:
+            return MatchdayPhase(
+                days_until_match=days_until_match,
+                phase="locked",
+                max_trades=0,
+                allow_flips=False,
+                reason=f"Match in {days_until_match}d — lineup only, no trading",
+            )
+        elif days_until_match is not None and days_until_match <= 4:
+            return MatchdayPhase(
+                days_until_match=days_until_match,
+                phase="moderate",
+                max_trades=max(self.max_trades_per_session // 2, 2),
+                allow_flips=False,
+                reason=f"Match in {days_until_match}d — lineup improvements only",
+            )
+        else:
+            return MatchdayPhase(
+                days_until_match=days_until_match,
+                phase="aggressive",
+                max_trades=self.max_trades_per_session,
+                allow_flips=True,
+                reason=(
+                    f"Match in {days_until_match}d — full trading"
+                    if days_until_match
+                    else "Unknown schedule — full trading"
+                ),
+            )
+
+    def _build_session_context(self, league) -> EPSessionContext:
+        """Build the single-fetch context for the entire session."""
+        from .trader import Trader
+
+        trader = Trader(
+            self.api,
+            self.settings,
+            bid_learner=self.learner,
+            activity_feed_learner=self.activity_feed_learner,
+        )
+
+        # Fetch matchday timing
+        days = trader.get_days_until_match(league)
+        phase = self._get_matchday_phase(days)
+
+        console.print(f"[cyan]📅 {phase.reason}[/cyan]")
+
+        # Single EP pipeline call with trend data
+        ep_result = trader.get_ep_recommendations_with_trends(league)
+
+        # Fetch bids and squad
+        my_bids = self.api.get_my_bids(league)
+        squad = self.api.get_squad(league)
+        team_info = self.api.get_team_info(league)
+        current_budget = team_info.get("budget", 0)
+        team_value = team_info.get("team_value", 0)
+
+        # Calculate flip budget based on matchday phase
+        max_debt = int(team_value * (self.settings.max_debt_pct_of_team_value / 100))
+        pending_bid_total = sum(p.user_offer_price for p in my_bids)
+
+        if phase.phase == "locked":
+            flip_budget = 0
+        elif phase.phase == "moderate":
+            flip_budget = current_budget - pending_bid_total
+        else:
+            flip_budget = current_budget + max_debt - pending_bid_total
+
+        return EPSessionContext(
+            ep_result=ep_result,
+            matchday_phase=phase,
+            my_bids=my_bids,
+            my_bid_amounts={p.id: p.user_offer_price for p in my_bids},
+            squad=squad,
+            current_budget=current_budget,
+            team_value=team_value,
+            flip_budget=flip_budget,
+        )
 
     def run_profit_trading_session(self, league) -> list[AutoTradeResult]:
         """
@@ -810,6 +916,392 @@ class AutoTrader:
 
         return results
 
+    def run_unified_trade_phase(self, league, ctx: EPSessionContext) -> list[AutoTradeResult]:
+        """Execute all qualifying trades from a single ranked candidate list.
+
+        Trade pairs and plain buys compete head-to-head by EP gain.
+        This replaces the old separate profit + lineup sessions.
+        """
+        from types import SimpleNamespace
+
+        results: list[AutoTradeResult] = []
+        buy_recs = ctx.ep_result.get("buy_recs", [])
+        trade_pairs = ctx.ep_result.get("trade_pairs", [])
+
+        effective_limit = min(
+            self.max_trades_per_session,
+            ctx.matchday_phase.max_trades,
+        )
+
+        console.print(
+            f"\n[bold cyan]🤖 Unified Trade Phase "
+            f"(limit {effective_limit}, phase: {ctx.matchday_phase.phase})[/bold cyan]"
+        )
+
+        # Build unified candidate list: (kind, ep_value, object)
+        candidates = []
+        for rec in buy_recs:
+            if rec.recommended_bid and rec.recommended_bid > 0:
+                candidates.append(("buy", rec.marginal_ep_gain, rec))
+        for pair in trade_pairs:
+            if pair.recommended_bid and pair.recommended_bid > 0:
+                candidates.append(("pair", pair.ep_gain, pair))
+
+        # Sort by EP gain descending — trade pairs compete directly with plain buys
+        candidates.sort(key=lambda x: x[1], reverse=True)
+
+        if not candidates:
+            console.print("[dim]No actionable opportunities[/dim]")
+            return results
+
+        console.print(
+            f"[cyan]📋 {len(candidates)} candidates "
+            f"({sum(1 for c in candidates if c[0] == 'buy')} buys, "
+            f"{sum(1 for c in candidates if c[0] == 'pair')} trade pairs)[/cyan]"
+        )
+
+        # Refresh squad and bids — earlier phases (sell monitoring, squad optimization)
+        # may have changed the actual counts since ctx was built.
+        fresh_squad = self.api.get_squad(league)
+        fresh_bids = self.api.get_my_bids(league)
+        current_squad_size = len(fresh_squad)
+        active_bid_count = len(fresh_bids)
+        available_slots = 15 - current_squad_size - active_bid_count
+        # Update bid amounts map for duplicate-bid detection
+        ctx.my_bid_amounts = {p.id: p.user_offer_price for p in fresh_bids}
+
+        console.print(
+            f"[cyan]📋 Squad: {current_squad_size} + {active_bid_count} bids = "
+            f"{current_squad_size + active_bid_count}/15 "
+            f"({available_slots} slot(s) open)[/cyan]"
+        )
+
+        # Also add profit flip candidates if phase allows and there are open slots
+        profit_flip_candidates = []
+        if ctx.matchday_phase.allow_flips and available_slots > 0:
+            try:
+                from .trader import Trader
+
+                trader = Trader(
+                    self.api,
+                    self.settings,
+                    bid_learner=self.learner,
+                    activity_feed_learner=self.activity_feed_learner,
+                )
+                profit_opps = trader.find_profit_opportunities(league)
+                # Filter out players already in EP candidates
+                ep_player_ids = {
+                    rec.player.id for _, _, rec in candidates if hasattr(rec, "player")
+                } | {pair.buy_player.id for _, _, pair in candidates if hasattr(pair, "buy_player")}
+                for opp in profit_opps:
+                    if opp.player.id not in ep_player_ids:
+                        profit_flip_candidates.append(opp)
+                if profit_flip_candidates:
+                    console.print(
+                        f"[cyan]💰 + {len(profit_flip_candidates)} profit flip candidate(s)[/cyan]"
+                    )
+            except Exception as e:
+                console.print(f"[yellow]Profit flip search failed: {e}[/yellow]")
+
+        for kind, _ep_val, obj in candidates:
+            if ctx.executed_trade_count >= effective_limit:
+                console.print(f"[yellow]Trade limit reached ({effective_limit})[/yellow]")
+                break
+            if self.daily_spend >= self.max_daily_spend:
+                console.print("[yellow]Daily spend limit reached[/yellow]")
+                break
+
+            if kind == "buy":
+                if available_slots <= 0:
+                    continue  # No slot for a plain buy
+                if ctx.my_bid_amounts.get(obj.player.id, 0) > 0:
+                    console.print(
+                        f"[dim]Skip {obj.player.last_name} — already have active bid[/dim]"
+                    )
+                    continue
+                if obj.recommended_bid > ctx.flip_budget:
+                    console.print(
+                        f"[yellow]Cannot afford {obj.player.last_name} "
+                        f"(€{obj.recommended_bid:,} > €{ctx.flip_budget:,})[/yellow]"
+                    )
+                    continue
+
+                result = self._execute_buy(
+                    league,
+                    SimpleNamespace(
+                        player=obj.player,
+                        buy_price=obj.recommended_bid,
+                        reason=obj.reason,
+                    ),
+                )
+                results.append(result)
+                if result.success:
+                    ctx.executed_trade_count += 1
+                    self.daily_spend += obj.recommended_bid
+                    ctx.flip_budget -= obj.recommended_bid
+                    available_slots -= 1
+
+            elif kind == "pair":
+                # Don't sell a player unnecessarily if there are open slots —
+                # the same target should appear as a plain buy candidate instead.
+                if available_slots > 0:
+                    continue
+                if ctx.my_bid_amounts.get(obj.buy_player.id, 0) > 0:
+                    console.print(
+                        f"[dim]Skip pair {obj.buy_player.last_name} — already have active bid[/dim]"
+                    )
+                    continue
+                net_cost = obj.recommended_bid - int(obj.sell_player.market_value * 0.95)
+                if net_cost > ctx.flip_budget:
+                    console.print(
+                        f"[yellow]Cannot afford trade pair "
+                        f"{obj.sell_player.last_name}→{obj.buy_player.last_name} "
+                        f"(net €{net_cost:,} > €{ctx.flip_budget:,})[/yellow]"
+                    )
+                    continue
+
+                console.print(
+                    f"\n[cyan]Trade: sell {obj.sell_player.first_name} {obj.sell_player.last_name}"
+                    f" → buy {obj.buy_player.first_name} {obj.buy_player.last_name}"
+                    f" (EP +{obj.ep_gain:.1f})[/cyan]"
+                )
+
+                sell_result = self._execute_instant_sell(
+                    league,
+                    obj.sell_player,
+                    f"Trade pair: making room for {obj.buy_player.last_name} (EP +{obj.ep_gain:.1f})",
+                )
+                results.append(sell_result)
+                if not sell_result.success:
+                    console.print("[red]Sell failed, skipping this trade pair[/red]")
+                    continue
+
+                buy_result = self._execute_buy(
+                    league,
+                    SimpleNamespace(
+                        player=obj.buy_player,
+                        buy_price=obj.recommended_bid,
+                        reason=f"Trade pair: EP +{obj.ep_gain:.1f}",
+                    ),
+                )
+                results.append(buy_result)
+                if buy_result.success:
+                    ctx.executed_trade_count += 1
+                    self.daily_spend += obj.recommended_bid
+                    ctx.flip_budget -= net_cost
+                    # Trade pair: slot freed by sell, consumed by buy = net zero
+                else:
+                    console.print(
+                        f"[bold red]⚠ WARNING: Sold {obj.sell_player.last_name} but failed to buy "
+                        f"{obj.buy_player.last_name} — squad is now {current_squad_size - 1}/15[/bold red]"
+                    )
+                    available_slots += 1  # Sell freed a slot but buy failed
+
+        # Execute profit flips with remaining slots
+        if profit_flip_candidates and available_slots > 0:
+            console.print(
+                f"\n[bold cyan]💰 Profit Flips ({len(profit_flip_candidates)} candidates)[/bold cyan]"
+            )
+            for opp in profit_flip_candidates:
+                if ctx.executed_trade_count >= effective_limit:
+                    break
+                if self.daily_spend >= self.max_daily_spend:
+                    break
+                if available_slots <= 0:
+                    break
+                if ctx.my_bid_amounts.get(opp.player.id, 0) > 0:
+                    continue
+                if opp.buy_price > ctx.flip_budget:
+                    continue
+
+                result = self._execute_buy(
+                    league,
+                    SimpleNamespace(
+                        player=opp.player,
+                        buy_price=opp.buy_price,
+                        reason=f"Flip: +{opp.expected_appreciation:.0f}% in {opp.hold_days}d",
+                    ),
+                )
+                results.append(result)
+                if result.success:
+                    ctx.executed_trade_count += 1
+                    self.daily_spend += opp.buy_price
+                    ctx.flip_budget -= opp.buy_price
+                    available_slots -= 1
+
+        console.print(
+            f"\n[green]✓ Executed {ctx.executed_trade_count} trade(s) this session[/green]"
+        )
+        return results
+
+    @staticmethod
+    def _sell_threshold_for_trend(trend_7d_pct: float | None) -> float:
+        """Profit% threshold required before selling, based on price momentum.
+
+        Rising players are held longer; falling players are sold earlier.
+        """
+        if trend_7d_pct is None:
+            return 10.0
+        if trend_7d_pct >= 5.0:
+            return 15.0  # Rising fast — let it ride
+        elif trend_7d_pct >= 2.0:
+            return 12.0  # Rising — hold a bit longer
+        elif trend_7d_pct >= -2.0:
+            return 10.0  # Stable — default
+        elif trend_7d_pct >= -5.0:
+            return 7.0  # Slight decline — take profit sooner
+        else:
+            return 5.0  # Falling fast — take any profit
+
+    def run_profit_sell_phase(self, league, ctx: EPSessionContext) -> list[AutoTradeResult]:
+        """Trend-aware profit sell monitoring.
+
+        Uses EP scores from ctx to protect best-11, and trend data to
+        dynamically adjust sell thresholds.
+        """
+        from .trader import Trader
+
+        results = []
+        console.print("\n[bold cyan]📈 Profit Sell Monitoring (trend-aware)[/bold cyan]")
+
+        squad = ctx.squad
+        if not squad:
+            console.print("[dim]No squad loaded[/dim]")
+            return results
+
+        squad_scores = ctx.ep_result.get("squad_scores", [])
+        if not squad_scores:
+            console.print("[yellow]Could not score squad — skipping sell monitoring[/yellow]")
+            return results
+
+        # Top 11 by EP are protected
+        sorted_by_ep = sorted(squad_scores, key=lambda s: s.expected_points, reverse=True)
+        best_11_ids = {s.player_id for s in sorted_by_ep[:11]}
+
+        # Check if replacements are lined up
+        buy_recs = ctx.ep_result.get("buy_recs", [])
+        trade_pairs = ctx.ep_result.get("trade_pairs", [])
+        has_replacement = len(buy_recs) > 0 or len(trade_pairs) > 0
+
+        # Build a Trader instance for trend lookups (uses cached data)
+        trader = Trader(
+            self.api,
+            self.settings,
+            bid_learner=self.learner,
+            activity_feed_learner=self.activity_feed_learner,
+        )
+
+        sell_candidates = []
+        for player in squad:
+            if player.id in best_11_ids:
+                continue
+
+            if not player.buy_price or player.buy_price <= 0:
+                continue
+
+            profit = player.market_value - player.buy_price
+            profit_pct = (profit / player.buy_price) * 100
+
+            # Get trend to determine dynamic threshold
+            try:
+                trend = trader.trend_service.get_trend(player.id, player.market_value, league.id)
+                trend_7d = trend.trend_7d_pct
+            except Exception:
+                trend_7d = None
+
+            sell_threshold = self._sell_threshold_for_trend(trend_7d)
+
+            # Profit target hit (trend-adjusted)
+            if profit_pct >= sell_threshold:
+                trend_info = f", trend {trend_7d:+.1f}%/wk" if trend_7d is not None else ""
+                sell_candidates.append(
+                    (
+                        player,
+                        profit_pct,
+                        f"Profit target ({sell_threshold:.0f}%) hit: +{profit_pct:.1f}% (€{profit:,}{trend_info})",
+                    )
+                )
+            # Stop-loss: only if there's a better player to buy
+            elif profit_pct <= -5.0 and has_replacement:
+                sell_candidates.append(
+                    (
+                        player,
+                        profit_pct,
+                        f"Stop-loss (replacement available): {profit_pct:.1f}% (€{profit:,})",
+                    )
+                )
+
+        if not sell_candidates:
+            console.print("[dim]No players meet sell criteria[/dim]")
+            return results
+
+        sell_candidates.sort(key=lambda x: x[1], reverse=True)
+        console.print(f"[green]Found {len(sell_candidates)} player(s) to sell[/green]")
+
+        for player, profit_pct, reason in sell_candidates:
+            console.print(
+                f"\n[cyan]Selling {player.first_name} {player.last_name} to Kickbase "
+                f"(MV €{player.market_value:,}, bought €{player.buy_price:,}, "
+                f"{profit_pct:+.1f}%)[/cyan]"
+            )
+
+            if self.dry_run:
+                console.print("[yellow]DRY RUN: Sell not executed[/yellow]")
+                results.append(
+                    AutoTradeResult(
+                        success=True,
+                        player_name=f"{player.first_name} {player.last_name}",
+                        action="SELL",
+                        price=player.market_value,
+                        reason=reason,
+                        timestamp=time.time(),
+                    )
+                )
+                continue
+
+            try:
+                self.api.client.sell_to_kickbase(league.id, player.id)
+                console.print(f"[green]✓ Sold {player.first_name} {player.last_name}[/green]")
+
+                if self.learner:
+                    try:
+                        self.learner.record_flip_outcome(
+                            player_id=player.id,
+                            buy_price=player.buy_price,
+                            sell_price=player.market_value,
+                            profit_pct=profit_pct,
+                        )
+                    except Exception:
+                        pass
+
+                results.append(
+                    AutoTradeResult(
+                        success=True,
+                        player_name=f"{player.first_name} {player.last_name}",
+                        action="SELL",
+                        price=player.market_value,
+                        reason=reason,
+                        timestamp=time.time(),
+                    )
+                )
+            except Exception as e:
+                console.print(
+                    f"[red]✗ Failed to sell {player.first_name} {player.last_name}: {e}[/red]"
+                )
+                results.append(
+                    AutoTradeResult(
+                        success=False,
+                        player_name=f"{player.first_name} {player.last_name}",
+                        action="SELL",
+                        price=player.market_value,
+                        reason=reason,
+                        timestamp=time.time(),
+                        error=str(e),
+                    )
+                )
+
+        return results
+
     def run_profit_sell_monitoring(self, league) -> list[AutoTradeResult]:
         """Check owned players for profit targets and sell to Kickbase.
 
@@ -957,11 +1449,16 @@ class AutoTrader:
         return results
 
     def run_full_session(self, league) -> AutoTradeSession:
-        """
-        Run a complete automated trading session
+        """Run a complete automated trading session.
 
-        Returns:
-            AutoTradeSession with summary
+        New unified flow:
+        1. Sync activity feed (competitive intelligence)
+        2. Build session context (single EP pipeline call + trends + matchday timing)
+        3. If locked (0-1 days to match) → set lineup only
+        4. Trend-aware profit selling
+        5. Squad optimization (budget/size safety)
+        6. Unified trade phase (trade pairs compete with plain buys, ranked by EP)
+        7. Set optimal lineup
         """
         start_time = time.time()
 
@@ -973,42 +1470,81 @@ class AutoTrader:
             console.print("[yellow]DRY RUN MODE - No trades will be executed[/yellow]")
         console.print(f"{'=' * 70}")
 
-        # Auto-sync activity feed for competitive intelligence
+        # Step 0: Sync activity feed for competitive intelligence
         try:
             console.print("\n[dim]Syncing league activity feed...[/dim]")
             activities = self.api.client.get_activities_feed(league.id, start=0)
             stats = self.activity_feed_learner.process_activity_feed(
                 activities, api_client=self.api.client
             )
-
             if stats["transfers_new"] > 0 or stats["market_values_new"] > 0:
                 console.print(
-                    f"[dim]✓ Synced: {stats['transfers_new']} new transfers, {stats['market_values_new']} new market values[/dim]"
+                    f"[dim]✓ Synced: {stats['transfers_new']} new transfers, "
+                    f"{stats['market_values_new']} new market values[/dim]"
                 )
         except Exception as e:
             console.print(f"[yellow]Warning: Could not sync activity feed: {e}[/yellow]")
 
-        profit_results = []
-        lineup_results = []
-        sell_results = []
-        errors = []
+        sell_results: list[AutoTradeResult] = []
+        trade_results: list[AutoTradeResult] = []
+        errors: list[str] = []
 
-        # Step 0: Sell monitoring — realize profits on appreciated players
+        # Step 1: Check resolved auctions for learning
+        self.check_resolved_auctions(league)
+
+        # Step 2: Build session context (single EP pipeline + trends + matchday phase)
         try:
-            sell_results = self.run_profit_sell_monitoring(league)
+            ctx = self._build_session_context(league)
         except Exception as e:
-            error_msg = f"Sell monitoring error: {str(e)}"
+            error_msg = f"EP pipeline failed: {e!s}"
+            console.print(f"[red]{error_msg}[/red]")
+            errors.append(error_msg)
+            # Fall back to just setting lineup
+            self._set_optimal_lineup(league, errors)
+            return AutoTradeSession(
+                start_time=start_time,
+                end_time=time.time(),
+                profit_trades=[],
+                lineup_trades=[],
+                errors=errors,
+                total_spent=0,
+                total_earned=0,
+                net_change=0,
+            )
+
+        # Step 3: If locked (match imminent), just set lineup and exit
+        if ctx.matchday_phase.phase == "locked":
+            console.print(
+                f"[yellow]Match imminent ({ctx.matchday_phase.days_until_match}d) "
+                f"— setting lineup only, no trading[/yellow]"
+            )
+            self._set_optimal_lineup(league, errors)
+            return AutoTradeSession(
+                start_time=start_time,
+                end_time=time.time(),
+                profit_trades=[],
+                lineup_trades=[],
+                errors=errors,
+                total_spent=0,
+                total_earned=0,
+                net_change=0,
+            )
+
+        # Step 4: Trend-aware profit selling
+        try:
+            sell_results = self.run_profit_sell_phase(league, ctx)
+        except Exception as e:
+            error_msg = f"Sell monitoring error: {e!s}"
             console.print(f"[red]{error_msg}[/red]")
             errors.append(error_msg)
 
-        # Step 1: Squad Optimization - Ensure best 11 and positive budget by gameday
+        # Step 5: Squad Optimization (budget/size safety)
         console.print("\n[bold cyan]🎯 Squad Optimization[/bold cyan]")
         try:
             squad_optimization = self.optimize_and_execute_squad(league)
             if squad_optimization and squad_optimization.players_to_sell:
-                # Track sales as part of session results
                 for player in squad_optimization.players_to_sell:
-                    lineup_results.append(
+                    sell_results.append(
                         AutoTradeResult(
                             success=True,
                             player_name=f"{player.first_name} {player.last_name}",
@@ -1019,31 +1555,70 @@ class AutoTrader:
                         )
                     )
         except Exception as e:
-            error_msg = f"Squad optimization error: {str(e)}"
+            error_msg = f"Squad optimization error: {e!s}"
             console.print(f"[red]{error_msg}[/red]")
             errors.append(error_msg)
 
-        # Run profit trading
+        # Step 6: Bid compliance + quality check
+        self._reset_daily_limits_if_needed()
+        if self.daily_spend < self.max_daily_spend:
+            try:
+                from .bid_evaluator import BidEvaluator
+                from .league_compliance import LeagueComplianceChecker
+                from .trader import Trader
+
+                trader = Trader(
+                    self.api,
+                    self.settings,
+                    bid_learner=self.learner,
+                    activity_feed_learner=self.activity_feed_learner,
+                )
+
+                market = self.api.get_market(league)
+                kickbase_market = [p for p in market if p.is_kickbase_seller()]
+                player_trends = {
+                    p.id: trader.trend_service.get_trend(p.id, p.market_value, league.id).to_dict()
+                    for p in kickbase_market[:50]
+                }
+
+                compliance_checker = LeagueComplianceChecker(self.api, self.settings)
+                adjusted, canceled = compliance_checker.run_bid_compliance_check(
+                    league, player_trends=player_trends, auto_resolve=True, dry_run=self.dry_run
+                )
+                if adjusted > 0 or canceled > 0:
+                    console.print(
+                        f"[cyan]Bid compliance: {adjusted} adjusted, {canceled} canceled[/cyan]"
+                    )
+
+                bid_evaluator = BidEvaluator(self.api, self.settings)
+                bid_evaluations = bid_evaluator.evaluate_active_bids(
+                    league, player_trends=player_trends, for_profit=True
+                )
+                if bid_evaluations:
+                    bid_evaluator.display_bid_evaluations(bid_evaluations)
+                    canceled_count = bid_evaluator.cancel_bad_bids(
+                        league, bid_evaluations, dry_run=self.dry_run
+                    )
+                    if canceled_count > 0:
+                        console.print(
+                            f"[yellow]Canceled {canceled_count} bid(s) that no longer make sense[/yellow]"
+                        )
+            except Exception as e:
+                console.print(f"[yellow]Bid compliance check failed: {e}[/yellow]")
+
+        # Step 7: Unified trade phase (EP buys + trade pairs + profit flips)
         try:
-            profit_results = self.run_profit_trading_session(league)
+            trade_results = self.run_unified_trade_phase(league, ctx)
         except Exception as e:
-            error_msg = f"Profit trading error: {str(e)}"
+            error_msg = f"Trading error: {e!s}"
             console.print(f"[red]{error_msg}[/red]")
             errors.append(error_msg)
 
-        # Run lineup trading
-        try:
-            lineup_results.extend(self.run_lineup_improvement_session(league))
-        except Exception as e:
-            error_msg = f"Lineup trading error: {str(e)}"
-            console.print(f"[red]{error_msg}[/red]")
-            errors.append(error_msg)
-
-        # Step 4: Set optimal lineup
+        # Step 8: Set optimal lineup
         self._set_optimal_lineup(league, errors)
 
         # Calculate totals
-        all_results = profit_results + lineup_results + sell_results
+        all_results = sell_results + trade_results
         total_spent = sum(r.price for r in all_results if r.action == "BUY" and r.success)
         total_earned = sum(r.price for r in all_results if r.action == "SELL" and r.success)
         net_change = total_earned - total_spent
@@ -1055,11 +1630,12 @@ class AutoTrader:
         console.print("[bold]Session Summary[/bold]")
         console.print(f"{'=' * 70}")
         console.print(f"Duration: {end_time - start_time:.1f}s")
+        console.print(f"Phase: {ctx.matchday_phase.phase} ({ctx.matchday_phase.reason})")
         console.print(
-            f"Profit trades: {len([r for r in profit_results if r.success])}/{len(profit_results)}"
+            f"Sells: {len([r for r in sell_results if r.success and r.action == 'SELL'])}"
         )
         console.print(
-            f"Lineup trades: {len([r for r in lineup_results if r.success])}/{len(lineup_results)}"
+            f"Trades: {len([r for r in trade_results if r.success])}/{len(trade_results)}"
         )
         console.print(f"Total spent: €{total_spent:,}")
         console.print(f"Total earned: €{total_earned:,}")
@@ -1074,8 +1650,8 @@ class AutoTrader:
         return AutoTradeSession(
             start_time=start_time,
             end_time=end_time,
-            profit_trades=profit_results,
-            lineup_trades=lineup_results,
+            profit_trades=trade_results,
+            lineup_trades=sell_results,
             errors=errors,
             total_spent=total_spent,
             total_earned=total_earned,

--- a/rehoboam/cli.py
+++ b/rehoboam/cli.py
@@ -1277,13 +1277,15 @@ def stats(
 def auto(
     league_index: int = typer.Option(0, help="League index (0 for first league)"),
     dry_run: bool = typer.Option(False, "--dry-run", help="Simulate trades without executing"),
-    max_trades: int = typer.Option(5, "--max-trades", help="Max trades per session"),
+    max_trades: int = typer.Option(10, "--max-trades", help="Max trades per session"),
     max_spend: int = typer.Option(50_000_000, "--max-spend", help="Max daily spend"),
     aggressive: bool = typer.Option(
-        False, "--aggressive", help="Lower buy threshold by 5 and increase max spend by 50%"
+        False,
+        "--aggressive",
+        help="Up to 15 trades, lower EP threshold, increase spend 50%",
     ),
 ):
-    """Run a single automated trading session (profit + lineup)"""
+    """Run a single automated trading session (unified EP + profit flips)"""
     from .auto_trader import AutoTrader
 
     console.print("[bold cyan]🤖 Automated Trading Session[/bold cyan]")
@@ -1309,10 +1311,12 @@ def auto(
 
     # Apply aggressive mode
     if aggressive:
-        settings.min_value_score_to_buy = max(settings.min_value_score_to_buy - 5, 40)
+        settings.min_ep_upgrade_threshold = max(settings.min_ep_upgrade_threshold - 2, 3.0)
+        max_trades = settings.auto_max_trades_aggressive
         max_spend = int(max_spend * 1.5)
         console.print(
-            "[yellow]AGGRESSIVE MODE: Lowered buy threshold, increased spending limit[/yellow]"
+            f"[yellow]AGGRESSIVE MODE: EP threshold {settings.min_ep_upgrade_threshold:.0f}, "
+            f"max {max_trades} trades, €{max_spend:,} spend limit[/yellow]"
         )
 
     console.print()
@@ -1331,8 +1335,8 @@ def auto(
     # Show summary
     console.print("\n[bold]Session Complete![/bold]")
     console.print(f"Duration: {session.end_time - session.start_time:.1f}s")
-    console.print(f"Profit trades executed: {len([r for r in session.profit_trades if r.success])}")
-    console.print(f"Lineup trades executed: {len([r for r in session.lineup_trades if r.success])}")
+    total_trades = len([r for r in session.profit_trades + session.lineup_trades if r.success])
+    console.print(f"Trades executed: {total_trades}")
 
     if session.net_change != 0:
         color = "green" if session.net_change > 0 else "red"

--- a/rehoboam/config.py
+++ b/rehoboam/config.py
@@ -103,14 +103,6 @@ class Settings(BaseSettings):
         default=15.0,
         description="Minimum value score difference to consider a replacement an upgrade",
     )
-    min_expected_points_to_buy: float = Field(
-        default=30.0,
-        description="Minimum expected points (0-180 scale) to consider buying a player",
-    )
-    min_ep_upgrade_threshold: float = Field(
-        default=10.0,
-        description="Minimum EP gain to consider a trade pair worthwhile",
-    )
     min_points_to_keep: int = Field(
         default=50,
         description="DEPRECATED - Bot now recommends sales based on value analysis, not raw points",
@@ -122,8 +114,18 @@ class Settings(BaseSettings):
         description="Minimum expected points to consider buying a player",
     )
     min_ep_upgrade_threshold: float = Field(
-        default=10.0,
-        description="Minimum EP gain to consider a market player an upgrade",
+        default=5.0,
+        description="Minimum EP gain to consider a market player an upgrade (lower = more trades that compound over the season)",
+    )
+
+    # Auto Trading Limits
+    auto_max_trades_normal: int = Field(
+        default=10,
+        description="Max trades per auto session in normal mode",
+    )
+    auto_max_trades_aggressive: int = Field(
+        default=15,
+        description="Max trades per auto session in aggressive mode",
     )
 
     # Safety Settings

--- a/rehoboam/scoring/decision.py
+++ b/rehoboam/scoring/decision.py
@@ -28,7 +28,7 @@ class DecisionEngine:
         min_ep_upgrade: Minimum marginal EP gain required to recommend a buy.
     """
 
-    def __init__(self, min_ep_to_buy: float = 30.0, min_ep_upgrade: float = 10.0) -> None:
+    def __init__(self, min_ep_to_buy: float = 30.0, min_ep_upgrade: float = 5.0) -> None:
         self.min_ep_to_buy = min_ep_to_buy
         self.min_ep_upgrade = min_ep_upgrade
 

--- a/rehoboam/trader.py
+++ b/rehoboam/trader.py
@@ -77,6 +77,89 @@ class Trader:
         self.market_price_tracker = MarketPriceTracker()
         self.compact_display = CompactDisplay(bidding_strategy=self.bidding)
 
+    def get_days_until_match(self, league) -> int | None:
+        """Return days until next match, or None if unknown."""
+        from datetime import datetime, timezone
+
+        try:
+            starting_eleven = self.api.get_starting_eleven(league)
+            next_match = starting_eleven.get("nm") or starting_eleven.get("nextMatch")
+            if not next_match:
+                return None
+            if isinstance(next_match, int | float):
+                next_match_date = datetime.fromtimestamp(next_match, tz=timezone.utc)
+            elif isinstance(next_match, str):
+                next_match_date = datetime.fromisoformat(next_match.replace("Z", "+00:00"))
+            else:
+                return None
+            # Use timezone-aware now() to avoid naive/aware comparison error
+            now = datetime.now(tz=timezone.utc)
+            days = (next_match_date - now).days
+            return max(days, 0)  # Don't return negative for past matches
+        except Exception:
+            return None
+
+    def get_ep_recommendations_with_trends(self, league) -> dict:
+        """get_ep_recommendations + wire trend data into bids.
+
+        Calls get_ep_recommendations once, then enriches each buy rec and
+        trade pair with market value trend data before recalculating bids.
+        This fixes the permanent 40% overbid penalty from missing trend_change_pct.
+        """
+        result = self.get_ep_recommendations(league)
+        current_budget = int(result.get("budget", 0))
+
+        for rec in result.get("buy_recs", []):
+            try:
+                trend = self.trend_service.get_trend(
+                    rec.player.id, rec.player.market_value, league.id
+                )
+                if not hasattr(rec, "metadata") or rec.metadata is None:
+                    rec.metadata = {}
+                rec.metadata["trend_7d_pct"] = trend.trend_7d_pct
+                rec.metadata["trend_14d_pct"] = trend.trend_14d_pct
+                rec.metadata["momentum"] = trend.momentum
+
+                bid_rec = self.bidding.calculate_ep_bid(
+                    asking_price=rec.player.price,
+                    market_value=rec.player.market_value,
+                    expected_points=rec.score.expected_points,
+                    marginal_ep_gain=rec.marginal_ep_gain,
+                    confidence=min(1.0, rec.score.data_quality.games_played / 10.0),
+                    current_budget=current_budget,
+                    sell_plan=rec.sell_plan,
+                    player_id=rec.player.id,
+                    trend_change_pct=trend.trend_7d_pct,
+                )
+                rec.recommended_bid = bid_rec.recommended_bid
+            except Exception:
+                pass  # Keep original bid if trend fetch fails
+
+        for pair in result.get("trade_pairs", []):
+            try:
+                trend = self.trend_service.get_trend(
+                    pair.buy_player.id, pair.buy_player.market_value, league.id
+                )
+                if not hasattr(pair, "metadata") or pair.metadata is None:
+                    pair.metadata = {}
+                pair.metadata["trend_7d_pct"] = trend.trend_7d_pct
+
+                bid_rec = self.bidding.calculate_ep_bid(
+                    asking_price=pair.buy_player.price,
+                    market_value=pair.buy_player.market_value,
+                    expected_points=pair.buy_score.expected_points,
+                    marginal_ep_gain=pair.ep_gain,
+                    confidence=0.7,
+                    current_budget=current_budget,
+                    player_id=pair.buy_player.id,
+                    trend_change_pct=trend.trend_7d_pct,
+                )
+                pair.recommended_bid = bid_rec.recommended_bid
+            except Exception:
+                pass
+
+        return result
+
     def run_learning_update(self, league: League):
         """
         Run learning system updates after analysis.
@@ -2714,29 +2797,27 @@ class Trader:
             min_ep_upgrade=getattr(self.settings, "min_ep_upgrade_threshold", 10.0),
         )
 
-        if squad_size >= 15:
-            buy_recs = []
-            trade_pairs = engine.build_trade_pairs(
-                market_scores=market_scores,
-                squad_scores=squad_scores,
-                roster_context=roster_context,
-                budget=current_budget,
-                market_players=market_player_map,
-                squad_players=squad_player_map,
-                top_n=5,
-            )
-        else:
-            buy_recs = engine.recommend_buys(
-                market_scores=market_scores,
-                squad_scores=squad_scores,
-                roster_context=roster_context,
-                budget=current_budget,
-                market_players=market_player_map,
-                is_emergency=is_emergency,
-                top_n=8 if is_emergency else 5,
-                squad_players=squad_player_map,
-            )
-            trade_pairs = []
+        # Always compute both buy recs and trade pairs so the unified
+        # trade phase can rank them against each other regardless of squad size.
+        buy_recs = engine.recommend_buys(
+            market_scores=market_scores,
+            squad_scores=squad_scores,
+            roster_context=roster_context,
+            budget=current_budget,
+            market_players=market_player_map,
+            is_emergency=is_emergency,
+            top_n=8 if is_emergency else 10,
+            squad_players=squad_player_map,
+        )
+        trade_pairs = engine.build_trade_pairs(
+            market_scores=market_scores,
+            squad_scores=squad_scores,
+            roster_context=roster_context,
+            budget=current_budget,
+            market_players=market_player_map,
+            squad_players=squad_player_map,
+            top_n=10,
+        )
 
         sell_recs = engine.recommend_sells(
             squad_scores=squad_scores,


### PR DESCRIPTION
## Summary

- **Unified trade phase**: Trade pairs and plain buys compete in a single ranked list sorted by EP gain, replacing the old separate profit + lineup sessions that called the EP pipeline twice
- **Trend-aware selling**: Hold rising players to +15% profit, sell falling players at +5% (was flat +10% for all)
- **Matchday-aware aggressiveness**: Aggressive 5+ days out, moderate 2-4d, locked 0-1d (lineup only)
- **Fix permanent 40% overbid penalty**: Wire `trend_change_pct` to `calculate_ep_bid` (was always `None`)
- **Lower EP upgrade threshold**: 10 → 5 (compounds over 20+ remaining matchdays)
- **Raise trade caps**: 10/session default, 15 with `--aggressive` (was 5)
- **Always evaluate trade pairs**: Removed squad-size gate so pairs compete with buys at any squad size
- **Fix stale data bugs**: Refresh squad/bids before trade phase, fix timezone comparison in matchday detection

## Key design decisions

1. Single `EPSessionContext` built once per session (one API round-trip instead of three)
2. Trade pairs skipped when open slots exist (avoids losing 5% to unnecessary instant-sells)
3. `MatchdayPhase` dataclass gates what's allowed: flips only in aggressive phase
4. Old methods (`run_profit_trading_session`, `run_lineup_improvement_session`) preserved but no longer called from `run_full_session`

## Test plan

- [x] All 147 existing tests pass
- [x] Ruff + Black clean on all changed files
- [x] Bandit security check passes
- [ ] Manual dry-run: `rehoboam auto --dry-run`
- [ ] Manual dry-run aggressive: `rehoboam auto --dry-run --aggressive`
- [ ] Verify matchday phase detection with live API data

🤖 Generated with [Claude Code](https://claude.com/claude-code)