### PR TITLE
fix: 7 bugs in auto path — sell plans, stale data, slot drift, bid ceiling

### DIFF
--- a/rehoboam/auto_trader.py
+++ b/rehoboam/auto_trader.py
@@ -118,17 +118,23 @@ class AutoTrader:
                 allow_flips=False,
                 reason=f"Match in {days_until_match}d — lineup improvements only",
             )
-        else:
+        elif days_until_match is not None:
             return MatchdayPhase(
                 days_until_match=days_until_match,
                 phase="aggressive",
                 max_trades=self.max_trades_per_session,
                 allow_flips=True,
-                reason=(
-                    f"Match in {days_until_match}d — full trading"
-                    if days_until_match
-                    else "Unknown schedule — full trading"
-                ),
+                reason=f"Match in {days_until_match}d — full trading",
+            )
+        else:
+            # Unknown schedule — default to moderate (not aggressive) to avoid
+            # accidentally going into debt right before a matchday we can't see.
+            return MatchdayPhase(
+                days_until_match=None,
+                phase="moderate",
+                max_trades=max(self.max_trades_per_session // 2, 2),
+                allow_flips=False,
+                reason="Unknown schedule — moderate trading (no flips)",
             )
 
     def _build_session_context(self, league) -> EPSessionContext:
@@ -288,7 +294,21 @@ class AutoTrader:
                     )
                     continue
 
-                result = self.execution.buy(league, obj.player, obj.recommended_bid, obj.reason)
+                # If buy exceeds current budget but has a sell plan, persist
+                # the sell plan IDs alongside the bid. Once the auction resolves
+                # (we won), the sells will be executed to recover the budget.
+                # This is buy-first-sell-after: never sell before securing the player.
+                sp_ids = None
+                if hasattr(obj, "sell_plan") and obj.sell_plan and obj.sell_plan.players_to_sell:
+                    sp_ids = [e.player_id for e in obj.sell_plan.players_to_sell]
+
+                result = self.execution.buy(
+                    league,
+                    obj.player,
+                    obj.recommended_bid,
+                    obj.reason,
+                    sell_plan_player_ids=sp_ids,
+                )
                 results.append(result)
                 if result.success:
                     ctx.executed_trade_count += 1
@@ -341,14 +361,26 @@ class AutoTrader:
                 if buy_result.success:
                     ctx.executed_trade_count += 1
                     self.daily_spend += obj.recommended_bid
-                    ctx.flip_budget -= net_cost
+                    # Use the actual sell proceeds (from sell_result.price) rather
+                    # than the estimated market value, to avoid budget drift.
+                    actual_net_cost = obj.recommended_bid - sell_result.price
+                    ctx.flip_budget -= actual_net_cost
                     # Trade pair: slot freed by sell, consumed by buy = net zero
                 else:
                     console.print(
                         f"[bold red]⚠ WARNING: Sold {obj.sell_player.last_name} but failed to buy "
-                        f"{obj.buy_player.last_name} — squad is now {current_squad_size - 1}/15[/bold red]"
+                        f"{obj.buy_player.last_name}[/bold red]"
                     )
-                    available_slots += 1  # Sell freed a slot but buy failed
+                    # Sell freed a slot but buy failed — re-fetch actual state
+                    # to avoid the counter drifting from reality.
+                    try:
+                        fresh = self.api.get_squad(league)
+                        fresh_bids = self.api.get_my_bids(league)
+                        current_squad_size = len(fresh)
+                        active_bid_count = len(fresh_bids)
+                        available_slots = 15 - current_squad_size - active_bid_count
+                    except Exception:
+                        available_slots += 1  # Fallback: optimistic increment
 
         # Execute profit flips with remaining slots
         if profit_flip_candidates and available_slots > 0:
@@ -417,7 +449,9 @@ class AutoTrader:
         results = []
         console.print("\n[bold cyan]📈 Profit Sell Monitoring (trend-aware)[/bold cyan]")
 
-        squad = ctx.squad
+        # Refresh squad — earlier phases (auction resolution, deferred sells)
+        # may have changed the squad since ctx was built.
+        squad = self.api.get_squad(league)
         if not squad:
             console.print("[dim]No squad loaded[/dim]")
             return results
@@ -562,14 +596,32 @@ class AutoTrader:
         trade_results: list[AutoTradeResult] = []
         errors: list[str] = []
 
-        # Step 1: Reconcile any pending bids against current squad (won/lost)
+        # Step 1: Reconcile pending bids (won/lost) + execute deferred sell plans
         try:
             squad = self.api.get_squad(league)
             bids = self.api.get_my_bids(league)
-            self.tracker.resolve_auctions(
+            deferred_sell_ids = self.tracker.resolve_auctions(
                 squad_ids={p.id for p in squad},
                 active_bid_ids={p.id for p in bids},
             )
+            # Execute any deferred sell plans from bids we won (buy-first-sell-after).
+            if deferred_sell_ids:
+                console.print(
+                    f"[cyan]Executing deferred sell plan for {len(deferred_sell_ids)} player(s)[/cyan]"
+                )
+                for sell_id in deferred_sell_ids:
+                    sell_player = next((p for p in squad if p.id == sell_id), None)
+                    if sell_player:
+                        result = self.execution.instant_sell(
+                            league,
+                            sell_player,
+                            "Deferred sell plan — recovering budget after winning auction",
+                        )
+                        sell_results.append(result)
+                    else:
+                        console.print(
+                            f"[yellow]Deferred sell target {sell_id} not in squad (already sold?)[/yellow]"
+                        )
         except Exception as e:
             console.print(f"[yellow]Auction resolution failed: {e}[/yellow]")
 
@@ -622,19 +674,8 @@ class AutoTrader:
         # Step 5: Squad Optimization (budget/size safety)
         console.print("\n[bold cyan]🎯 Squad Optimization[/bold cyan]")
         try:
-            squad_optimization = self.optimize_and_execute_squad(league)
-            if squad_optimization and squad_optimization.players_to_sell:
-                for player in squad_optimization.players_to_sell:
-                    sell_results.append(
-                        AutoTradeResult(
-                            success=True,
-                            player_name=f"{player.first_name} {player.last_name}",
-                            action="SELL",
-                            price=player.market_value,
-                            reason="Squad optimization - excess player",
-                            timestamp=time.time(),
-                        )
-                    )
+            optimization_sells = self.optimize_and_execute_squad(league)
+            sell_results.extend(optimization_sells)
         except Exception as e:
             error_msg = f"Squad optimization error: {e!s}"
             console.print(f"[red]{error_msg}[/red]")
@@ -798,14 +839,16 @@ class AutoTrader:
             console.print(f"[red]{error_msg}[/red]")
             errors.append(error_msg)
 
-    def optimize_and_execute_squad(self, league):
+    def optimize_and_execute_squad(self, league) -> list[AutoTradeResult]:
         """Run squad optimization and execute any forced sales.
 
-        Uses avg_points directly as the ranking signal for who to drop —
-        simpler and tighter than the legacy PlayerValue+matchup pipeline.
+        Returns a list of AutoTradeResult for actual sells executed (not
+        hypothetical). An empty list means no sells were needed.
         """
         from .squad_optimizer import SquadOptimizer
         from .trader import Trader
+
+        results: list[AutoTradeResult] = []
 
         trader = Trader(
             self.api,
@@ -816,9 +859,8 @@ class AutoTrader:
         optimization = trader.optimize_squad_for_gameday(league)
 
         if not optimization:
-            return None
+            return results
 
-        # Use avg_points as the player_values dict for display purposes
         squad = self.api.get_squad(league)
         player_values = {p.id: float(p.average_points or 0) for p in squad}
 
@@ -830,13 +872,14 @@ class AutoTrader:
                 f"\n[yellow]⚠️  Budget negative, selling "
                 f"{len(optimization.players_to_sell)} player(s)...[/yellow]"
             )
-            results = optimizer.execute_sell_recommendations(
-                optimization, api=self.api, league=league, dry_run=self.dry_run
-            )
-            if results["sold"]:
-                total = sum(p.market_value for p in results["sold"])
-                console.print(
-                    f"[green]✓ Sold {len(results['sold'])} player(s) for €{total:,}[/green]"
+            # Execute via our ExecutionService so dry_run, tracking, and real
+            # success/failure results all flow through the same path.
+            for player in optimization.players_to_sell:
+                result = self.execution.instant_sell(
+                    league,
+                    player,
+                    "Squad optimization — forced sell to recover budget",
                 )
+                results.append(result)
 
-        return optimization
+        return results

--- a/rehoboam/learning/tracker.py
+++ b/rehoboam/learning/tracker.py
@@ -55,8 +55,18 @@ class LearningTracker:
     # Bid placed → pending
     # ------------------------------------------------------------------
 
-    def record_bid_placed(self, player, our_bid: int) -> None:
-        """Record a freshly-placed bid as pending (outcome TBD)."""
+    def record_bid_placed(
+        self,
+        player,
+        our_bid: int,
+        sell_plan_player_ids: list[str] | None = None,
+    ) -> None:
+        """Record a freshly-placed bid as pending (outcome TBD).
+
+        If the buy has a paired sell_plan (players to sell after winning to
+        recover budget), persist their IDs here so resolve_auctions can
+        execute the sells when we detect we won the auction.
+        """
         try:
             asking_price = player.price
             overbid_pct = ((our_bid - asking_price) / asking_price * 100) if asking_price > 0 else 0
@@ -70,6 +80,8 @@ class LearningTracker:
                 "timestamp": time.time(),
                 "market_value": getattr(player, "market_value", 0),
             }
+            if sell_plan_player_ids:
+                entry["sell_plan_player_ids"] = sell_plan_player_ids
 
             pending = _load_json(_PENDING_BIDS, [])
             pending.append(entry)
@@ -81,28 +93,41 @@ class LearningTracker:
     # Pending → resolved (won/lost)
     # ------------------------------------------------------------------
 
-    def resolve_auctions(self, squad_ids: set[str], active_bid_ids: set[str]) -> None:
+    def resolve_auctions(
+        self,
+        squad_ids: set[str],
+        active_bid_ids: set[str],
+    ) -> list[str]:
         """Reconcile pending bids against current squad + bids.
 
-        - If a pending bid's player is now in the squad → we won
-        - If a pending bid's player is not in squad AND not in active bids → we lost
+        Returns a list of player IDs that need to be sold (from sell plans
+        attached to bids we won). The caller is responsible for executing
+        those sells — this method only records outcomes and returns the IDs.
+
+        - If a pending bid's player is now in the squad → we won.
+          If the bid had sell_plan_player_ids, they're returned.
+        - If a pending bid's player is not in squad AND not in active bids → lost
         - Otherwise → still pending (keep for next check)
         """
+        sell_plan_ids: list[str] = []
         try:
             pending = _load_json(_PENDING_BIDS, [])
             if not pending:
-                return
+                return sell_plan_ids
 
             still_pending = []
             for bid_data in pending:
                 player_id = bid_data["player_id"]
 
                 if player_id in squad_ids:
-                    # Won — record the outcome AND track the purchase for flip calc
                     self._record_outcome(bid_data, won=True)
                     self._track_purchase(player_id, bid_data)
+                    # Collect sell plan IDs from bids we won — caller will
+                    # execute the sells to recover budget.
+                    for sp_id in bid_data.get("sell_plan_player_ids", []):
+                        if sp_id not in sell_plan_ids:
+                            sell_plan_ids.append(sp_id)
                 elif player_id not in active_bid_ids:
-                    # Lost — record the outcome and drop
                     self._record_outcome(bid_data, won=False)
                 else:
                     still_pending.append(bid_data)
@@ -110,6 +135,7 @@ class LearningTracker:
             _save_json(_PENDING_BIDS, still_pending)
         except Exception:
             pass
+        return sell_plan_ids
 
     def _record_outcome(self, bid_data: dict, won: bool) -> None:
         try:

--- a/rehoboam/services/execution.py
+++ b/rehoboam/services/execution.py
@@ -57,8 +57,22 @@ class ExecutionService:
     # Public actions
     # ------------------------------------------------------------------
 
-    def buy(self, league, player, price: int, reason: str) -> AutoTradeResult:
-        """Place a buy offer at the given price."""
+    def buy(
+        self,
+        league,
+        player,
+        price: int,
+        reason: str,
+        sell_plan_player_ids: list[str] | None = None,
+    ) -> AutoTradeResult:
+        """Place a buy offer at the given price.
+
+        If the buy has a paired sell_plan (bench players to sell after winning
+        the auction to recover budget), pass their IDs here. They'll be
+        persisted alongside the pending bid and executed when resolve_auctions
+        detects we won. This ensures buy-first-sell-after semantics: we never
+        sell the old player before securing the new one.
+        """
         return self._do(
             action="BUY",
             player=player,
@@ -67,7 +81,9 @@ class ExecutionService:
             announce=f"Buying {player.first_name} {player.last_name} for €{price:,}",
             success_msg=f"Buy order placed for {player.first_name} {player.last_name}",
             api_call=lambda: self.api.buy_player(league, player, price),
-            on_success=lambda: self.tracker.record_bid_placed(player, price),
+            on_success=lambda: self.tracker.record_bid_placed(
+                player, price, sell_plan_player_ids=sell_plan_player_ids
+            ),
         )
 
     def instant_sell(self, league, player, reason: str) -> AutoTradeResult:

--- a/rehoboam/trader.py
+++ b/rehoboam/trader.py
@@ -293,6 +293,22 @@ class Trader:
 
         for pair in trade_pairs:
             try:
+                # Trade pairs get a synthetic sell plan so calculate_ep_bid
+                # factors in the sell recovery when computing budget_ceiling.
+                # Without this, budget_ceiling = current_budget + 0 which
+                # caps the bid below asking price → recommended_bid=0 and
+                # perfectly affordable trade pairs get silently dropped.
+                from .scoring.models import SellPlan
+
+                sell_recovery = int(pair.sell_player.market_value * 0.95)
+                synthetic_sell_plan = SellPlan(
+                    players_to_sell=[],
+                    total_recovery=sell_recovery,
+                    net_budget_after=int(current_budget) + sell_recovery - pair.buy_player.price,
+                    is_viable=True,
+                    ep_impact=0.0,
+                    reasoning="Trade pair sell recovery",
+                )
                 bid_rec = self.bidding.calculate_ep_bid(
                     asking_price=pair.buy_player.price,
                     market_value=pair.buy_player.market_value,
@@ -300,6 +316,7 @@ class Trader:
                     marginal_ep_gain=pair.ep_gain,
                     confidence=0.7,
                     current_budget=int(current_budget),
+                    sell_plan=synthetic_sell_plan,
                     player_id=pair.buy_player.id,
                 )
                 pair.recommended_bid = bid_rec.recommended_bid
@@ -372,6 +389,17 @@ class Trader:
                 pair.metadata = pair.metadata or {}
                 pair.metadata["trend_7d_pct"] = trend.trend_7d_pct
 
+                from .scoring.models import SellPlan
+
+                sell_recovery = int(pair.sell_player.market_value * 0.95)
+                synthetic_sell_plan = SellPlan(
+                    players_to_sell=[],
+                    total_recovery=sell_recovery,
+                    net_budget_after=current_budget + sell_recovery - pair.buy_player.price,
+                    is_viable=True,
+                    ep_impact=0.0,
+                    reasoning="Trade pair sell recovery",
+                )
                 bid_rec = self.bidding.calculate_ep_bid(
                     asking_price=pair.buy_player.price,
                     market_value=pair.buy_player.market_value,
@@ -379,6 +407,7 @@ class Trader:
                     marginal_ep_gain=pair.ep_gain,
                     confidence=0.7,
                     current_budget=current_budget,
+                    sell_plan=synthetic_sell_plan,
                     player_id=pair.buy_player.id,
                     trend_change_pct=trend.trend_7d_pct,
                 )


### PR DESCRIPTION
## Summary

7 concrete bugs found during post-refactor evaluation, all in the auto trading path. Each one can cost real matchday points or money.

### Critical fixes

1. **Sell plans never executed** — Buy recs with over-budget sell plans had their bids placed but the paired sells were never run. Budget goes negative → 0 pts for the matchday. Now persists sell_plan_player_ids alongside pending bids. When resolve_auctions detects we won the auction, it returns the IDs and the caller executes the deferred sells. **Buy-first-sell-after**: never sell the old player before securing the new one.

2. **Squad optimization reports fake success** — Reported `success=True` for every player regardless of whether the API sell call worked. Budget math was corrupted for subsequent phases. Now routes through `ExecutionService` for real results.

3. **Trade pair bids silently drop to 0** — `calculate_ep_bid` for trade pairs had `budget_ceiling = current_budget + 0` (no sell plan). If budget < asking price, bid caps to 0 → pair skipped. Now passes a synthetic `SellPlan` with `total_recovery = sell_player MV × 0.95`.

### Important fixes

4. **Stale squad in sell phase** — Used `ctx.squad` from session start. Earlier phases (auction resolution, deferred sells) can change the squad. Now fetches fresh.

5. **Slot counter drift** — After a failed trade pair buy, the local `available_slots` was incremented without re-fetching from API. Two consecutive failures would drift the counter. Now re-fetches squad + bids.

6. **Unknown matchday → aggressive (should be moderate)** — When `get_days_until_match` returns None (API failure), defaulted to aggressive with full trading + flips. Could go into debt right before a matchday. Now defaults to moderate (no flips, halved cap).

7. **Net cost drift** — Trade pair budget update used estimated market value, not actual sell price. Now uses `sell_result.price`.

## Test plan

- [x] 121/121 tests pass
- [x] Ruff + Black clean
- [ ] Manual dry-run: `rehoboam status`
- [ ] Observe next scheduled Azure run for correct behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)