### PR TITLE
feat: persist pending bids + tracked purchases in bid_learning.db

### DIFF
--- a/rehoboam/bid_learner.py
+++ b/rehoboam/bid_learner.py
@@ -179,6 +179,67 @@ class BidLearner:
             """
             )
 
+            # Operational state — bids placed but not yet resolved.
+            # Replaces the legacy `pending_bids.json` file, which Azure
+            # didn't sync between runs. One row per active auction; on
+            # win/loss, the row is deleted and the outcome is appended
+            # to `auction_outcomes` (which is the historical record).
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS pending_bids (
+                    player_id TEXT PRIMARY KEY,
+                    player_name TEXT NOT NULL,
+                    our_bid INTEGER NOT NULL,
+                    asking_price INTEGER NOT NULL,
+                    our_overbid_pct REAL NOT NULL,
+                    timestamp REAL NOT NULL,
+                    market_value INTEGER,
+                    player_value_score REAL
+                )
+            """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_pending_bids_timestamp
+                ON pending_bids(timestamp)
+            """
+            )
+
+            # Sell-plan join table: when a bid wins, the listed players
+            # are sold to recover budget. Normalized so we can answer
+            # "which auctions freed which slots" without parsing JSON.
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS pending_bid_sell_plans (
+                    pending_bid_player_id TEXT NOT NULL,
+                    sell_player_id TEXT NOT NULL,
+                    PRIMARY KEY (pending_bid_player_id, sell_player_id)
+                )
+            """
+            )
+
+            # Operational state — players we currently hold with their
+            # cost basis. Replaces `tracked_purchases.json`. On sell,
+            # the row is deleted and the closed flip is appended to
+            # `flip_outcomes` (which is the historical record).
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS tracked_purchases (
+                    player_id TEXT PRIMARY KEY,
+                    player_name TEXT NOT NULL,
+                    buy_price INTEGER NOT NULL,
+                    buy_date REAL NOT NULL,
+                    source TEXT
+                )
+            """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_tracked_purchases_buy_date
+                ON tracked_purchases(buy_date)
+            """
+            )
+
             conn.commit()
 
     def record_outcome(self, outcome: AuctionOutcome):
@@ -240,6 +301,161 @@ class BidLearner:
                     outcome.position,
                     1 if outcome.was_injured else 0,
                 ),
+            )
+            conn.commit()
+
+    # ------------------------------------------------------------------
+    # Operational state: pending bids + tracked purchases
+    #
+    # These two table families used to live in JSON files (`pending_bids.json`,
+    # `tracked_purchases.json`) which Azure wiped between runs. They live
+    # here so they ride along with the existing `bid_learning.db` blob sync.
+    # On lifecycle close (auction resolved / player sold) the row is deleted
+    # and the historical outcome is appended to `auction_outcomes` /
+    # `flip_outcomes` — those tables are the durable archive.
+    # ------------------------------------------------------------------
+
+    def add_pending_bid(
+        self,
+        *,
+        player_id: str,
+        player_name: str,
+        our_bid: int,
+        asking_price: int,
+        our_overbid_pct: float,
+        timestamp: float,
+        market_value: int | None = None,
+        player_value_score: float | None = None,
+        sell_plan_player_ids: list[str] | None = None,
+    ) -> None:
+        """Record a freshly placed bid as pending (outcome TBD).
+
+        Re-bidding on the same player overwrites the existing row — there's
+        only ever one active auction per player from our side.
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO pending_bids (
+                    player_id, player_name, our_bid, asking_price,
+                    our_overbid_pct, timestamp, market_value, player_value_score
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+                (
+                    player_id,
+                    player_name,
+                    our_bid,
+                    asking_price,
+                    our_overbid_pct,
+                    timestamp,
+                    market_value,
+                    player_value_score,
+                ),
+            )
+            # Replace sell-plan rows: an INSERT OR REPLACE on pending_bids
+            # alone leaves stale join rows behind, so clear and reinsert.
+            conn.execute(
+                "DELETE FROM pending_bid_sell_plans WHERE pending_bid_player_id = ?",
+                (player_id,),
+            )
+            if sell_plan_player_ids:
+                conn.executemany(
+                    """
+                    INSERT INTO pending_bid_sell_plans (
+                        pending_bid_player_id, sell_player_id
+                    ) VALUES (?, ?)
+                """,
+                    [(player_id, sp) for sp in sell_plan_player_ids],
+                )
+            conn.commit()
+
+    def get_pending_bids(self) -> list[dict[str, Any]]:
+        """Return all pending bids, oldest first, with their sell plans inlined."""
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(
+                """
+                SELECT player_id, player_name, our_bid, asking_price,
+                       our_overbid_pct, timestamp, market_value, player_value_score
+                FROM pending_bids
+                ORDER BY timestamp ASC
+            """
+            ).fetchall()
+
+            sell_plan_rows = conn.execute(
+                """
+                SELECT pending_bid_player_id, sell_player_id
+                FROM pending_bid_sell_plans
+            """
+            ).fetchall()
+
+        sell_plans: dict[str, list[str]] = {}
+        for r in sell_plan_rows:
+            sell_plans.setdefault(r["pending_bid_player_id"], []).append(r["sell_player_id"])
+
+        return [
+            {**dict(row), "sell_plan_player_ids": sell_plans.get(row["player_id"], [])}
+            for row in rows
+        ]
+
+    def delete_pending_bid(self, player_id: str) -> None:
+        """Remove the pending bid + its sell-plan rows. No-op if missing."""
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                "DELETE FROM pending_bid_sell_plans WHERE pending_bid_player_id = ?",
+                (player_id,),
+            )
+            conn.execute(
+                "DELETE FROM pending_bids WHERE player_id = ?",
+                (player_id,),
+            )
+            conn.commit()
+
+    def add_tracked_purchase(
+        self,
+        *,
+        player_id: str,
+        player_name: str,
+        buy_price: int,
+        buy_date: float,
+        source: str | None = None,
+    ) -> None:
+        """Record a player we now hold, with its cost basis.
+
+        Re-buying overwrites the existing row — the latest cost basis
+        wins so flip P&L always reflects the most recent purchase.
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO tracked_purchases (
+                    player_id, player_name, buy_price, buy_date, source
+                )
+                VALUES (?, ?, ?, ?, ?)
+            """,
+                (player_id, player_name, buy_price, buy_date, source),
+            )
+            conn.commit()
+
+    def get_tracked_purchase(self, player_id: str) -> dict[str, Any] | None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute(
+                """
+                SELECT player_id, player_name, buy_price, buy_date, source
+                FROM tracked_purchases
+                WHERE player_id = ?
+            """,
+                (player_id,),
+            ).fetchone()
+        return dict(row) if row else None
+
+    def delete_tracked_purchase(self, player_id: str) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                "DELETE FROM tracked_purchases WHERE player_id = ?",
+                (player_id,),
             )
             conn.commit()
 

--- a/rehoboam/learning/migration.py
+++ b/rehoboam/learning/migration.py
@@ -1,0 +1,123 @@
+"""One-time migration of legacy JSON state files into bid_learning.db.
+
+Until rehoboam ran on Azure, two JSON files in `logs/` held operational
+state — `pending_bids.json` (active auctions) and `tracked_purchases.json`
+(currently held players + cost basis). Azure's deployment only synced
+SQLite databases between runs, so these files were silently wiped each
+invocation.
+
+This module imports any leftover JSON content into the new
+`pending_bids` and `tracked_purchases` tables on first boot, then
+renames the source files to `.bak` so future boots skip the work.
+The DB rows are authoritative — if a row already exists for a given
+player_id, the JSON entry is discarded rather than overwriting it.
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from ..bid_learner import BidLearner
+
+logger = logging.getLogger(__name__)
+
+
+def _load_json(path: Path) -> Any | None:
+    if not path.exists():
+        return None
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except Exception as e:
+        logger.warning("Could not read %s for migration: %s", path, e)
+        return None
+
+
+def _archive(path: Path) -> None:
+    """Rename `foo.json` to `foo.json.bak` so we don't re-import next boot.
+
+    `Path.with_suffix` would replace the existing `.json` rather than
+    appending, so we build the target name explicitly.
+    """
+    bak = path.with_name(path.name + ".bak")
+    try:
+        path.rename(bak)
+    except Exception as e:
+        logger.warning("Could not archive %s after migration: %s", path, e)
+
+
+def _migrate_pending_bids(learner: BidLearner, path: Path) -> int:
+    data = _load_json(path)
+    if data is None:
+        return 0
+
+    existing_ids = {b["player_id"] for b in learner.get_pending_bids()}
+    imported = 0
+    for bid in data:
+        try:
+            player_id = bid["player_id"]
+            if player_id in existing_ids:
+                continue
+            learner.add_pending_bid(
+                player_id=player_id,
+                player_name=bid["player_name"],
+                our_bid=bid["our_bid"],
+                asking_price=bid["asking_price"],
+                our_overbid_pct=bid["our_overbid_pct"],
+                timestamp=bid["timestamp"],
+                market_value=bid.get("market_value"),
+                player_value_score=bid.get("player_value_score"),
+                sell_plan_player_ids=bid.get("sell_plan_player_ids"),
+            )
+            imported += 1
+        except (KeyError, TypeError) as e:
+            logger.warning("Skipping malformed pending_bid entry %r: %s", bid, e)
+
+    _archive(path)
+    return imported
+
+
+def _migrate_tracked_purchases(learner: BidLearner, path: Path) -> int:
+    data = _load_json(path)
+    if data is None:
+        return 0
+
+    imported = 0
+    for player_id, info in data.items():
+        try:
+            if learner.get_tracked_purchase(player_id) is not None:
+                continue
+            learner.add_tracked_purchase(
+                player_id=player_id,
+                player_name=info["player_name"],
+                buy_price=info["buy_price"],
+                buy_date=info["buy_date"],
+                source=info.get("source"),
+            )
+            imported += 1
+        except (KeyError, TypeError) as e:
+            logger.warning("Skipping malformed tracked_purchase %s=%r: %s", player_id, info, e)
+
+    _archive(path)
+    return imported
+
+
+def migrate_json_state_if_needed(
+    learner: BidLearner,
+    *,
+    pending_bids_path: Path,
+    tracked_purchases_path: Path,
+) -> dict[str, int]:
+    """Import legacy JSON state into BidLearner tables (idempotent).
+
+    Returns a dict of how many rows were imported per file, for logging.
+    Files that don't exist (already migrated, or fresh deploy) are
+    silently skipped. DB rows always win over JSON entries with the
+    same player_id — Azure-restored state is never clobbered by stale
+    local JSON.
+    """
+    return {
+        "pending_bids": _migrate_pending_bids(learner, pending_bids_path),
+        "tracked_purchases": _migrate_tracked_purchases(learner, tracked_purchases_path),
+    }

--- a/rehoboam/learning/migration.py
+++ b/rehoboam/learning/migration.py
@@ -54,6 +54,7 @@ def _migrate_pending_bids(learner: BidLearner, path: Path) -> int:
 
     existing_ids = {b["player_id"] for b in learner.get_pending_bids()}
     imported = 0
+    failed = 0
     for bid in data:
         try:
             player_id = bid["player_id"]
@@ -72,9 +73,15 @@ def _migrate_pending_bids(learner: BidLearner, path: Path) -> int:
             )
             imported += 1
         except (KeyError, TypeError) as e:
+            failed += 1
             logger.warning("Skipping malformed pending_bid entry %r: %s", bid, e)
 
-    _archive(path)
+    # If every entry failed (corrupted/mid-write JSON) keep the file on
+    # disk for human inspection — silently archiving it would permanently
+    # discard state the operator believes was migrated. A successful
+    # import (or a clean dedup against existing DB rows) still archives.
+    if imported > 0 or failed == 0:
+        _archive(path)
     return imported
 
 
@@ -84,6 +91,7 @@ def _migrate_tracked_purchases(learner: BidLearner, path: Path) -> int:
         return 0
 
     imported = 0
+    failed = 0
     for player_id, info in data.items():
         try:
             if learner.get_tracked_purchase(player_id) is not None:
@@ -97,9 +105,11 @@ def _migrate_tracked_purchases(learner: BidLearner, path: Path) -> int:
             )
             imported += 1
         except (KeyError, TypeError) as e:
+            failed += 1
             logger.warning("Skipping malformed tracked_purchase %s=%r: %s", player_id, info, e)
 
-    _archive(path)
+    if imported > 0 or failed == 0:
+        _archive(path)
     return imported
 
 

--- a/rehoboam/learning/tracker.py
+++ b/rehoboam/learning/tracker.py
@@ -1,55 +1,61 @@
 """Learning tracker — persists bid/purchase/flip outcomes for the bid_learner.
 
-Separates the file I/O and outcome-reconciliation logic from AutoTrader so the
-trading code stays focused on decisions and execution.
+Separates the operational state from AutoTrader so the trading code stays
+focused on decisions and execution. Two slices of state are managed:
 
-Two JSON files are maintained under `logs/`:
+- pending bids — auctions placed but not yet known to be won/lost
+- tracked purchases — players we currently hold, with their cost basis
 
-- `pending_bids.json` — bids we placed but don't yet know if we won
-- `tracked_purchases.json` — players we bought (for later flip profit calc)
+Both used to live in JSON files (`pending_bids.json`,
+`tracked_purchases.json`) under `logs/`. Azure didn't sync those, so
+they were silently wiped between runs. Both now live in `bid_learning.db`
+alongside `auction_outcomes` and `flip_outcomes` (which are the
+historical archive — operational rows are deleted on lifecycle close).
 
-On each `resolve_auctions()` call, pending bids are checked against the current
-squad + active bids to determine won/lost, and outcomes are pushed into the
-BidLearner (which is the real storage layer).
+On `__init__`, any leftover JSON files are imported into the DB and
+renamed to `.bak` (one-time, idempotent — see `migration.py`).
+
+On each `resolve_auctions()` call, pending bids are checked against the
+current squad + active bids to determine won/lost; outcomes are pushed
+into the BidLearner's history tables.
 """
 
-import json
+import logging
 import time
 from pathlib import Path
-from typing import Any
 
 from ..bid_learner import AuctionOutcome, BidLearner, FlipOutcome
+from .migration import migrate_json_state_if_needed
+
+logger = logging.getLogger(__name__)
 
 _LOG_DIR = Path("logs")
-_PENDING_BIDS = _LOG_DIR / "pending_bids.json"
-_TRACKED_PURCHASES = _LOG_DIR / "tracked_purchases.json"
-
-
-def _load_json(path: Path, default: Any) -> Any:
-    if not path.exists():
-        return default
-    try:
-        with open(path) as f:
-            return json.load(f)
-    except Exception:
-        return default
-
-
-def _save_json(path: Path, data: Any) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w") as f:
-        json.dump(data, f, indent=2)
+_PENDING_BIDS_JSON = _LOG_DIR / "pending_bids.json"
+_TRACKED_PURCHASES_JSON = _LOG_DIR / "tracked_purchases.json"
 
 
 class LearningTracker:
     """Persists trade outcomes for the adaptive bidding feedback loop.
 
-    All methods silently swallow exceptions — learning side effects must never
-    block the main trading loop. A failed write is not worse than skipped data.
+    All public methods silently swallow exceptions — learning side effects
+    must never block the main trading loop. A failed write is not worse
+    than skipped data.
     """
 
     def __init__(self, bid_learner: BidLearner):
         self.bid_learner = bid_learner
+
+        # One-time migration from legacy JSON state files. Idempotent:
+        # missing files are no-ops, and successful imports rename the
+        # source to `.bak` so subsequent boots skip the work.
+        try:
+            migrate_json_state_if_needed(
+                bid_learner,
+                pending_bids_path=_PENDING_BIDS_JSON,
+                tracked_purchases_path=_TRACKED_PURCHASES_JSON,
+            )
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning("State migration failed (continuing): %s", e)
 
     # ------------------------------------------------------------------
     # Bid placed → pending
@@ -71,23 +77,18 @@ class LearningTracker:
             asking_price = player.price
             overbid_pct = ((our_bid - asking_price) / asking_price * 100) if asking_price > 0 else 0
 
-            entry = {
-                "player_id": player.id,
-                "player_name": f"{player.first_name} {player.last_name}",
-                "our_bid": our_bid,
-                "asking_price": asking_price,
-                "our_overbid_pct": overbid_pct,
-                "timestamp": time.time(),
-                "market_value": getattr(player, "market_value", 0),
-            }
-            if sell_plan_player_ids:
-                entry["sell_plan_player_ids"] = sell_plan_player_ids
-
-            pending = _load_json(_PENDING_BIDS, [])
-            pending.append(entry)
-            _save_json(_PENDING_BIDS, pending)
-        except Exception:
-            pass
+            self.bid_learner.add_pending_bid(
+                player_id=player.id,
+                player_name=f"{player.first_name} {player.last_name}",
+                our_bid=our_bid,
+                asking_price=asking_price,
+                our_overbid_pct=overbid_pct,
+                timestamp=time.time(),
+                market_value=getattr(player, "market_value", 0),
+                sell_plan_player_ids=sell_plan_player_ids,
+            )
+        except Exception as e:
+            logger.warning("Failed to record bid placement: %s", e)
 
     # ------------------------------------------------------------------
     # Pending → resolved (won/lost)
@@ -111,30 +112,26 @@ class LearningTracker:
         """
         sell_plan_ids: list[str] = []
         try:
-            pending = _load_json(_PENDING_BIDS, [])
+            pending = self.bid_learner.get_pending_bids()
             if not pending:
                 return sell_plan_ids
 
-            still_pending = []
             for bid_data in pending:
                 player_id = bid_data["player_id"]
 
                 if player_id in squad_ids:
                     self._record_outcome(bid_data, won=True)
                     self._track_purchase(player_id, bid_data)
-                    # Collect sell plan IDs from bids we won — caller will
-                    # execute the sells to recover budget.
                     for sp_id in bid_data.get("sell_plan_player_ids", []):
                         if sp_id not in sell_plan_ids:
                             sell_plan_ids.append(sp_id)
+                    self.bid_learner.delete_pending_bid(player_id)
                 elif player_id not in active_bid_ids:
                     self._record_outcome(bid_data, won=False)
-                else:
-                    still_pending.append(bid_data)
-
-            _save_json(_PENDING_BIDS, still_pending)
-        except Exception:
-            pass
+                    self.bid_learner.delete_pending_bid(player_id)
+                # else: still pending — leave the row in place
+        except Exception as e:
+            logger.warning("Auction resolution failed: %s", e)
         return sell_plan_ids
 
     def _record_outcome(self, bid_data: dict, won: bool) -> None:
@@ -151,8 +148,8 @@ class LearningTracker:
                 market_value=bid_data.get("market_value"),
             )
             self.bid_learner.record_outcome(outcome)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning("Failed to record auction outcome: %s", e)
 
     # ------------------------------------------------------------------
     # Purchase tracking (for later flip profit calc)
@@ -161,15 +158,15 @@ class LearningTracker:
     def _track_purchase(self, player_id: str, bid_data: dict) -> None:
         """Record that we bought a player — used later to compute flip profit."""
         try:
-            purchases = _load_json(_TRACKED_PURCHASES, {})
-            purchases[player_id] = {
-                "player_name": bid_data["player_name"],
-                "buy_price": bid_data["our_bid"],
-                "buy_date": bid_data["timestamp"],
-            }
-            _save_json(_TRACKED_PURCHASES, purchases)
-        except Exception:
-            pass
+            self.bid_learner.add_tracked_purchase(
+                player_id=player_id,
+                player_name=bid_data["player_name"],
+                buy_price=bid_data["our_bid"],
+                buy_date=bid_data["timestamp"],
+                source="real",
+            )
+        except Exception as e:
+            logger.warning("Failed to track purchase: %s", e)
 
     # ------------------------------------------------------------------
     # Flip outcome (bought + sold → profit recorded)
@@ -181,11 +178,10 @@ class LearningTracker:
         Silently skips if we have no record of buying this player.
         """
         try:
-            purchases = _load_json(_TRACKED_PURCHASES, {})
-            if player.id not in purchases:
+            purchase = self.bid_learner.get_tracked_purchase(player.id)
+            if purchase is None:
                 return
 
-            purchase = purchases[player.id]
             buy_price = purchase["buy_price"]
             buy_date = purchase["buy_date"]
             sell_date = time.time()
@@ -209,9 +205,6 @@ class LearningTracker:
                 was_injured=(player.status != 0) if hasattr(player, "status") else False,
             )
             self.bid_learner.record_flip(outcome)
-
-            # Drop from tracked purchases now that flip is closed
-            del purchases[player.id]
-            _save_json(_TRACKED_PURCHASES, purchases)
-        except Exception:
-            pass
+            self.bid_learner.delete_tracked_purchase(player.id)
+        except Exception as e:
+            logger.warning("Failed to record flip outcome: %s", e)

--- a/tests/test_bid_state_db.py
+++ b/tests/test_bid_state_db.py
@@ -1,0 +1,245 @@
+"""Tests for the SQLite-backed bid/purchase state replacing legacy JSON files.
+
+The bot used to keep `pending_bids.json` and `tracked_purchases.json` in
+the working directory. Azure wiped those between runs because only
+`bid_learning.db` was synced to blob storage. These tests cover the new
+in-DB equivalents living alongside the existing learning tables in
+`bid_learning.db`.
+"""
+
+import time
+
+import pytest
+
+from rehoboam.bid_learner import BidLearner
+
+
+@pytest.fixture
+def learner(tmp_path):
+    return BidLearner(db_path=tmp_path / "bid_learning.db")
+
+
+# ---------------------------------------------------------------------------
+# pending_bids
+# ---------------------------------------------------------------------------
+
+
+class TestPendingBids:
+    def test_get_pending_bids_empty_by_default(self, learner):
+        assert learner.get_pending_bids() == []
+
+    def test_add_and_get_simple_bid(self, learner):
+        ts = time.time()
+        learner.add_pending_bid(
+            player_id="123",
+            player_name="Test Player",
+            our_bid=10_000_000,
+            asking_price=8_000_000,
+            our_overbid_pct=25.0,
+            timestamp=ts,
+            market_value=8_500_000,
+            player_value_score=72.5,
+        )
+
+        bids = learner.get_pending_bids()
+        assert len(bids) == 1
+        bid = bids[0]
+        assert bid["player_id"] == "123"
+        assert bid["player_name"] == "Test Player"
+        assert bid["our_bid"] == 10_000_000
+        assert bid["asking_price"] == 8_000_000
+        assert bid["our_overbid_pct"] == 25.0
+        assert bid["timestamp"] == ts
+        assert bid["market_value"] == 8_500_000
+        assert bid["player_value_score"] == 72.5
+        # Bids without sell plans should expose an empty list, never None,
+        # so resolve_auctions can iterate without an isinstance check.
+        assert bid["sell_plan_player_ids"] == []
+
+    def test_add_bid_with_sell_plan_persists_join_rows(self, learner):
+        # Sell plans are stored in a normalized join table so future
+        # analytics can ask "which bids freed which slot" without parsing
+        # JSON blobs.
+        learner.add_pending_bid(
+            player_id="555",
+            player_name="Star Striker",
+            our_bid=20_000_000,
+            asking_price=18_000_000,
+            our_overbid_pct=11.1,
+            timestamp=time.time(),
+            sell_plan_player_ids=["111", "222"],
+        )
+
+        bids = learner.get_pending_bids()
+        assert len(bids) == 1
+        # Order doesn't matter — caller only iterates the list.
+        assert sorted(bids[0]["sell_plan_player_ids"]) == ["111", "222"]
+
+    def test_get_pending_bids_returns_sorted_by_timestamp(self, learner):
+        learner.add_pending_bid(
+            player_id="A",
+            player_name="A",
+            our_bid=1,
+            asking_price=1,
+            our_overbid_pct=0.0,
+            timestamp=200.0,
+        )
+        learner.add_pending_bid(
+            player_id="B",
+            player_name="B",
+            our_bid=1,
+            asking_price=1,
+            our_overbid_pct=0.0,
+            timestamp=100.0,
+        )
+
+        bids = learner.get_pending_bids()
+        # Oldest first matches resolve_auctions semantics — earliest bids
+        # tend to be the ones whose auctions resolve first.
+        assert [b["player_id"] for b in bids] == ["B", "A"]
+
+    def test_delete_pending_bid_removes_row(self, learner):
+        learner.add_pending_bid(
+            player_id="123",
+            player_name="x",
+            our_bid=1,
+            asking_price=1,
+            our_overbid_pct=0.0,
+            timestamp=time.time(),
+        )
+        learner.delete_pending_bid("123")
+        assert learner.get_pending_bids() == []
+
+    def test_delete_pending_bid_also_removes_sell_plan_rows(self, learner):
+        # A dangling sell-plan row would be a silent FK leak — every
+        # delete must clear both tables.
+        learner.add_pending_bid(
+            player_id="123",
+            player_name="x",
+            our_bid=1,
+            asking_price=1,
+            our_overbid_pct=0.0,
+            timestamp=time.time(),
+            sell_plan_player_ids=["A", "B"],
+        )
+        learner.delete_pending_bid("123")
+
+        # Re-adding the same player_id with no sell plan must not see
+        # ghosts from the previous insert.
+        learner.add_pending_bid(
+            player_id="123",
+            player_name="x",
+            our_bid=1,
+            asking_price=1,
+            our_overbid_pct=0.0,
+            timestamp=time.time(),
+        )
+        bids = learner.get_pending_bids()
+        assert len(bids) == 1
+        assert bids[0]["sell_plan_player_ids"] == []
+
+    def test_delete_unknown_pending_bid_is_noop(self, learner):
+        # resolve_auctions can race with squad fetches — being asked to
+        # delete a bid that's already gone must not raise.
+        learner.delete_pending_bid("nonexistent")  # no exception
+
+    def test_player_id_is_unique(self, learner):
+        # Re-placing a bid on the same player should overwrite, not
+        # duplicate.  Two pending rows for the same player would make
+        # resolve_auctions ambiguous.
+        learner.add_pending_bid(
+            player_id="123",
+            player_name="x",
+            our_bid=1_000_000,
+            asking_price=1_000_000,
+            our_overbid_pct=0.0,
+            timestamp=time.time(),
+        )
+        learner.add_pending_bid(
+            player_id="123",
+            player_name="x",
+            our_bid=2_000_000,
+            asking_price=1_500_000,
+            our_overbid_pct=33.3,
+            timestamp=time.time(),
+        )
+
+        bids = learner.get_pending_bids()
+        assert len(bids) == 1
+        assert bids[0]["our_bid"] == 2_000_000
+
+
+# ---------------------------------------------------------------------------
+# tracked_purchases
+# ---------------------------------------------------------------------------
+
+
+class TestTrackedPurchases:
+    def test_get_unknown_purchase_returns_none(self, learner):
+        assert learner.get_tracked_purchase("missing") is None
+
+    def test_add_and_get_purchase(self, learner):
+        ts = time.time()
+        learner.add_tracked_purchase(
+            player_id="42",
+            player_name="Test Player",
+            buy_price=5_000_000,
+            buy_date=ts,
+            source="real",
+        )
+
+        p = learner.get_tracked_purchase("42")
+        assert p is not None
+        assert p["player_id"] == "42"
+        assert p["player_name"] == "Test Player"
+        assert p["buy_price"] == 5_000_000
+        assert p["buy_date"] == ts
+        assert p["source"] == "real"
+
+    def test_source_defaults_to_none_when_not_provided(self, learner):
+        # Real bids we won have source='real'; squad-snapshot detections
+        # have source='detected'; an explicit None is fine for callers
+        # that don't track provenance.
+        learner.add_tracked_purchase(
+            player_id="99",
+            player_name="x",
+            buy_price=1,
+            buy_date=1.0,
+        )
+        p = learner.get_tracked_purchase("99")
+        assert p is not None
+        assert p["source"] is None
+
+    def test_delete_tracked_purchase(self, learner):
+        learner.add_tracked_purchase(
+            player_id="42",
+            player_name="x",
+            buy_price=1,
+            buy_date=1.0,
+        )
+        learner.delete_tracked_purchase("42")
+        assert learner.get_tracked_purchase("42") is None
+
+    def test_delete_unknown_purchase_is_noop(self, learner):
+        learner.delete_tracked_purchase("missing")  # no exception
+
+    def test_player_id_is_unique(self, learner):
+        # If we somehow buy the same player twice without a sell in
+        # between, the latest cost basis wins — flip P&L should reflect
+        # the most recent purchase.
+        learner.add_tracked_purchase(
+            player_id="42",
+            player_name="x",
+            buy_price=1_000_000,
+            buy_date=1.0,
+        )
+        learner.add_tracked_purchase(
+            player_id="42",
+            player_name="x",
+            buy_price=2_000_000,
+            buy_date=2.0,
+        )
+
+        p = learner.get_tracked_purchase("42")
+        assert p["buy_price"] == 2_000_000
+        assert p["buy_date"] == 2.0

--- a/tests/test_state_migration.py
+++ b/tests/test_state_migration.py
@@ -1,0 +1,213 @@
+"""Tests for the one-time JSON → SQLite migration of pending bids and
+tracked purchases.
+
+The migration runs on `LearningTracker` construction and is idempotent —
+once the JSON files have been imported and renamed to `.bak`, subsequent
+boots are no-ops.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from rehoboam.bid_learner import BidLearner
+from rehoboam.learning.migration import migrate_json_state_if_needed
+
+
+@pytest.fixture
+def learner(tmp_path):
+    return BidLearner(db_path=tmp_path / "bid_learning.db")
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data))
+
+
+class TestMigratePendingBids:
+    def test_imports_existing_pending_bids_json(self, tmp_path, learner):
+        pending_path = tmp_path / "pending_bids.json"
+        _write_json(
+            pending_path,
+            [
+                {
+                    "player_id": "10771",
+                    "player_name": "Yan Diomande",
+                    "our_bid": 14_097_338,
+                    "asking_price": 12_477_338,
+                    "our_overbid_pct": 12.98,
+                    "timestamp": 1_762_686_174.95,
+                    "market_value": 1_821_396,
+                }
+            ],
+        )
+
+        migrate_json_state_if_needed(
+            learner,
+            pending_bids_path=pending_path,
+            tracked_purchases_path=tmp_path / "missing.json",
+        )
+
+        bids = learner.get_pending_bids()
+        assert len(bids) == 1
+        assert bids[0]["player_id"] == "10771"
+        assert bids[0]["our_bid"] == 14_097_338
+        # Successful import renames the JSON to .bak so the next boot
+        # doesn't re-import (and we keep a recovery copy for one cycle).
+        assert not pending_path.exists()
+        assert pending_path.with_suffix(".json.bak").exists()
+
+    def test_imports_pending_bid_sell_plans(self, tmp_path, learner):
+        pending_path = tmp_path / "pending_bids.json"
+        _write_json(
+            pending_path,
+            [
+                {
+                    "player_id": "555",
+                    "player_name": "Star",
+                    "our_bid": 1,
+                    "asking_price": 1,
+                    "our_overbid_pct": 0.0,
+                    "timestamp": 1.0,
+                    "sell_plan_player_ids": ["111", "222"],
+                }
+            ],
+        )
+
+        migrate_json_state_if_needed(
+            learner,
+            pending_bids_path=pending_path,
+            tracked_purchases_path=tmp_path / "missing.json",
+        )
+
+        bids = learner.get_pending_bids()
+        assert sorted(bids[0]["sell_plan_player_ids"]) == ["111", "222"]
+
+    def test_no_pending_bids_file_is_noop(self, tmp_path, learner):
+        # Fresh deploys without legacy state must not crash.
+        migrate_json_state_if_needed(
+            learner,
+            pending_bids_path=tmp_path / "missing.json",
+            tracked_purchases_path=tmp_path / "missing.json",
+        )
+        assert learner.get_pending_bids() == []
+
+    def test_migration_is_idempotent_via_bak_rename(self, tmp_path, learner):
+        pending_path = tmp_path / "pending_bids.json"
+        _write_json(
+            pending_path,
+            [
+                {
+                    "player_id": "X",
+                    "player_name": "x",
+                    "our_bid": 1,
+                    "asking_price": 1,
+                    "our_overbid_pct": 0.0,
+                    "timestamp": 1.0,
+                }
+            ],
+        )
+
+        # First call imports.
+        migrate_json_state_if_needed(
+            learner,
+            pending_bids_path=pending_path,
+            tracked_purchases_path=tmp_path / "missing.json",
+        )
+        # Second call must not double-insert (file is gone, .bak remains).
+        migrate_json_state_if_needed(
+            learner,
+            pending_bids_path=pending_path,
+            tracked_purchases_path=tmp_path / "missing.json",
+        )
+
+        assert len(learner.get_pending_bids()) == 1
+
+
+class TestMigrateTrackedPurchases:
+    def test_imports_existing_tracked_purchases_json(self, tmp_path, learner):
+        purchases_path = tmp_path / "tracked_purchases.json"
+        _write_json(
+            purchases_path,
+            {
+                "10115": {
+                    "player_name": "Svensson",
+                    "buy_price": 25_066_414,
+                    "buy_date": 1_776_501_427.5,
+                    "source": "detected",
+                },
+                "2855": {
+                    "player_name": "Ragnar Ache",
+                    "buy_price": 10_224_738,
+                    "buy_date": 1_763_030_992.5,
+                    # Missing 'source' — older entries didn't have it; default to None.
+                },
+            },
+        )
+
+        migrate_json_state_if_needed(
+            learner,
+            pending_bids_path=tmp_path / "missing.json",
+            tracked_purchases_path=purchases_path,
+        )
+
+        svensson = learner.get_tracked_purchase("10115")
+        assert svensson is not None
+        assert svensson["buy_price"] == 25_066_414
+        assert svensson["source"] == "detected"
+
+        ache = learner.get_tracked_purchase("2855")
+        assert ache is not None
+        assert ache["source"] is None
+
+        assert not purchases_path.exists()
+        assert purchases_path.with_suffix(".json.bak").exists()
+
+    def test_no_tracked_purchases_file_is_noop(self, tmp_path, learner):
+        migrate_json_state_if_needed(
+            learner,
+            pending_bids_path=tmp_path / "missing.json",
+            tracked_purchases_path=tmp_path / "missing.json",
+        )
+        assert learner.get_tracked_purchase("anything") is None
+
+
+class TestMigrationDoesNotOverwriteExistingDbRows:
+    def test_skips_import_when_table_already_populated(self, tmp_path, learner):
+        # If the DB already has rows (e.g. Azure restored a backup that
+        # included the new tables) we must NOT re-import an old JSON
+        # left lying around — that would resurrect stale state.
+        learner.add_tracked_purchase(
+            player_id="10115",
+            player_name="Svensson (DB)",
+            buy_price=22_000_000,
+            buy_date=999.0,
+            source="real",
+        )
+
+        purchases_path = tmp_path / "tracked_purchases.json"
+        _write_json(
+            purchases_path,
+            {
+                "10115": {
+                    "player_name": "Svensson (JSON)",
+                    "buy_price": 25_066_414,
+                    "buy_date": 1.0,
+                    "source": "detected",
+                }
+            },
+        )
+
+        migrate_json_state_if_needed(
+            learner,
+            pending_bids_path=tmp_path / "missing.json",
+            tracked_purchases_path=purchases_path,
+        )
+
+        # DB row wins; JSON is still renamed (to prevent re-import next boot).
+        p = learner.get_tracked_purchase("10115")
+        assert p["player_name"] == "Svensson (DB)"
+        assert p["buy_price"] == 22_000_000
+        assert not purchases_path.exists()
+        assert purchases_path.with_suffix(".json.bak").exists()

--- a/tests/test_state_migration.py
+++ b/tests/test_state_migration.py
@@ -173,6 +173,54 @@ class TestMigrateTrackedPurchases:
         assert learner.get_tracked_purchase("anything") is None
 
 
+class TestMigrationPreservesJsonOnPartialFailure:
+    """If a JSON file is malformed (mid-write, schema drift, corrupted),
+    the migration must NOT silently archive it — that would permanently
+    discard state the operator believes was migrated. We rename to .bak
+    only when every entry imported cleanly OR when at least one entry
+    succeeded and the rest were genuine schema-mismatch skips.
+    """
+
+    def test_archive_skipped_when_all_entries_malformed(self, tmp_path, learner):
+        purchases_path = tmp_path / "tracked_purchases.json"
+        # Every entry missing required `buy_price` — every row will fail.
+        _write_json(
+            purchases_path,
+            {
+                "1": {"player_name": "x", "buy_date": 1.0},
+                "2": {"player_name": "y", "buy_date": 2.0},
+            },
+        )
+
+        migrate_json_state_if_needed(
+            learner,
+            pending_bids_path=tmp_path / "missing.json",
+            tracked_purchases_path=purchases_path,
+        )
+
+        # JSON must still be on disk for human inspection / retry.
+        assert purchases_path.exists()
+        assert not purchases_path.with_suffix(".json.bak").exists()
+
+    def test_archive_skipped_when_pending_bids_all_malformed(self, tmp_path, learner):
+        pending_path = tmp_path / "pending_bids.json"
+        _write_json(
+            pending_path,
+            [
+                {"player_id": "x"},  # missing every other required field
+            ],
+        )
+
+        migrate_json_state_if_needed(
+            learner,
+            pending_bids_path=pending_path,
+            tracked_purchases_path=tmp_path / "missing.json",
+        )
+
+        assert pending_path.exists()
+        assert not pending_path.with_suffix(".json.bak").exists()
+
+
 class TestMigrationDoesNotOverwriteExistingDbRows:
     def test_skips_import_when_table_already_populated(self, tmp_path, learner):
         # If the DB already has rows (e.g. Azure restored a backup that


### PR DESCRIPTION
## Summary

The two operational state files (`pending_bids.json`, `tracked_purchases.json`) lived in `logs/` and were **never included in the Azure blob sync**, so each scheduled run started with empty state. Flip P&L wasn't recorded (only 3 rows in `flip_outcomes` despite weeks of trading). Auctions weren't reconciled across runs. And multi-year analytics had nothing to query against.

Both now live in `bid_learning.db` alongside `auction_outcomes` and `flip_outcomes` (the historical archive). On lifecycle close (auction resolved, player sold), the operational row is deleted and the durable outcome is appended — same separation as before, now in one queryable DB.

## Changes

- **Schema** (`bid_learner.py`): adds `pending_bids` + `pending_bid_sell_plans` (normalized join) and `tracked_purchases` tables, with appropriate indexes.
- **CRUD on BidLearner**: `add_pending_bid` / `get_pending_bids` / `delete_pending_bid` / `add_tracked_purchase` / `get_tracked_purchase` / `delete_tracked_purchase`.
- **`LearningTracker` refactor**: replaces 4 JSON I/O sites with BidLearner method calls. Public API unchanged — no callers updated.
- **One-time migration** (`learning/migration.py`): on first boot, imports any leftover JSON content into the new tables and renames the source files to `.bak`. Idempotent on re-run. DB rows always win over JSON entries with the same `player_id` so an Azure-restored backup is never clobbered by stale local JSON.

## Test plan

- [x] 14 CRUD tests in `tests/test_bid_state_db.py` (empty start, sell-plan join rows, idempotent re-add, delete cascading, unique-on-player-id)
- [x] 7 migration tests in `tests/test_state_migration.py` (import, archive, idempotency, missing files, DB-wins-over-JSON)
- [x] Full suite: 213 passed, 1 skipped — no regressions
- [x] `black --check` and `ruff check` clean
- [ ] Live verification on next Azure run: confirm `tracked_purchases.json.bak` appears in blob storage and `flip_outcomes` rows start accumulating again

## Follow-ups (for Linear)

- Add a `rehoboam fetch-azure-state` CLI to pull the live blob locally for debugging.
- Position-aware `has_replacement` check in the sell phase (separate from PR #22's trend guard).
- Refresh stale `performance_cache` so 25/26 game data isn't missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)