### PR TITLE
fix: trend-aware loss-sell guard — don't sell rebounding players at a loss

### DIFF
--- a/rehoboam/auto_trader.py
+++ b/rehoboam/auto_trader.py
@@ -510,6 +510,21 @@ class AutoTrader:
         else:
             return 5.0  # Falling fast — take any profit
 
+    @staticmethod
+    def _can_loss_sell_with_replacement(trend_7d_pct: float | None) -> bool:
+        """Loss-sell guard: don't realize a loss while the price is rebounding.
+
+        The stop-loss and dead-weight branches realize a market-value loss
+        when a buy candidate is available. That makes sense for a player
+        whose price keeps sliding, but not for one already bouncing back —
+        selling there just locks in a loss the recovery would erase.
+        Returns False to defer the sell when the 7-day trend is a real
+        rebound (≥+1%/wk); falls back to legacy behavior otherwise.
+        """
+        if trend_7d_pct is None:
+            return True
+        return trend_7d_pct < 1.0
+
     def run_profit_sell_phase(self, league, ctx: EPSessionContext) -> list[AutoTradeResult]:
         """Trend-aware profit sell monitoring.
 
@@ -563,6 +578,11 @@ class AutoTrader:
             activity_feed_learner=self.activity_feed_learner,
         )
 
+        # Cache the 7d trend per player — used in both the stop-loss branch
+        # and the dead-weight loop below to keep loss-sells from firing while
+        # a player's price is rebounding.
+        trend_7d_by_id: dict[str, float | None] = {}
+
         sell_candidates = []
         for player in squad:
             if player.id in best_11_ids:
@@ -590,6 +610,7 @@ class AutoTrader:
                 trend_7d = trend.trend_7d_pct
             except Exception:
                 trend_7d = None
+            trend_7d_by_id[player.id] = trend_7d
 
             sell_threshold = self._sell_threshold_for_trend(trend_7d)
 
@@ -603,8 +624,14 @@ class AutoTrader:
                         f"Profit target ({sell_threshold:.0f}%) hit: +{profit_pct:.1f}% (€{profit:,}{trend_info})",
                     )
                 )
-            # Stop-loss: only if there's a better player to buy
-            elif profit_pct <= -5.0 and has_replacement:
+            # Stop-loss: only if there's a better player to buy AND the
+            # price isn't already rebounding (locking in a loss while the
+            # recovery is in progress is the worst possible exit).
+            elif (
+                profit_pct <= -5.0
+                and has_replacement
+                and self._can_loss_sell_with_replacement(trend_7d)
+            ):
                 sell_candidates.append(
                     (
                         player,
@@ -634,10 +661,29 @@ class AutoTrader:
             profit = player.market_value - player.buy_price
             profit_pct = (profit / player.buy_price) * 100
 
+            # Reuse the trend cached in the first loop. Every player that
+            # reaches this point passed the same best_11 + buy_price gates
+            # in loop 1 and either landed in `already_selling` (filtered
+            # above) or had its trend cached, so a missing key would mean
+            # an upstream filter changed — fetch defensively in that case.
+            if player.id in trend_7d_by_id:
+                trend_7d = trend_7d_by_id[player.id]
+            else:
+                try:
+                    trend_7d = trader.trend_service.get_trend(
+                        player.id, player.market_value, league.id
+                    ).trend_7d_pct
+                except Exception:
+                    trend_7d = None
+
             # Always sell dead weight at a profit.  At a loss, only sell
-            # when the EP pipeline has a replacement lined up — the freed
-            # slot is worth more than the loss.
-            if profit_pct >= 0 or has_replacement:
+            # when the EP pipeline has a replacement lined up *and* the
+            # price isn't already rebounding — the freed slot is worth
+            # more than the loss only if the loss isn't about to shrink
+            # on its own.
+            if profit_pct >= 0 or (
+                has_replacement and self._can_loss_sell_with_replacement(trend_7d)
+            ):
                 sell_candidates.append(
                     (
                         player,

--- a/tests/test_profit_sell_phase.py
+++ b/tests/test_profit_sell_phase.py
@@ -1,0 +1,42 @@
+"""Tests for the trend-aware loss-sell guard in AutoTrader.
+
+The profit-take side of the sell phase already adjusts its threshold based
+on 7-day price trend (`_sell_threshold_for_trend`). The loss side did not,
+which led to selling rebounding players at a locked-in loss the moment any
+unrelated buy candidate showed up. The guard tested here keeps loss-sells
+from firing while the player's price is meaningfully rebounding.
+"""
+
+from rehoboam.auto_trader import AutoTrader
+
+
+class TestCanLossSellWithReplacement:
+    def test_no_trend_data_allows_sell(self):
+        # No data → fall back to legacy behavior so we don't regress on
+        # players the trend service can't score yet.
+        assert AutoTrader._can_loss_sell_with_replacement(None) is True
+
+    def test_flat_trend_allows_sell(self):
+        assert AutoTrader._can_loss_sell_with_replacement(0.0) is True
+
+    def test_declining_trend_allows_sell(self):
+        assert AutoTrader._can_loss_sell_with_replacement(-3.5) is True
+
+    def test_steeply_declining_allows_sell(self):
+        assert AutoTrader._can_loss_sell_with_replacement(-12.0) is True
+
+    def test_mild_uptick_below_threshold_allows_sell(self):
+        # Sub-1% drift is noise, not a rebound — don't paralyze the bot.
+        assert AutoTrader._can_loss_sell_with_replacement(0.4) is True
+
+    def test_meaningful_rebound_blocks_sell(self):
+        # Svensson's case: down ~10% from buy, but bouncing back at +2%/wk.
+        # Realizing the loss now wastes the recovery already in progress.
+        assert AutoTrader._can_loss_sell_with_replacement(2.0) is False
+
+    def test_strong_uptrend_blocks_sell(self):
+        assert AutoTrader._can_loss_sell_with_replacement(5.0) is False
+
+    def test_threshold_boundary_blocks_sell(self):
+        # 1.0% is the cutoff — at-or-above counts as a rebound.
+        assert AutoTrader._can_loss_sell_with_replacement(1.0) is False


### PR DESCRIPTION
## Summary

- The stop-loss and dead-weight branches in `run_profit_sell_phase` were ignoring price trend, so a player like Svensson — bought at €24.3M, dipped to €19.4M, recovering at +2%/wk to €20.9M — got sold the moment any unrelated buy candidate appeared, locking in a ~€3M loss instead of letting the rebound continue.
- Adds `_can_loss_sell_with_replacement` which defers the sell when the 7-day trend is a real rebound (≥+1%/wk); falls back to legacy behavior when trend data is missing.
- Threads the cached 7-day trend through the dead-weight loop so both loss-side branches share the guard. Profit-take side already had its own trend-aware threshold (`_sell_threshold_for_trend`) and is unchanged.

## Behavior

| Scenario | Before | After |
|---|---|---|
| Loss ≥-5%, replacement available, trend rising +2%/wk | **Sells** (locks in loss) | Holds (recovery in progress) |
| Loss ≥-5%, replacement available, trend flat or down | Sells | Sells (unchanged) |
| Loss ≥-5%, no replacement | Holds | Holds (unchanged) |
| Profit ≥ trend-adjusted threshold | Sells | Sells (unchanged) |
| No trend data | Sells | Sells (unchanged — legacy fallback) |

## Test plan

- [x] `tests/test_profit_sell_phase.py` — new file, 8 unit tests covering the helper boundary (None, flat, decline, mild uptick, threshold rebound, strong uptrend)
- [x] `pytest tests/` — 200 passed, 1 skipped (no regressions)
- [x] `black --check` and `ruff check` clean
- [ ] Live sanity-check on next Azure run: confirm a rebounding player isn't auto-sold

🤖 Generated with [Claude Code](https://claude.com/claude-code)