### PR TITLE
feat: smarter dip-buying + matchday-aware flip hold cap

### DIFF
--- a/rehoboam/auto_trader.py
+++ b/rehoboam/auto_trader.py
@@ -36,6 +36,22 @@ class MatchdayPhase:
     reason: str
 
 
+def _max_flip_hold_days(days_until_match: int | None) -> int | None:
+    """Cap on a profit-flip's hold_days to fit before the next matchday.
+
+    A flip we can't sell before kickoff risks both an unsellable position and
+    the value drop that often follows uncertain matchday outcomes. Returns
+    ``None`` when the schedule is unknown (no constraint applied — the
+    matchday-phase logic already defaults to no-flips in that case).
+
+    The "−1 day" buffer leaves a safety margin for the sell to actually clear
+    given Kickbase's auction mechanics.
+    """
+    if days_until_match is None:
+        return None
+    return max(1, days_until_match - 1)
+
+
 @dataclass
 class EPSessionContext:
     """Single-fetch context for the entire auto session."""
@@ -261,12 +277,29 @@ class AutoTrader:
                 ep_player_ids = {
                     rec.player.id for _, _, rec in candidates if hasattr(rec, "player")
                 } | {pair.buy_player.id for _, _, pair in candidates if hasattr(pair, "buy_player")}
+
+                # Cap flip hold time so we don't enter a position we can't exit
+                # before the next matchday — being caught at kickoff with a
+                # half-finished flip risks the lineup penalty AND market drop.
+                max_hold_days = _max_flip_hold_days(ctx.matchday_phase.days_until_match)
+
+                skipped_long_hold = 0
                 for opp in profit_opps:
-                    if opp.player.id not in ep_player_ids:
-                        profit_flip_candidates.append(opp)
+                    if opp.player.id in ep_player_ids:
+                        continue
+                    if max_hold_days is not None and opp.hold_days > max_hold_days:
+                        skipped_long_hold += 1
+                        continue
+                    profit_flip_candidates.append(opp)
+
                 if profit_flip_candidates:
                     console.print(
                         f"[cyan]💰 + {len(profit_flip_candidates)} profit flip candidate(s)[/cyan]"
+                    )
+                if skipped_long_hold > 0:
+                    console.print(
+                        f"[dim]Skipped {skipped_long_hold} flip(s) — "
+                        f"hold time would exceed matchday window[/dim]"
                     )
             except Exception as e:
                 console.print(f"[yellow]Profit flip search failed: {e}[/yellow]")

--- a/rehoboam/profit_trader.py
+++ b/rehoboam/profit_trader.py
@@ -143,24 +143,40 @@ class ProfitTrader:
                     )
                     continue  # Skip small sample size anomalies
 
-                # Filter 3: Accept rising trends OR stable performers with good points
+                # Filter 3: Accept rising trends OR stable performers with good
+                # points OR dip-in-uptrend (mean reversion).
                 expected_appreciation = 0
+                is_dip_in_uptrend = trend.get("is_dip_in_uptrend", False)
+                is_secular_decline = trend.get("is_secular_decline", False)
+                is_recovery = trend.get("is_recovery", False)
+
                 if trend_direction == "rising" and trend_pct > 5:
                     # Expect trend to continue (cap at 20%)
                     expected_appreciation = min(trend_pct, 20)
+                elif is_recovery and player.average_points >= 30:
+                    # Recovery signal: short-term reversal after dip → catch the bounce
+                    expected_appreciation = 12
+                elif is_dip_in_uptrend and player.average_points >= 30:
+                    # Genuine dip in a longer uptrend — best mean-reversion play.
+                    # Trend service already filtered for: recent down + medium up.
+                    expected_appreciation = 10
                 elif trend_direction == "stable" and player.average_points >= 40:
                     # Stable good performers - conservative 8% appreciation
                     expected_appreciation = 8
                 elif trend_direction == "falling" and peak_value > 0:
-                    # Mean reversion for players significantly below peak
+                    # Hard mean reversion for high-quality players that crashed.
+                    # Stricter threshold than dip-in-uptrend because a falling
+                    # trend without uptrend context is riskier.
+                    if is_secular_decline:
+                        continue  # genuine decline, not a dip — avoid
                     current_vs_peak_pct = ((current_value - peak_value) / peak_value) * 100
-                    if current_vs_peak_pct < -50 and player.average_points >= 40:
-                        # More than 50% below peak + good performer = mean reversion play
+                    if current_vs_peak_pct < -25 and player.average_points >= 40:
+                        # >25% below peak + high performer + not in secular decline
                         expected_appreciation = min(abs(current_vs_peak_pct) * 0.3, 15)
                     else:
-                        continue  # Skip falling players not far below peak
+                        continue  # Not deep enough or not high enough quality
                 else:
-                    # Not rising, not stable good performer, not recovery candidate
+                    # Not a recognized profit pattern — skip
                     continue
 
                 # Skip if no profit potential

--- a/tests/test_profit_dip_buying.py
+++ b/tests/test_profit_dip_buying.py
@@ -1,0 +1,175 @@
+"""Tests for dip-buying logic in ProfitTrader.find_profit_opportunities()
+and the matchday hold-time cap in auto_trader._max_flip_hold_days().
+"""
+
+from rehoboam.auto_trader import _max_flip_hold_days
+from rehoboam.kickbase_client import MarketPlayer
+from rehoboam.profit_trader import ProfitTrader
+
+
+def _make_player(**overrides) -> MarketPlayer:
+    defaults = {
+        "id": "p1",
+        "first_name": "Test",
+        "last_name": "Player",
+        "position": "Midfielder",
+        "team_id": "t1",
+        "team_name": "Test FC",
+        "price": 5_000_000,
+        "market_value": 5_000_000,  # Equal to price → KICKBASE seller
+        "points": 80,
+        "average_points": 35.0,
+        "status": 0,
+    }
+    defaults.update(overrides)
+    return MarketPlayer(**defaults)
+
+
+def _trend(
+    direction: str = "stable",
+    pct: float = 0.0,
+    current: int = 5_000_000,
+    peak: int = 5_500_000,
+    is_dip_in_uptrend: bool = False,
+    is_recovery: bool = False,
+    is_secular_decline: bool = False,
+):
+    return {
+        "has_data": True,
+        "trend": direction,
+        "trend_pct": pct,
+        "current_value": current,
+        "peak_value": peak,
+        "is_dip_in_uptrend": is_dip_in_uptrend,
+        "is_recovery": is_recovery,
+        "is_secular_decline": is_secular_decline,
+    }
+
+
+class TestDipInUptrendBuy:
+    def test_dip_in_uptrend_creates_opportunity(self):
+        """A short-term dip in a longer uptrend → flip candidate."""
+        player = _make_player(average_points=35.0)
+        trader = ProfitTrader()
+        opps = trader.find_profit_opportunities(
+            market_players=[player],
+            current_budget=20_000_000,
+            player_trends={
+                player.id: _trend(direction="falling", pct=-3.0, is_dip_in_uptrend=True),
+            },
+            team_value=80_000_000,
+        )
+        assert len(opps) == 1
+        assert "appreciation" in opps[0].reason.lower() or opps[0].expected_appreciation > 0
+
+    def test_dip_in_uptrend_requires_decent_avg_points(self):
+        """Sub-30 avg points → dip-in-uptrend not enough; skip."""
+        player = _make_player(average_points=15.0)
+        trader = ProfitTrader()
+        opps = trader.find_profit_opportunities(
+            market_players=[player],
+            current_budget=20_000_000,
+            player_trends={
+                player.id: _trend(direction="falling", pct=-3.0, is_dip_in_uptrend=True),
+            },
+            team_value=80_000_000,
+        )
+        # MIN_AVG_POINTS=20 filter would catch this anyway, but verify behavior
+        assert opps == []
+
+    def test_recovery_signal_triggers_buy(self):
+        """Recovery (short-term up after dip) → flip candidate."""
+        player = _make_player(average_points=32.0)
+        trader = ProfitTrader()
+        opps = trader.find_profit_opportunities(
+            market_players=[player],
+            current_budget=20_000_000,
+            player_trends={
+                player.id: _trend(direction="rising", pct=4.0, is_recovery=True),
+            },
+            team_value=80_000_000,
+        )
+        assert len(opps) == 1
+
+
+class TestSecularDeclineBlocked:
+    def test_secular_decline_blocks_falling_buy(self):
+        """A falling player flagged as secular decline should NOT be a flip candidate
+        even if they're far below peak."""
+        player = _make_player(average_points=50.0)
+        trader = ProfitTrader()
+        opps = trader.find_profit_opportunities(
+            market_players=[player],
+            current_budget=20_000_000,
+            player_trends={
+                player.id: _trend(
+                    direction="falling",
+                    pct=-15.0,
+                    current=3_000_000,
+                    peak=8_000_000,
+                    is_secular_decline=True,
+                ),
+            },
+            team_value=80_000_000,
+        )
+        assert opps == []
+
+
+class TestLowerDipThreshold:
+    def test_below_peak_triggers_mean_reversion(self):
+        """Threshold lowered from -50% to -25% — a player far below peak
+        with high avg_points qualifies as a mean-reversion play. (Old code
+        only triggered below -50%.)"""
+        player = _make_player(price=4_000_000, market_value=4_000_000, average_points=50.0)
+        trader = ProfitTrader()
+        opps = trader.find_profit_opportunities(
+            market_players=[player],
+            current_budget=20_000_000,
+            player_trends={
+                player.id: _trend(
+                    direction="falling",
+                    pct=-8.0,
+                    current=4_000_000,
+                    peak=8_000_000,  # 50% below peak — old threshold also met
+                ),
+            },
+            team_value=80_000_000,
+        )
+        assert len(opps) == 1
+
+    def test_secular_decline_blocked_even_far_below_peak(self):
+        """Far below peak BUT secular decline → still skipped (regression
+        check that the new is_secular_decline gate fires)."""
+        player = _make_player(price=4_000_000, market_value=4_000_000, average_points=50.0)
+        trader = ProfitTrader()
+        opps = trader.find_profit_opportunities(
+            market_players=[player],
+            current_budget=20_000_000,
+            player_trends={
+                player.id: _trend(
+                    direction="falling",
+                    pct=-8.0,
+                    current=4_000_000,
+                    peak=8_000_000,
+                    is_secular_decline=True,
+                ),
+            },
+            team_value=80_000_000,
+        )
+        assert opps == []
+
+
+class TestMaxFlipHoldDays:
+    def test_unknown_schedule_no_cap(self):
+        assert _max_flip_hold_days(None) is None
+
+    def test_3_days_until_match_cap_is_2(self):
+        """3 days until match → flip must complete in ≤2 days (1d safety buffer)."""
+        assert _max_flip_hold_days(3) == 2
+
+    def test_1_day_until_match_floors_at_1(self):
+        """Even with very tight schedule, return at least 1 (don't return 0/negative)."""
+        assert _max_flip_hold_days(1) == 1
+
+    def test_far_match_allows_long_holds(self):
+        assert _max_flip_hold_days(10) == 9


### PR DESCRIPTION
## Summary

Two improvements to the profit-trading side that net more flips without distracting from lineup focus.

### 1. Dip-buying uses trend service signals

Old logic: mean-reversion buys only triggered when a player was **50%+ below peak** — extremely rare in practice.

New logic uses the trend service's already-computed flags:
- \`is_dip_in_uptrend\` → mean-reversion buy (+10% expected appreciation)
- \`is_recovery\` (post-dip bounce) → +12% expected
- Falling >**25%** below peak (was 50%) → quality-gated mean reversion
- \`is_secular_decline\` → always blocked (no catching falling knives)

### 2. Flip hold-time capped by matchday proximity

New \`_max_flip_hold_days(days_until_match)\` filter. A flip with \`hold_days > days_until_match - 1\` gets skipped — we don't enter positions we can't exit before kickoff. A flip we still hold at match start risks both an unsellable position AND the value drop that often follows uncertain match outcomes.

## Test plan

- [x] \`pytest\`: 165 passed, 1 skipped (10 new tests)
- [x] \`ruff check\`: clean
- [x] Tests cover: dip-in-uptrend buys, recovery buys, secular-decline block, lowered peak threshold, hold-time cap edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)