### PR TITLE
fix: cap positions in select_best_eleven + proactive dead-weight selling

### DIFF
--- a/rehoboam/auto_trader.py
+++ b/rehoboam/auto_trader.py
@@ -593,6 +593,40 @@ class AutoTrader:
                     )
                 )
 
+        # Dead-weight sell: surplus-position bench players (e.g. 2nd/3rd GK)
+        # that block the squad from buying useful players.  Even at a small
+        # loss, freeing the slot is worth it when the EP pipeline has buy
+        # candidates waiting — the matchday points gained over a season
+        # vastly outweigh a one-time market value loss.
+        from .formation import _POSITION_MAX_STARTERS
+
+        already_selling = {p.id for p, _, _ in sell_candidates}
+        for player in squad:
+            if player.id in best_11_ids or player.id in already_selling:
+                continue
+            if not player.buy_price or player.buy_price <= 0:
+                continue
+
+            max_starters = _POSITION_MAX_STARTERS.get(player.position, 3)
+            if position_counts.get(player.position, 0) <= max_starters:
+                continue  # Position not saturated — not dead weight
+
+            profit = player.market_value - player.buy_price
+            profit_pct = (profit / player.buy_price) * 100
+
+            # Always sell dead weight at a profit.  At a loss, only sell
+            # when the EP pipeline has a replacement lined up — the freed
+            # slot is worth more than the loss.
+            if profit_pct >= 0 or has_replacement:
+                sell_candidates.append(
+                    (
+                        player,
+                        profit_pct,
+                        f"Dead weight ({player.position} surplus): "
+                        f"{profit_pct:+.1f}% (€{profit:,}), freeing slot",
+                    )
+                )
+
         if not sell_candidates:
             console.print("[dim]No players meet sell criteria[/dim]")
             return results

--- a/rehoboam/formation.py
+++ b/rehoboam/formation.py
@@ -128,11 +128,19 @@ def select_best_eleven(squad: list, player_values: dict[str, float]) -> list:
         if len(selected) >= requirements.starting_eleven_size:
             break
 
-    # Second pass: fill remaining spots with best available
+    # Second pass: fill remaining spots with best available, but respect
+    # position ceilings.  A 2nd GK can never play in any formation, so
+    # picking one here would block a useful outfield player and break
+    # marginal-EP calculations downstream.
     if len(selected) < requirements.starting_eleven_size:
         for player in sorted_squad:
             if player not in selected:
+                pos = player.position
+                max_at_pos = _POSITION_MAX_STARTERS.get(pos, 3)
+                if position_counts.get(pos, 0) >= max_at_pos:
+                    continue  # position saturated — skip
                 selected.append(player)
+                position_counts[pos] = position_counts.get(pos, 0) + 1
                 if len(selected) >= requirements.starting_eleven_size:
                     break
 

--- a/tests/test_scoring/test_dead_weight.py
+++ b/tests/test_scoring/test_dead_weight.py
@@ -5,7 +5,7 @@ would permanently bench a same-position peer (e.g. 2nd GK), and that the
 fieldability guard in formation.py correctly identifies unfieldable squads.
 """
 
-from rehoboam.formation import _POSITION_MAX_STARTERS, validate_formation
+from rehoboam.formation import _POSITION_MAX_STARTERS, select_best_eleven, validate_formation
 from rehoboam.kickbase_client import MarketPlayer
 from rehoboam.scoring.decision import DecisionEngine, _would_create_dead_weight
 from rehoboam.scoring.models import DataQuality, PlayerScore
@@ -122,6 +122,89 @@ class TestPositionMaxStarters:
 
     def test_fwd_max_is_3(self):
         assert _POSITION_MAX_STARTERS["Forward"] == 3
+
+
+# ---------------------------------------------------------------------------
+# select_best_eleven position cap
+# ---------------------------------------------------------------------------
+
+
+class TestSelectBestElevenPositionCap:
+    def test_second_gk_never_in_best_11(self):
+        """With 12 players including 2 GKs, best-11 should only include 1 GK."""
+        squad = [
+            _make_player("gk1", "Goalkeeper"),
+            _make_player("gk2", "Goalkeeper"),
+            *[_make_player(f"def{i}", "Defender") for i in range(4)],
+            *[_make_player(f"mid{i}", "Midfielder") for i in range(4)],
+            *[_make_player(f"fwd{i}", "Forward") for i in range(2)],
+        ]
+        # GK1 has highest EP so both GKs would be picked without the cap
+        values = {p.id: 50.0 for p in squad}
+        values["gk1"] = 90.0
+        values["gk2"] = 80.0  # Higher than most outfield
+
+        best_11 = select_best_eleven(squad, values)
+        gk_count = sum(1 for p in best_11 if p.position == "Goalkeeper")
+        assert gk_count == 1, f"Expected 1 GK in best-11, got {gk_count}"
+        assert any(p.id == "gk1" for p in best_11), "Best GK should be selected"
+        assert not any(p.id == "gk2" for p in best_11), "2nd GK should NOT be in best-11"
+
+    def test_three_gks_only_one_selected(self):
+        """With 3 GKs in a 12-player squad, exactly 1 GK in best-11."""
+        squad = [
+            _make_player("gk1", "Goalkeeper"),
+            _make_player("gk2", "Goalkeeper"),
+            _make_player("gk3", "Goalkeeper"),
+            *[_make_player(f"def{i}", "Defender") for i in range(3)],
+            *[_make_player(f"mid{i}", "Midfielder") for i in range(3)],
+            *[_make_player(f"fwd{i}", "Forward") for i in range(3)],
+        ]
+        values = {p.id: 40.0 for p in squad}
+        values["gk1"] = 90.0
+        values["gk2"] = 85.0
+        values["gk3"] = 80.0
+
+        best_11 = select_best_eleven(squad, values)
+        gk_count = sum(1 for p in best_11 if p.position == "Goalkeeper")
+        assert gk_count == 1
+
+    def test_outfield_player_preferred_over_surplus_gk(self):
+        """A MID with lower EP should still beat a surplus GK for a best-11 spot."""
+        squad = [
+            _make_player("gk1", "Goalkeeper"),
+            _make_player("gk2", "Goalkeeper"),
+            *[_make_player(f"def{i}", "Defender") for i in range(3)],
+            *[_make_player(f"mid{i}", "Midfielder") for i in range(4)],
+            *[_make_player(f"fwd{i}", "Forward") for i in range(2)],
+        ]
+        values = {p.id: 50.0 for p in squad}
+        values["gk1"] = 90.0
+        values["gk2"] = 80.0  # Higher than mid3
+        values["mid3"] = 30.0  # Lowest, but should still beat surplus GK
+
+        best_11 = select_best_eleven(squad, values)
+        assert any(
+            p.id == "mid3" for p in best_11
+        ), "Outfield player should be preferred over surplus GK"
+        assert not any(p.id == "gk2" for p in best_11)
+
+    def test_six_defenders_only_five_in_best_11(self):
+        """Max 5 DEF can start. 6th DEF should be excluded."""
+        squad = [
+            _make_player("gk1", "Goalkeeper"),
+            *[_make_player(f"def{i}", "Defender") for i in range(6)],
+            *[_make_player(f"mid{i}", "Midfielder") for i in range(3)],
+            _make_player("fwd0", "Forward"),
+        ]
+        values = {p.id: 50.0 for p in squad}
+        # All defenders have high EP
+        for i in range(6):
+            values[f"def{i}"] = 70.0 - i
+
+        best_11 = select_best_eleven(squad, values)
+        def_count = sum(1 for p in best_11 if p.position == "Defender")
+        assert def_count == 5, f"Expected max 5 DEF, got {def_count}"
 
 
 # ---------------------------------------------------------------------------
@@ -258,10 +341,10 @@ class TestRecommendBuysDeadWeight:
         # No forced sell plan — position not saturated
         assert rec.sell_plan is None
 
-    def test_gk_upgrade_skipped_if_sell_plan_not_viable(self):
-        """If the forced sell plan is unviable (only 1 GK, can't sell it
-        without breaking minimums), the buy should be skipped entirely."""
-        # Minimal squad: only the GK, and the GK is protected
+    def test_gk_buy_with_one_existing_gk_gets_sell_plan(self):
+        """With exactly 1 GK in squad and buying a 2nd, the dead-weight guard
+        fires and attaches a viable sell plan for the old GK (because buying
+        the new GK means selling the old one is safe — count stays at 1)."""
         squad = [_make_player("gk1", "Goalkeeper", market_value=2_000_000)]
         scores = [_make_score("gk1", 35.0, "Goalkeeper", market_value=2_000_000)]
         squad_players = {p.id: p for p in squad}
@@ -278,15 +361,13 @@ class TestRecommendBuysDeadWeight:
             budget=50_000_000,
             market_players=market_players,
             squad_players=squad_players,
-            is_emergency=True,  # Allow lower thresholds
+            is_emergency=True,
         )
 
-        # The GK is the only one in squad → selling would break the minimum.
-        # build_sell_plan should refuse to sell a position-minimum player,
-        # BUT the old GK is the displaced player which goes first in the
-        # sell plan ordering. It would need to check position minimums.
-        # If sell plan is not viable → the rec should be filtered out.
-        for rec in recs:
-            if rec.player.id == "new_gk" and rec.sell_plan is not None:
-                # If it somehow passes, the sell plan should at least be viable
-                assert rec.sell_plan.is_viable
+        # The GK upgrade should be recommended with a forced sell plan
+        gk_rec = next((r for r in recs if r.player.id == "new_gk"), None)
+        assert gk_rec is not None, "GK upgrade should be recommended"
+        assert gk_rec.sell_plan is not None, "Must have forced sell plan"
+        assert gk_rec.sell_plan.is_viable, "Sell plan must be viable"
+        sell_ids = [e.player_id for e in gk_rec.sell_plan.players_to_sell]
+        assert "gk1" in sell_ids, "Old GK should be the sell target"


### PR DESCRIPTION
## Summary

- **Root fix**: `select_best_eleven()` pass 2 now respects `_POSITION_MAX_STARTERS` — a 2nd GK can never occupy a best-11 slot, regardless of EP score
- **Dead-weight sell**: Surplus-position bench players (e.g. 2nd/3rd GK) are proactively sold in the profit sell phase — at profit always, at a loss when the EP pipeline has buy replacements waiting

### Problem
With 3 GKs and 12 players, all 3 GKs made the best-11 via pass 2 (high EP fills remaining spots). This caused a cascade of failures:
1. All market MIDs/FWDs showed `marginal_ep_gain = 0` (can't beat GKs in best-11)
2. EP pipeline returned zero buy recommendations — bot was completely paralyzed
3. Lineup was set to broken "5-2-1" formation with 3 GKs
4. Surplus GKs were "protected" from selling (treated as starters)
5. Emergency player the user manually bought got sold immediately (on bench, stop-loss)

### The 6-line keystone fix
Pass 2 of `select_best_eleven()` now checks `_POSITION_MAX_STARTERS` before adding a player. Result: surplus GKs fall to bench, MID/FWD candidates show positive marginal EP, lineup is valid, and the bot starts buying again.

## Test plan
- [x] 2 GKs → only 1 in best-11 (highest EP GK selected)
- [x] 3 GKs → exactly 1 in best-11
- [x] Outfield player with lower EP preferred over surplus GK
- [x] 6 DEFs → max 5 in best-11
- [x] End-to-end: real Kickbase data now shows 5 buy recommendations (was 0)
- [x] Full regression: 186 passed, 0 failures


🤖 Generated with [Claude Code](https://claude.com/claude-code)