### PR TITLE
fix: refresh flip budget after mid-session sells and bid cancels

### DIFF
--- a/rehoboam/auto_trader.py
+++ b/rehoboam/auto_trader.py
@@ -52,6 +52,22 @@ def _max_flip_hold_days(days_until_match: int | None) -> int | None:
     return max(1, days_until_match - 1)
 
 
+def _compute_flip_budget(
+    phase: str, current_budget: int, pending_bid_total: int, max_debt: int
+) -> int:
+    """Free budget for flip trading, by matchday phase.
+
+    Shared by session-context build and the trade-phase refresh so both
+    call sites agree on the formula after sells/bid-cancels mutate the
+    inputs mid-session.
+    """
+    if phase == "locked":
+        return 0
+    if phase == "moderate":
+        return current_budget - pending_bid_total
+    return current_budget + max_debt - pending_bid_total
+
+
 @dataclass
 class EPSessionContext:
     """Single-fetch context for the entire auto session."""
@@ -183,13 +199,7 @@ class AutoTrader:
         # Calculate flip budget based on matchday phase
         max_debt = int(team_value * (self.settings.max_debt_pct_of_team_value / 100))
         pending_bid_total = sum(p.user_offer_price for p in my_bids)
-
-        if phase.phase == "locked":
-            flip_budget = 0
-        elif phase.phase == "moderate":
-            flip_budget = current_budget - pending_bid_total
-        else:
-            flip_budget = current_budget + max_debt - pending_bid_total
+        flip_budget = _compute_flip_budget(phase.phase, current_budget, pending_bid_total, max_debt)
 
         return EPSessionContext(
             ep_result=ep_result,
@@ -244,14 +254,24 @@ class AutoTrader:
             f"{sum(1 for c in candidates if c[0] == 'pair')} trade pairs)[/cyan]"
         )
 
-        # Refresh squad and bids — earlier phases (sell monitoring, squad optimization)
-        # may have changed the actual counts since ctx was built.
+        # Refresh squad, bids, and budget — sell monitoring, squad optimization,
+        # and bid compliance/evaluation can all mutate these between ctx build
+        # and the trade phase. Without re-running the flip-budget math against
+        # fresh numbers, we skip affordable candidates after a mid-session sell
+        # or bid cancel.
         fresh_squad = self.api.get_squad(league)
         fresh_bids = self.api.get_my_bids(league)
+        fresh_team_info = self.api.get_team_info(league)
         current_squad_size = len(fresh_squad)
         active_bid_count = len(fresh_bids)
         available_slots = 15 - current_squad_size - active_bid_count
-        # Update bid amounts map for duplicate-bid detection
+        ctx.current_budget = fresh_team_info.get("budget", ctx.current_budget)
+        ctx.team_value = fresh_team_info.get("team_value", ctx.team_value)
+        pending_bid_total = sum(p.user_offer_price for p in fresh_bids)
+        max_debt = int(ctx.team_value * (self.settings.max_debt_pct_of_team_value / 100))
+        ctx.flip_budget = _compute_flip_budget(
+            ctx.matchday_phase.phase, ctx.current_budget, pending_bid_total, max_debt
+        )
         ctx.my_bid_amounts = {p.id: p.user_offer_price for p in fresh_bids}
 
         console.print(

--- a/tests/test_flip_budget.py
+++ b/tests/test_flip_budget.py
@@ -1,0 +1,39 @@
+"""Tests for flip-budget math used by the auto-trade session.
+
+The helper is called twice per session: once when the session context
+is built, and again inside the trade phase after earlier phases
+(sells, squad optimization, bid cancellations) have changed the
+underlying numbers.
+"""
+
+from rehoboam.auto_trader import _compute_flip_budget
+
+
+class TestComputeFlipBudget:
+    def test_locked_phase_returns_zero(self):
+        assert _compute_flip_budget("locked", 10_000_000, 0, 5_000_000) == 0
+
+    def test_moderate_phase_subtracts_pending_bids(self):
+        assert _compute_flip_budget("moderate", 20_000_000, 5_000_000, 10_000_000) == 15_000_000
+
+    def test_moderate_phase_ignores_max_debt(self):
+        assert _compute_flip_budget("moderate", 10_000_000, 0, 99_000_000) == 10_000_000
+
+    def test_aggressive_phase_adds_max_debt(self):
+        assert _compute_flip_budget("aggressive", 10_000_000, 2_000_000, 15_000_000) == 23_000_000
+
+    def test_canceling_bid_frees_budget(self):
+        # Regression guard for the "stale flip_budget" bug: after a bid
+        # cancel, pending_bid_total drops, and the trade phase must see
+        # the freed cash.
+        before = _compute_flip_budget("moderate", 21_000_000, 18_000_000, 0)
+        after_cancel = _compute_flip_budget("moderate", 21_000_000, 8_000_000, 0)
+        assert after_cancel - before == 10_000_000
+
+    def test_sell_increases_budget(self):
+        # Regression guard for the same bug via a different trigger:
+        # a mid-session sell raises current_budget, and the trade phase
+        # must see the proceeds.
+        before = _compute_flip_budget("moderate", 3_000_000, 0, 0)
+        after_sell = _compute_flip_budget("moderate", 21_000_000, 0, 0)
+        assert after_sell - before == 18_000_000


### PR DESCRIPTION
## Summary

- `run_unified_trade_phase` now re-fetches team info + bids and recomputes `ctx.flip_budget` against fresh numbers before deciding which candidates are affordable.
- Extracted the per-phase flip-budget math into a pure helper (`_compute_flip_budget`) so context-build and trade-phase refresh use the same formula.

## Why

The session context captured `flip_budget` at start-of-session and never refreshed it, even though sell monitoring, squad optimization, and bid compliance/evaluation all mutate the inputs. Affordable candidates were being skipped because the budget snapshot reflected pre-sell / pre-cancel state.

**Observed in production on 2026-04-18 22:00 CEST** (from `AppTraces` on Azure):

```
✓  Batz sold instantly to Kickbase           (+€11,212,093)
✓  Rönnow sold instantly to Kickbase         (+€6,941,602)
...
🤖 Unified Trade Phase (limit 7, phase: moderate)
📋 5 candidates (3 buys, 2 trade pairs)
Cannot afford Koulierakis (€10,041,686 > €2,804,243.0)
Cannot afford Mets        (€3,940,475  > €2,804,243.0)
Cannot afford Sander      (€9,850,730  > €2,804,243.0)
```

Two stop-loss sells freed €18.1M, then the trade phase immediately declared three candidates unaffordable against a stale €2.8M free-budget from before the sells. The same bug fires for bid cancels in the bid-evaluator phase.

## Test plan

- [x] `pytest tests/test_flip_budget.py` — new helper tests including regression guards for both triggers (sell-increases and cancel-frees)
- [x] `pytest tests/` — full suite: 192 passed
- [x] `ruff check` + `black --check`
- [ ] Post-merge: watch the next scheduled run on Azure — expect trade phase to see fresh budget after any sells/cancels in earlier phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)