### PR TITLE
feat: competitor-aware EP bidding

### DIFF
--- a/rehoboam/activity_feed_learner.py
+++ b/rehoboam/activity_feed_learner.py
@@ -421,6 +421,20 @@ class ActivityFeedLearner:
                 "aggression_level": aggression,
             }
 
+    def has_aggressive_competitors(self, threat_score_threshold: float = 100.0) -> bool:
+        """Return True if the league has at least one high-threat competitor.
+
+        Threat score combines purchase frequency and average spend — a manager
+        with ``threat_score > 100`` is actively buying and paying premium prices.
+        Used by bidding logic to tighten the skip criteria on contested
+        mid-tier auctions (we won't outbid a whale for a solid-but-not-essential
+        upgrade).
+        """
+        for competitor in self.get_top_competitors(limit=5):
+            if competitor.get("threat_score", 0) > threat_score_threshold:
+                return True
+        return False
+
     def get_top_competitors(self, limit: int = 5) -> list[dict[str, Any]]:
         """
         Get the most active/aggressive competitors

--- a/rehoboam/bidding_strategy.py
+++ b/rehoboam/bidding_strategy.py
@@ -16,6 +16,68 @@ except ImportError:
     ActivityFeedLearner = None
 
 
+# ---------------------------------------------------------------------------
+# Competitor-aware bidding helpers
+# ---------------------------------------------------------------------------
+
+
+def _contested_skip_reason(
+    ep_tier: str,
+    offer_count: int,
+    has_aggressive_competitors: bool,
+) -> str | None:
+    """Return a skip reason if the auction isn't worth joining, else None.
+
+    The league is won by matchday points, not by hoarding players. Paying a
+    premium in a contested auction for a marginal upgrade just inflates the
+    price for a rival without improving our chances of winning — this function
+    encodes that restraint.
+
+    Skip rules:
+    - Marginal tier + 2+ offers → skip. Never burn budget on a bidding war
+      for a player who barely moves our EP.
+    - Solid/strong upgrades + 4+ offers + aggressive whales in league → skip.
+      Our normal bid won't beat an aggressive competitor willing to overpay,
+      and the EP gain doesn't justify matching their premium.
+
+    *must_have* tier is never skipped — we need the player regardless.
+    """
+    if ep_tier == "marginal" and offer_count >= 2:
+        return f"Marginal EP + {offer_count} offers — skipping contested auction"
+
+    if has_aggressive_competitors and offer_count >= 4:
+        if ep_tier in ("solid_upgrade", "strong_upgrade"):
+            return (
+                f"{ep_tier} EP + {offer_count} offers + aggressive league — "
+                "won't outbid a whale for a non-essential upgrade"
+            )
+
+    return None
+
+
+def _contested_overbid_bump(ep_tier: str, offer_count: int) -> float:
+    """Extra overbid percentage to apply when we're contested but committing.
+
+    Pulls ahead of rival bids for players we actually want. Scaling by tier:
+    must_have defends hardest (bigger bump), marginal gets nothing (skipped
+    upstream anyway). A lone extra bidder barely moves the needle.
+    """
+    if offer_count <= 1:
+        return 0.0
+
+    # 2-3 offers: moderate pressure; 4+: heavy pressure
+    heavy = offer_count >= 4
+
+    if ep_tier == "must_have":
+        return 6.0 if heavy else 3.0
+    if ep_tier == "strong_upgrade":
+        return 3.0 if heavy else 2.0
+    if ep_tier == "solid_upgrade":
+        return 2.0 if heavy else 1.0
+    # marginal tier reached here only if skip logic didn't fire (shouldn't happen)
+    return 0.0
+
+
 @dataclass
 class BidRecommendation:
     """Recommended bid for a player"""
@@ -270,6 +332,8 @@ class SmartBidding:
         sell_plan: SellPlan | None = None,
         player_id: str | None = None,
         trend_change_pct: float | None = None,
+        offer_count: int = 0,
+        has_aggressive_competitors: bool = False,
     ) -> BidRecommendation:
         """
         Calculate optimal bid driven by expected points (EP) gain rather than market value.
@@ -284,6 +348,13 @@ class SmartBidding:
             sell_plan: Optional plan to sell players to raise funds
             player_id: For activity feed demand lookup
             trend_change_pct: Market value trend (negative = falling)
+            offer_count: Number of other managers currently bidding on the player.
+                Controls competitor-aware bidding: contested marginal buys are
+                skipped (don't inflate rival auctions), must-haves are defended
+                harder.
+            has_aggressive_competitors: True when the league has known high-threat
+                buyers (from ActivityFeedLearner). Tightens the skip criteria for
+                mid-tier contested auctions.
 
         Returns:
             BidRecommendation — recommended_bid=0 if no improvement warranted
@@ -314,6 +385,26 @@ class SmartBidding:
         else:
             ep_tier = "marginal"
             tier_bonus = 0.0
+
+        # Competitor-aware skip: don't feed contested auctions for players that
+        # wouldn't meaningfully change our matchday output. We'd just inflate
+        # the price for a rival without improving our chances of winning the league.
+        contested_skip_reason = _contested_skip_reason(
+            ep_tier=ep_tier,
+            offer_count=offer_count,
+            has_aggressive_competitors=has_aggressive_competitors,
+        )
+        if contested_skip_reason is not None:
+            return BidRecommendation(
+                base_price=asking_price,
+                recommended_bid=0,
+                overbid_amount=0,
+                overbid_pct=0.0,
+                reasoning=contested_skip_reason,
+                budget_ceiling=current_budget,
+                sell_plan=sell_plan,
+                marginal_ep_gain=marginal_ep_gain,
+            )
 
         # Budget ceiling = current budget + any sell plan recovery
         budget_ceiling = current_budget + (sell_plan.total_recovery if sell_plan else 0)
@@ -372,6 +463,12 @@ class SmartBidding:
         else:
             overbid_pct *= 0.6  # Unknown trend: conservative
 
+        # Offer-count bump: when we're contested and the player is worth
+        # winning, bid harder to pull ahead of rival offers. Applied AFTER
+        # trend scaling so the "fight for this player" signal isn't dampened
+        # by a falling market value — contestedness doesn't care about trend.
+        overbid_pct += _contested_overbid_bump(ep_tier=ep_tier, offer_count=offer_count)
+
         # Cap overbid (must_have tier gets elite cap)
         max_overbid = self.elite_max_overbid_pct if ep_tier == "must_have" else self.max_overbid_pct
         overbid_pct = min(overbid_pct, max_overbid)
@@ -421,6 +518,8 @@ class SmartBidding:
             f"EP tier: {ep_tier} (+{marginal_ep_gain:.1f} pts)",
             f"overbid {actual_overbid_pct:.1f}%",
         ]
+        if offer_count >= 2:
+            reasoning_parts.append(f"contested ({offer_count} offers)")
         if sell_plan:
             reasoning_parts.append(f"sell plan: +€{sell_plan.total_recovery:,} recovery")
         reasoning = " | ".join(reasoning_parts)

--- a/rehoboam/trader.py
+++ b/rehoboam/trader.py
@@ -45,6 +45,7 @@ class Trader:
         self.settings = settings
         self.verbose = verbose
         self.bid_learner = bid_learner
+        self.activity_feed_learner = activity_feed_learner
         self.history_cache = ValueHistoryCache()
         self.trend_service = TrendService(self.api.client, self.history_cache)
         self.matchup_analyzer = MatchupAnalyzer()
@@ -356,6 +357,15 @@ class Trader:
         result = self.get_ep_recommendations(league)
         current_budget = int(result.get("budget", 0))
 
+        # League-level competitor context: checked once per session so all bids
+        # in this run share the same "is the league aggressive today?" signal.
+        has_whales = False
+        if self.activity_feed_learner is not None:
+            try:
+                has_whales = self.activity_feed_learner.has_aggressive_competitors()
+            except Exception:
+                has_whales = False
+
         for rec in result.get("buy_recs", []):
             try:
                 trend = self.trend_service.get_trend(
@@ -365,17 +375,24 @@ class Trader:
                 rec.metadata["trend_7d_pct"] = trend.trend_7d_pct
                 rec.metadata["trend_14d_pct"] = trend.trend_14d_pct
                 rec.metadata["momentum"] = trend.momentum
+                rec.metadata["offer_count"] = rec.player.offer_count
 
+                # Floor confidence at 0.7 to match the non-trend path so a
+                # player with few recorded games doesn't produce a *lower*
+                # bid here than in the plain EP pipeline. Data-quality gaps
+                # already penalize the EP score upstream (grade F halving).
                 bid_rec = self.bidding.calculate_ep_bid(
                     asking_price=rec.player.price,
                     market_value=rec.player.market_value,
                     expected_points=rec.score.expected_points,
                     marginal_ep_gain=rec.marginal_ep_gain,
-                    confidence=min(1.0, rec.score.data_quality.games_played / 10.0),
+                    confidence=max(0.7, min(1.0, rec.score.data_quality.games_played / 10.0)),
                     current_budget=current_budget,
                     sell_plan=rec.sell_plan,
                     player_id=rec.player.id,
                     trend_change_pct=trend.trend_7d_pct,
+                    offer_count=rec.player.offer_count,
+                    has_aggressive_competitors=has_whales,
                 )
                 rec.recommended_bid = bid_rec.recommended_bid
             except Exception:
@@ -388,6 +405,7 @@ class Trader:
                 )
                 pair.metadata = pair.metadata or {}
                 pair.metadata["trend_7d_pct"] = trend.trend_7d_pct
+                pair.metadata["offer_count"] = pair.buy_player.offer_count
 
                 from .scoring.models import SellPlan
 
@@ -410,6 +428,8 @@ class Trader:
                     sell_plan=synthetic_sell_plan,
                     player_id=pair.buy_player.id,
                     trend_change_pct=trend.trend_7d_pct,
+                    offer_count=pair.buy_player.offer_count,
+                    has_aggressive_competitors=has_whales,
                 )
                 pair.recommended_bid = bid_rec.recommended_bid
             except Exception:

--- a/tests/test_ep_bidding.py
+++ b/tests/test_ep_bidding.py
@@ -233,3 +233,172 @@ class TestBidRecommendationBackwardCompat:
         max_bid = result.max_profitable_bid
         assert isinstance(max_bid, int)
         assert max_bid > 0
+
+
+class TestCompetitorAwareBidding:
+    """Tests for offer_count and has_aggressive_competitors bid modulation."""
+
+    def _must_have_bid(self, bidding: SmartBidding, **overrides):
+        """Shared setup for a must-have tier bid with knobs for competitor args."""
+        kwargs = {
+            "asking_price": 10_000_000,
+            "market_value": 10_000_000,
+            "expected_points": 80.0,
+            "marginal_ep_gain": 25.0,
+            "confidence": 0.8,
+            "current_budget": 30_000_000,
+            "sell_plan": None,
+            "trend_change_pct": 0.0,  # neutral trend, no scaling
+        }
+        kwargs.update(overrides)
+        return bidding.calculate_ep_bid(**kwargs)
+
+    def _marginal_bid(self, bidding: SmartBidding, **overrides):
+        """Shared setup for a marginal tier bid."""
+        kwargs = {
+            "asking_price": 5_000_000,
+            "market_value": 5_000_000,
+            "expected_points": 30.0,
+            "marginal_ep_gain": 3.0,
+            "confidence": 0.6,
+            "current_budget": 15_000_000,
+            "sell_plan": None,
+            "trend_change_pct": 0.0,
+        }
+        kwargs.update(overrides)
+        return bidding.calculate_ep_bid(**kwargs)
+
+    def test_no_competition_no_change(self):
+        """offer_count=0 should produce the same bid as baseline."""
+        bidding = SmartBidding()
+        baseline = self._must_have_bid(bidding, offer_count=0)
+        assert baseline.recommended_bid > 0
+
+    def test_contested_must_have_bids_higher(self):
+        """Heavily contested must-have → higher bid than uncontested."""
+        bidding = SmartBidding()
+        uncontested = self._must_have_bid(bidding, offer_count=0)
+        contested = self._must_have_bid(bidding, offer_count=4)
+        assert contested.recommended_bid > uncontested.recommended_bid
+        assert "contested" in contested.reasoning
+
+    def test_marginal_contested_skips(self):
+        """Marginal EP + 2+ offers → don't feed the auction, skip."""
+        bidding = SmartBidding()
+        result = self._marginal_bid(bidding, offer_count=2)
+        assert result.recommended_bid == 0
+        assert "Marginal" in result.reasoning
+        assert "skipping" in result.reasoning.lower()
+
+    def test_marginal_uncontested_still_bids(self):
+        """Marginal EP + 0 offers → still bid (nothing to avoid)."""
+        bidding = SmartBidding()
+        result = self._marginal_bid(bidding, offer_count=0)
+        assert result.recommended_bid > 0
+
+    def test_solid_upgrade_skipped_when_whales_and_heavy_contest(self):
+        """Solid upgrade + 4+ offers + aggressive league → don't outbid whales."""
+        bidding = SmartBidding()
+        result = bidding.calculate_ep_bid(
+            asking_price=8_000_000,
+            market_value=8_000_000,
+            expected_points=45.0,
+            marginal_ep_gain=7.0,  # solid_upgrade tier
+            confidence=0.7,
+            current_budget=20_000_000,
+            sell_plan=None,
+            trend_change_pct=0.0,
+            offer_count=5,
+            has_aggressive_competitors=True,
+        )
+        assert result.recommended_bid == 0
+        assert "whale" in result.reasoning.lower()
+
+    def test_solid_upgrade_bids_when_no_whales(self):
+        """Same solid upgrade + offers but no whales → still bids."""
+        bidding = SmartBidding()
+        result = bidding.calculate_ep_bid(
+            asking_price=8_000_000,
+            market_value=8_000_000,
+            expected_points=45.0,
+            marginal_ep_gain=7.0,
+            confidence=0.7,
+            current_budget=20_000_000,
+            sell_plan=None,
+            trend_change_pct=0.0,
+            offer_count=5,
+            has_aggressive_competitors=False,
+        )
+        assert result.recommended_bid > 0
+
+    def test_must_have_never_skipped_even_with_whales(self):
+        """must_have tier is always worth fighting for, regardless of competition."""
+        bidding = SmartBidding()
+        result = self._must_have_bid(
+            bidding,
+            offer_count=6,
+            has_aggressive_competitors=True,
+        )
+        assert result.recommended_bid > 0
+
+    def test_contested_bump_survives_falling_trend(self):
+        """Regression: contested bump must apply AFTER trend scaling.
+
+        A must_have player with a sharply falling trend (-15%) still needs
+        aggressive bidding when contested — the "fight this auction" signal
+        shouldn't be dampened by a value dip.
+        """
+        bidding = SmartBidding()
+        falling_uncontested = self._must_have_bid(bidding, offer_count=0, trend_change_pct=-15.0)
+        falling_contested = self._must_have_bid(bidding, offer_count=4, trend_change_pct=-15.0)
+        # Gap between contested/uncontested should be the full +6% heavy bump,
+        # not a trend-dampened fraction of it.
+        assert falling_contested.overbid_pct - falling_uncontested.overbid_pct >= 4.0, (
+            f"Contested bump was dampened by trend scaling "
+            f"(gap: {falling_contested.overbid_pct - falling_uncontested.overbid_pct:.1f}%)"
+        )
+
+
+class TestAggressiveCompetitorsHelper:
+    """Tests for ActivityFeedLearner.has_aggressive_competitors()."""
+
+    def test_no_data_returns_false(self, tmp_path):
+        from rehoboam.activity_feed_learner import ActivityFeedLearner
+
+        learner = ActivityFeedLearner(db_path=tmp_path / "test.db")
+        assert learner.has_aggressive_competitors() is False
+
+    def test_high_threat_detected(self, tmp_path):
+        """A manager with many purchases + high avg price → threat_score > 100."""
+        import sqlite3
+        import time
+
+        from rehoboam.activity_feed_learner import ActivityFeedLearner
+
+        db_path = tmp_path / "test.db"
+        learner = ActivityFeedLearner(db_path=db_path)
+
+        # Manually seed league_transfers with a "whale" manager
+        with sqlite3.connect(db_path) as conn:
+            for i in range(10):
+                conn.execute(
+                    """
+                    INSERT INTO league_transfers (
+                        activity_id, player_id, player_name, buyer_name,
+                        transfer_price, transfer_type, timestamp, processed_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        f"act_{i}",
+                        f"p{i}",
+                        f"Player {i}",
+                        "Whale",
+                        15_000_000,
+                        1,
+                        "2026-04-01T10:00:00Z",
+                        time.time(),
+                    ),
+                )
+            conn.commit()
+
+        assert learner.has_aggressive_competitors() is True


### PR DESCRIPTION
## Summary

Teaches the EP bidding pipeline to factor in live auction competition (\`offer_count\`) and league-level competitor aggression. The core insight: we win the league with matchday points, not by hoarding players — so burning budget in contested marginal auctions just inflates rival prices without helping us.

## Skip rules

| Scenario | Action |
|---|---|
| Marginal EP (<5 gain) + 2+ offers | **skip** — don't feed bidding wars |
| Solid/strong upgrade + 4+ offers + aggressive league | **skip** — won't outbid whales for non-essential upgrades |
| \`must_have\` (≥20 EP gain) + any competition | never skipped — we need the player |

## Overbid bumps (for auctions we DO enter)

Applied after trend scaling so contested auctions with falling market values still get the full \"fight this player\" signal.

| Tier | 2-3 offers | 4+ offers |
|---|---|---|
| must_have | +3% | +6% |
| strong_upgrade | +2% | +3% |
| solid_upgrade | +1% | +2% |

## Also fixed

- Floored confidence at 0.7 in \`get_ep_recommendations_with_trends\` so data-sparse new players don't produce a *lower* bid than the plain \`get_ep_recommendations\` path.

## Test plan

- [x] \`pytest\`: 143 passed, 1 skipped (10 new tests)
- [x] \`ruff check\`: clean
- [x] Regression test: contested bump survives trend scaling
- [x] Code review identified 2 real bugs (bump order, confidence inconsistency) — both fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)