### PR TITLE
feat: lineup EP pipeline + tough-run sell + DGW-aware bid

### DIFF
--- a/rehoboam/auto_trader.py
+++ b/rehoboam/auto_trader.py
@@ -651,7 +651,7 @@ class AutoTrader:
                 f"[yellow]Match imminent ({ctx.matchday_phase.days_until_match}d) "
                 f"— setting lineup only, no trading[/yellow]"
             )
-            self._set_optimal_lineup(league, errors)
+            self._set_optimal_lineup(league, errors, squad_scores=ctx.ep_result.get("squad_scores"))
             return AutoTradeSession(
                 start_time=start_time,
                 end_time=time.time(),
@@ -736,8 +736,10 @@ class AutoTrader:
             console.print(f"[red]{error_msg}[/red]")
             errors.append(error_msg)
 
-        # Step 8: Set optimal lineup
-        self._set_optimal_lineup(league, errors)
+        # Step 8: Set optimal lineup using EP pipeline scores from the session.
+        # Players acquired mid-session (if any) fall back to the legacy
+        # calculator inside _set_optimal_lineup.
+        self._set_optimal_lineup(league, errors, squad_scores=ctx.ep_result.get("squad_scores"))
 
         # Calculate totals
         all_results = sell_results + trade_results
@@ -780,11 +782,21 @@ class AutoTrader:
             net_change=net_change,
         )
 
-    def _set_optimal_lineup(self, league, errors: list[str]):
-        """Calculate and set the optimal starting 11 via API"""
-        from .expected_points import calculate_expected_points
+    def _set_optimal_lineup(
+        self,
+        league,
+        errors: list[str],
+        squad_scores: list | None = None,
+    ):
+        """Calculate and set the optimal starting 11 via API.
+
+        Prefers the new EP scoring pipeline (via *squad_scores* when the caller
+        already computed them) so the lineup benefits from DGW multipliers,
+        injury penalties, 5-fixture SOS, and position-weighted scoring. Falls
+        back to the legacy calculator per-player only when scores are missing
+        (e.g. EP pipeline failed, or a player was just bought mid-session).
+        """
         from .formation import get_formation_string, order_for_lineup, select_best_eleven
-        from .value_history import ValueHistoryCache
 
         console.print("\n[bold cyan]📋 Setting Optimal Lineup[/bold cyan]")
 
@@ -794,26 +806,17 @@ class AutoTrader:
                 console.print("[yellow]Not enough players to set lineup[/yellow]")
                 return
 
-            history_cache = ValueHistoryCache()
+            # Build ep_scores from the new pipeline when available; fall back
+            # to the legacy per-player calculator only for uncovered squad
+            # members or when the caller didn't provide scores.
+            ep_scores: dict[str, float] = {}
+            if squad_scores:
+                ep_scores = {s.player_id: s.expected_points for s in squad_scores}
 
-            # Calculate expected points for each player
-            ep_scores = {}
-            for player in squad:
-                try:
-                    perf_data = history_cache.get_cached_performance(
-                        player_id=player.id, league_id=league.id, max_age_hours=24
-                    )
-                    if not perf_data:
-                        perf_data = self.api.client.get_player_performance(league.id, player.id)
-                        if perf_data:
-                            history_cache.cache_performance(
-                                player_id=player.id, league_id=league.id, data=perf_data
-                            )
-
-                    ep = calculate_expected_points(player=player, performance_data=perf_data)
-                    ep_scores[player.id] = ep.expected_points
-                except Exception:
-                    ep_scores[player.id] = 0
+            missing = [p for p in squad if p.id not in ep_scores]
+            if missing:
+                for player in missing:
+                    ep_scores[player.id] = self._legacy_expected_points(league, player)
 
             # Select best 11, order by position for API (GK→DEF→MID→FWD)
             best_eleven = select_best_eleven(squad, ep_scores)
@@ -838,6 +841,32 @@ class AutoTrader:
             error_msg = f"Set lineup error: {e!s}"
             console.print(f"[red]{error_msg}[/red]")
             errors.append(error_msg)
+
+    def _legacy_expected_points(self, league, player) -> float:
+        """Fallback per-player EP using the legacy calculator.
+
+        Only used when the new EP pipeline didn't score this player — e.g. a
+        mid-session purchase, or the pipeline failed upstream. Kept narrow so
+        the legacy path doesn't drift back into the main lineup flow.
+        """
+        from .expected_points import calculate_expected_points
+        from .value_history import ValueHistoryCache
+
+        try:
+            history_cache = ValueHistoryCache()
+            perf_data = history_cache.get_cached_performance(
+                player_id=player.id, league_id=league.id, max_age_hours=24
+            )
+            if not perf_data:
+                perf_data = self.api.client.get_player_performance(league.id, player.id)
+                if perf_data:
+                    history_cache.cache_performance(
+                        player_id=player.id, league_id=league.id, data=perf_data
+                    )
+            ep = calculate_expected_points(player=player, performance_data=perf_data)
+            return ep.expected_points
+        except Exception:
+            return 0.0
 
     def optimize_and_execute_squad(self, league) -> list[AutoTradeResult]:
         """Run squad optimization and execute any forced sales.

--- a/rehoboam/bidding_strategy.py
+++ b/rehoboam/bidding_strategy.py
@@ -334,6 +334,7 @@ class SmartBidding:
         trend_change_pct: float | None = None,
         offer_count: int = 0,
         has_aggressive_competitors: bool = False,
+        is_dgw: bool = False,
     ) -> BidRecommendation:
         """
         Calculate optimal bid driven by expected points (EP) gain rather than market value.
@@ -355,10 +356,18 @@ class SmartBidding:
             has_aggressive_competitors: True when the league has known high-threat
                 buyers (from ActivityFeedLearner). Tightens the skip criteria for
                 mid-tier contested auctions.
+            is_dgw: True when the player has a double gameweek (2 matches in one
+                matchday). Averaging across two matches reduces outcome variance,
+                so we have higher confidence in the EP prediction — the bid
+                confidence is floored at 0.9 to reflect that certainty.
 
         Returns:
             BidRecommendation — recommended_bid=0 if no improvement warranted
         """
+        # DGW players have less variance (2 matches = averaged outcome), so
+        # we're more confident in the EP estimate regardless of data quality.
+        if is_dgw:
+            confidence = max(confidence, 0.9)
         # No improvement → no bid
         if marginal_ep_gain == 0:
             return BidRecommendation(
@@ -518,6 +527,8 @@ class SmartBidding:
             f"EP tier: {ep_tier} (+{marginal_ep_gain:.1f} pts)",
             f"overbid {actual_overbid_pct:.1f}%",
         ]
+        if is_dgw:
+            reasoning_parts.append("DGW")
         if offer_count >= 2:
             reasoning_parts.append(f"contested ({offer_count} offers)")
         if sell_plan:

--- a/rehoboam/scoring/decision.py
+++ b/rehoboam/scoring/decision.py
@@ -546,7 +546,15 @@ class DecisionEngine:
             in_best_11 = player.id in best_11_ids
 
             bench_bonus = 0.0 if in_best_11 else 20.0
-            expendability = 100.0 - ep + bench_bonus
+
+            # Tough-run penalty: if the player's next fixtures are brutal, sell
+            # now before the value drops. fixture_bonus is already baked into
+            # `ep`, so we apply only HALF the negative component here to tilt
+            # the sort order without double-counting the signal.
+            fixture_bonus = ps.fixture_bonus if ps else 0.0
+            tough_run_penalty = max(0.0, -fixture_bonus) * 0.5
+
+            expendability = 100.0 - ep + bench_bonus + tough_run_penalty
 
             minimum = POSITION_MINIMUMS.get(player.position, 0)
             is_protected = position_counts.get(player.position, 0) <= minimum
@@ -561,6 +569,8 @@ class DecisionEngine:
             if not in_best_11:
                 reason_parts.append("bench player")
             reason_parts.append(f"EP={ep:.1f}")
+            if tough_run_penalty > 0:
+                reason_parts.append(f"tough run ahead ({fixture_bonus:+.0f} fixture bonus)")
             if is_protected:
                 reason_parts.append("position minimum")
             reason = "; ".join(reason_parts)

--- a/rehoboam/trader.py
+++ b/rehoboam/trader.py
@@ -287,6 +287,7 @@ class Trader:
                     current_budget=int(current_budget),
                     sell_plan=rec.sell_plan,
                     player_id=rec.player.id,
+                    is_dgw=rec.score.is_dgw,
                 )
                 rec.recommended_bid = bid_rec.recommended_bid
             except Exception:
@@ -319,6 +320,7 @@ class Trader:
                     current_budget=int(current_budget),
                     sell_plan=synthetic_sell_plan,
                     player_id=pair.buy_player.id,
+                    is_dgw=pair.buy_score.is_dgw,
                 )
                 pair.recommended_bid = bid_rec.recommended_bid
             except Exception:
@@ -393,6 +395,7 @@ class Trader:
                     trend_change_pct=trend.trend_7d_pct,
                     offer_count=rec.player.offer_count,
                     has_aggressive_competitors=has_whales,
+                    is_dgw=rec.score.is_dgw,
                 )
                 rec.recommended_bid = bid_rec.recommended_bid
             except Exception:
@@ -430,6 +433,7 @@ class Trader:
                     trend_change_pct=trend.trend_7d_pct,
                     offer_count=pair.buy_player.offer_count,
                     has_aggressive_competitors=has_whales,
+                    is_dgw=pair.buy_score.is_dgw,
                 )
                 pair.recommended_bid = bid_rec.recommended_bid
             except Exception:

--- a/tests/test_ep_bidding.py
+++ b/tests/test_ep_bidding.py
@@ -359,6 +359,53 @@ class TestCompetitorAwareBidding:
         )
 
 
+class TestDGWBidding:
+    """Tests for is_dgw flag in calculate_ep_bid()."""
+
+    def test_dgw_floors_confidence(self):
+        """DGW player bid should reflect higher confidence even when the
+        caller passes a low confidence (e.g. from small games_played sample).
+        """
+        bidding = SmartBidding()
+        non_dgw = bidding.calculate_ep_bid(
+            asking_price=10_000_000,
+            market_value=10_000_000,
+            expected_points=80.0,
+            marginal_ep_gain=25.0,
+            confidence=0.5,
+            current_budget=30_000_000,
+            trend_change_pct=0.0,
+            is_dgw=False,
+        )
+        # Same inputs but DGW: confidence gets floored at 0.9, triggering the
+        # +5% confidence bonus branch → higher overbid.
+        dgw = bidding.calculate_ep_bid(
+            asking_price=10_000_000,
+            market_value=10_000_000,
+            expected_points=80.0,
+            marginal_ep_gain=25.0,
+            confidence=0.5,
+            current_budget=30_000_000,
+            trend_change_pct=0.0,
+            is_dgw=True,
+        )
+        assert dgw.overbid_pct > non_dgw.overbid_pct
+        assert "DGW" in dgw.reasoning
+
+    def test_non_dgw_no_dgw_in_reasoning(self):
+        bidding = SmartBidding()
+        result = bidding.calculate_ep_bid(
+            asking_price=10_000_000,
+            market_value=10_000_000,
+            expected_points=80.0,
+            marginal_ep_gain=25.0,
+            confidence=0.8,
+            current_budget=30_000_000,
+            trend_change_pct=0.0,
+        )
+        assert "DGW" not in result.reasoning
+
+
 class TestAggressiveCompetitorsHelper:
     """Tests for ActivityFeedLearner.has_aggressive_competitors()."""
 

--- a/tests/test_scoring/test_decision.py
+++ b/tests/test_scoring/test_decision.py
@@ -5,7 +5,14 @@ from rehoboam.scoring.decision import DecisionEngine
 from rehoboam.scoring.models import DataQuality, PlayerScore
 
 
-def _make_score(player_id, ep, position="Midfielder", price=5_000_000, market_value=5_000_000):
+def _make_score(
+    player_id,
+    ep,
+    position="Midfielder",
+    price=5_000_000,
+    market_value=5_000_000,
+    fixture_bonus=0.0,
+):
     dq = DataQuality(
         grade="A",
         games_played=15,
@@ -21,7 +28,7 @@ def _make_score(player_id, ep, position="Midfielder", price=5_000_000, market_va
         base_points=ep * 0.5,
         consistency_bonus=5.0,
         lineup_bonus=10.0,
-        fixture_bonus=0.0,
+        fixture_bonus=fixture_bonus,
         form_bonus=0.0,
         minutes_bonus=0.0,
         dgw_multiplier=1.0,
@@ -225,6 +232,39 @@ class TestRecommendSells:
 
         gk_rec = next(r for r in recommendations if r.score.player_id == "gk1")
         assert gk_rec.is_protected
+
+    def test_tough_run_raises_expendability(self):
+        """Two identical-EP players — the one with a tough fixture run ahead
+        should be more expendable (selling now beats waiting for EP to drop)."""
+        squad = []
+        squad_scores = []
+        squad.append(_make_player("gk1", "Goalkeeper"))
+        squad_scores.append(_make_score("gk1", 40.0, "Goalkeeper"))
+        for i in range(3):
+            squad.append(_make_player(f"def{i}", "Defender"))
+            squad_scores.append(_make_score(f"def{i}", 35.0, "Defender"))
+        # Two midfielders with identical EP but different fixture runs
+        squad.append(_make_player("mid_easy", "Midfielder"))
+        squad_scores.append(_make_score("mid_easy", 45.0, "Midfielder", fixture_bonus=+5.0))
+        squad.append(_make_player("mid_tough", "Midfielder"))
+        squad_scores.append(_make_score("mid_tough", 45.0, "Midfielder", fixture_bonus=-10.0))
+        squad.append(_make_player("fwd0", "Forward"))
+        squad_scores.append(_make_score("fwd0", 50.0, "Forward"))
+
+        squad_players = {p.id: p for p in squad}
+        engine = DecisionEngine()
+        recommendations = engine.recommend_sells(
+            squad_scores=squad_scores, roster_context={}, squad_players=squad_players
+        )
+
+        tough = next(r for r in recommendations if r.score.player_id == "mid_tough")
+        easy = next(r for r in recommendations if r.score.player_id == "mid_easy")
+
+        assert tough.expendability > easy.expendability, (
+            "Tough fixture run should raise expendability vs an identical player "
+            f"with an easy run (tough={tough.expendability}, easy={easy.expendability})"
+        )
+        assert "tough run ahead" in tough.reason
 
 
 class TestSelectLineup:


### PR DESCRIPTION
## Summary

Three improvements that each close a known gap where our scoring work didn't reach actual decisions:

### 1. Lineup uses the new EP pipeline (HIGH IMPACT)

\`_set_optimal_lineup()\` in auto_trader was still calling the legacy \`calculate_expected_points()\` calculator. This meant:
- DGW ×1.8 multiplier → never factored into starting XI
- Injury penalty (−10 / −20 / −30) → ignored at lineup time
- 5-fixture Strength of Schedule → not used
- Position-weighted consistency/form → not used

All our recent scoring improvements now reach the actual lineup. The method accepts \`squad_scores\` from the session context; falls back to the legacy calculator per-player only for mid-session purchases the pipeline hasn't scored yet.

### 2. Tough-run sell timing

\`recommend_sells()\` in decision.py now adds a softened penalty (half the negative fixture_bonus) to expendability. Players facing brutal upcoming fixtures get prioritized for sale BEFORE their EP and market value drop.

### 3. DGW-aware bidding

\`calculate_ep_bid()\` now takes \`is_dgw\`. When true, confidence is floored at 0.9 to reflect the reduced variance from averaging across 2 matches. Flows into the existing confidence-bonus branch → higher overbid when statistically warranted.

## Test plan

- [x] \`pytest\`: 146 passed, 1 skipped (3 new tests)
- [x] \`ruff check\`: clean
- [x] Import sanity check after changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)