### PR TITLE
feat: scorer self-calibration from matchday outcomes

### DIFF
--- a/rehoboam/bid_learner.py
+++ b/rehoboam/bid_learner.py
@@ -290,6 +290,58 @@ class BidLearner:
     # a quarter. Tuned for fantasy football's seasonal form cycles.
     EP_ACCURACY_HALF_LIFE_DAYS = 60.0
 
+    # Minimum matchdays per position before the scorer calibration multiplier
+    # is trusted. Below this we return 1.0 (uncalibrated) so new seasons don't
+    # start with wildly swung scores from noisy small samples.
+    POSITION_CALIBRATION_MIN_MATCHDAYS = 10
+
+    def get_position_calibration_multiplier(self, position: str) -> float:
+        """Time-decayed actual/predicted EP ratio for a position, [0.5, 1.5].
+
+        Used by the scorer to correct systematic over/under-prediction at a
+        position level. E.g. if defenders consistently score 20% more than
+        we predict, this returns ~1.2 and the scorer boosts defender EPs.
+
+        Wider clamp than :meth:`get_ep_accuracy_factor` (which only dampens
+        bids) because here we want to raise scores when under-predicting, not
+        just lower them. Reuses the 60-day half-life decay so recent
+        matchdays dominate.
+
+        Returns 1.0 (uncalibrated) when there are fewer than
+        :attr:`POSITION_CALIBRATION_MIN_MATCHDAYS` records, or when total
+        weighted predicted EP is zero.
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute(
+                """
+                SELECT predicted_ep, actual_points, timestamp
+                FROM matchday_outcomes
+                WHERE player_position = ? AND predicted_ep > 0
+                """,
+                (position,),
+            )
+            rows = cursor.fetchall()
+
+        if len(rows) < self.POSITION_CALIBRATION_MIN_MATCHDAYS:
+            return 1.0
+
+        now_ts = datetime.now(tz=timezone.utc).timestamp()
+        half_life_seconds = self.EP_ACCURACY_HALF_LIFE_DAYS * 86_400
+
+        weighted_actual = 0.0
+        weighted_predicted = 0.0
+        for predicted_ep, actual_points, ts in rows:
+            age_seconds = self._age_seconds(ts, now_ts)
+            weight = 0.5 ** (age_seconds / half_life_seconds)
+            weighted_actual += weight * actual_points
+            weighted_predicted += weight * predicted_ep
+
+        if weighted_predicted <= 0:
+            return 1.0
+
+        raw_factor = weighted_actual / weighted_predicted
+        return max(0.5, min(1.5, raw_factor))
+
     def get_ep_accuracy_factor(
         self,
         player_id: str | None = None,

--- a/rehoboam/scoring/scorer.py
+++ b/rehoboam/scoring/scorer.py
@@ -210,10 +210,18 @@ def _grade_data_quality(
 # ---------------------------------------------------------------------------
 
 
-def score_player(data: PlayerData) -> PlayerScore:
+def score_player(data: PlayerData, calibration_multiplier: float = 1.0) -> PlayerScore:
     """Score a player from assembled PlayerData.  Pure function — no I/O.
 
-    Scoring bands (before DGW multiplier):
+    Args:
+        data: Assembled per-player data (already pre-fetched by DataCollector).
+        calibration_multiplier: Position-level correction factor from
+            BidLearner.get_position_calibration_multiplier(). When the scorer
+            systematically over/under-predicts for a position (e.g. defenders
+            scoring 20% more than we predict), this multiplier closes the gap.
+            Default 1.0 (uncalibrated). Applied to the final EP alongside DGW.
+
+    Scoring bands (before DGW / calibration multipliers):
         base_points       0 – 40    (avg_points * 2, capped at 40)
         consistency_bonus -5 – +15  (forwards: -2 – +8; see _CONSISTENCY_SCALE)
         lineup_bonus      -20 – +20
@@ -224,6 +232,7 @@ def score_player(data: PlayerData) -> PlayerScore:
         ─────────────────────────────
         subtotal          ~-90 – 114  → clamped 0–100 pre-DGW
         DGW ×1.8          0 – 180
+        calibration       ×0.5 – ×1.5 (final output still clamped to 0–180)
     """
     player = data.player
     avg_pts: float = player.average_points or 0.0
@@ -447,7 +456,10 @@ def score_player(data: PlayerData) -> PlayerScore:
     if data.is_dgw:
         notes.append("DOUBLE GAMEWEEK ×1.8")
 
-    expected_points = min(pre_dgw * dgw_multiplier, 180.0)
+    if calibration_multiplier != 1.0:
+        notes.append(f"Position calibration ×{calibration_multiplier:.2f}")
+
+    expected_points = min(pre_dgw * dgw_multiplier * calibration_multiplier, 180.0)
 
     return PlayerScore(
         player_id=player.id,

--- a/rehoboam/trader.py
+++ b/rehoboam/trader.py
@@ -204,6 +204,22 @@ class Trader:
         # --- 3. Score all players ---
         collector = DataCollector(matchup_analyzer=self.matchup_analyzer)
 
+        # Pre-compute position calibration multipliers once per session
+        # (one SQL query per position vs once per player). Stays at 1.0
+        # without a bid_learner or with insufficient historical data.
+        position_calibrations: dict[str, float] = {}
+        if self.bid_learner is not None:
+            for pos in ("Goalkeeper", "Defender", "Midfielder", "Forward"):
+                try:
+                    position_calibrations[pos] = (
+                        self.bid_learner.get_position_calibration_multiplier(pos)
+                    )
+                except Exception:
+                    position_calibrations[pos] = 1.0
+
+        def _calibration_for(player) -> float:
+            return position_calibrations.get(player.position, 1.0)
+
         market_scores: list = []
         market_player_map: dict = {}
         for player in kickbase_market:
@@ -215,7 +231,9 @@ class Trader:
                     player_details=details,
                     team_profiles=team_profiles,
                 )
-                market_scores.append(score_player(data))
+                market_scores.append(
+                    score_player(data, calibration_multiplier=_calibration_for(player))
+                )
                 market_player_map[player.id] = player
             except Exception as e:
                 if self.verbose:
@@ -232,7 +250,9 @@ class Trader:
                     player_details=details,
                     team_profiles=team_profiles,
                 )
-                squad_scores.append(score_player(data))
+                squad_scores.append(
+                    score_player(data, calibration_multiplier=_calibration_for(player))
+                )
                 squad_player_map[player.id] = player
             except Exception as e:
                 if self.verbose:

--- a/tests/test_matchday_outcomes.py
+++ b/tests/test_matchday_outcomes.py
@@ -230,6 +230,178 @@ class TestTimeDecay:
             assert 0.88 <= factor <= 0.92
 
 
+class TestPositionCalibrationMultiplier:
+    """Tests for get_position_calibration_multiplier()."""
+
+    def test_returns_1_with_no_data(self, tmp_path):
+        learner = BidLearner(db_path=tmp_path / "test.db")
+        assert learner.get_position_calibration_multiplier("Defender") == 1.0
+
+    def test_returns_1_with_too_few_records(self, tmp_path):
+        """Below POSITION_CALIBRATION_MIN_MATCHDAYS (10) → no calibration."""
+        learner = BidLearner(db_path=tmp_path / "test.db")
+        for i in range(5):
+            learner.record_matchday_outcome(
+                player_id=f"d{i}",
+                player_position="Defender",
+                matchday_date=f"2026-04-{1 + i:02d}",
+                predicted_ep=40.0,
+                actual_points=80.0,  # 2x — would trigger calibration if trusted
+            )
+        assert learner.get_position_calibration_multiplier("Defender") == 1.0
+
+    def test_under_predicting_returns_high_multiplier(self, tmp_path):
+        """Actual > predicted → multiplier > 1.0 (boost future predictions)."""
+        learner = BidLearner(db_path=tmp_path / "test.db")
+        for i in range(15):
+            learner.record_matchday_outcome(
+                player_id=f"d{i % 5}",
+                player_position="Defender",
+                matchday_date=f"2026-04-{1 + i:02d}",
+                predicted_ep=40.0,
+                actual_points=48.0,  # 20% over prediction
+            )
+        mult = learner.get_position_calibration_multiplier("Defender")
+        assert 1.15 <= mult <= 1.25
+
+    def test_over_predicting_returns_low_multiplier(self, tmp_path):
+        """Actual < predicted → multiplier < 1.0 (dampen future predictions)."""
+        learner = BidLearner(db_path=tmp_path / "test.db")
+        for i in range(15):
+            learner.record_matchday_outcome(
+                player_id=f"f{i % 5}",
+                player_position="Forward",
+                matchday_date=f"2026-04-{1 + i:02d}",
+                predicted_ep=60.0,
+                actual_points=42.0,  # 30% under
+            )
+        mult = learner.get_position_calibration_multiplier("Forward")
+        assert 0.65 <= mult <= 0.75
+
+    def test_clamped_at_upper_bound(self, tmp_path):
+        """Multiplier capped at 1.5 even when actual >> predicted."""
+        learner = BidLearner(db_path=tmp_path / "test.db")
+        for i in range(15):
+            learner.record_matchday_outcome(
+                player_id=f"d{i % 5}",
+                player_position="Defender",
+                matchday_date=f"2026-04-{1 + i:02d}",
+                predicted_ep=10.0,
+                actual_points=100.0,
+            )
+        assert learner.get_position_calibration_multiplier("Defender") == 1.5
+
+    def test_clamped_at_lower_bound(self, tmp_path):
+        """Multiplier floored at 0.5 even when actual << predicted."""
+        learner = BidLearner(db_path=tmp_path / "test.db")
+        for i in range(15):
+            learner.record_matchday_outcome(
+                player_id=f"f{i % 5}",
+                player_position="Forward",
+                matchday_date=f"2026-04-{1 + i:02d}",
+                predicted_ep=100.0,
+                actual_points=10.0,
+            )
+        assert learner.get_position_calibration_multiplier("Forward") == 0.5
+
+
+class TestScorerCalibration:
+    """Tests for calibration_multiplier in score_player()."""
+
+    def test_default_multiplier_no_change(self):
+        """calibration_multiplier=1.0 (default) leaves the EP unchanged."""
+        from rehoboam.kickbase_client import MarketPlayer
+        from rehoboam.scoring.models import PlayerData
+        from rehoboam.scoring.scorer import score_player
+
+        player = MarketPlayer(
+            id="p1",
+            first_name="Test",
+            last_name="Player",
+            position="Defender",
+            team_id="t1",
+            team_name="Test FC",
+            price=5_000_000,
+            market_value=5_000_000,
+            points=20,
+            average_points=15.0,
+            status=0,
+        )
+        data = PlayerData(
+            player=player,
+            performance=None,
+            player_details=None,
+            team_strength=None,
+            opponent_strength=None,
+            is_dgw=False,
+        )
+        baseline = score_player(data)
+        explicit_one = score_player(data, calibration_multiplier=1.0)
+        assert explicit_one.expected_points == baseline.expected_points
+
+    def test_high_multiplier_boosts_score(self):
+        from rehoboam.kickbase_client import MarketPlayer
+        from rehoboam.scoring.models import PlayerData
+        from rehoboam.scoring.scorer import score_player
+
+        player = MarketPlayer(
+            id="p1",
+            first_name="Test",
+            last_name="Player",
+            position="Defender",
+            team_id="t1",
+            team_name="Test FC",
+            price=5_000_000,
+            market_value=5_000_000,
+            points=20,
+            average_points=15.0,
+            status=0,
+        )
+        data = PlayerData(
+            player=player,
+            performance=None,
+            player_details=None,
+            team_strength=None,
+            opponent_strength=None,
+            is_dgw=False,
+        )
+        baseline = score_player(data)
+        boosted = score_player(data, calibration_multiplier=1.3)
+        # 30% higher (clamped at 180)
+        assert boosted.expected_points > baseline.expected_points
+        assert any("calibration" in n.lower() for n in boosted.notes)
+
+    def test_clamped_at_180_with_dgw_and_high_calibration(self):
+        from rehoboam.kickbase_client import MarketPlayer
+        from rehoboam.scoring.models import PlayerData
+        from rehoboam.scoring.scorer import score_player
+
+        player = MarketPlayer(
+            id="p1",
+            first_name="Test",
+            last_name="Player",
+            position="Forward",
+            team_id="t1",
+            team_name="Test FC",
+            price=5_000_000,
+            market_value=5_000_000,
+            points=200,
+            average_points=50.0,
+            status=0,
+        )
+        data = PlayerData(
+            player=player,
+            performance=None,
+            player_details=None,
+            team_strength=None,
+            opponent_strength=None,
+            is_dgw=True,
+        )
+        result = score_player(data, calibration_multiplier=1.5)
+        # base ~40 → pre_dgw 100 → ×1.8 ×1.5 = 270 → clamped at 180
+        assert result.expected_points <= 180.0
+
+
 class TestWonPlayerOutcomeQuality:
     def test_returns_default_with_no_data(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

The scorer now reads back its own track record and corrects per-position. If defenders systematically score 20% more than we predict, future defender EPs get a +20% calibration boost. If forwards under-deliver, their EPs get dampened. Compounding improvement: every matchday of recorded outcomes makes scoring more accurate.

## Mechanism

\`BidLearner.get_position_calibration_multiplier(position)\` → time-decayed actual/predicted ratio with:
- 60-day half-life (recent matchdays dominate)
- Clamped to **[0.5, 1.5]** — wider than \`get_ep_accuracy_factor\`'s [0.5, 1.0] because here we want to *raise* scores too, not just dampen
- Returns 1.0 below 10 records per position (avoid noisy small-sample corrections)

\`score_player()\` gains an optional \`calibration_multiplier\` parameter (default 1.0). Applied at the final clamp alongside the DGW multiplier.

\`Trader.get_ep_recommendations()\` pre-computes one multiplier per position per session (4 SQL queries total) and passes it into every scoring call.

## Test plan

- [x] \`pytest\`: 155 passed, 1 skipped (9 new tests)
- [x] \`ruff check\`: clean
- [x] Tests cover: insufficient data → 1.0, under-predicting → boost, over-predicting → dampen, both clamps, scorer integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)