### PR TITLE
fix: scorer reads `mp` (real API field) instead of nonexistent `t`

### DIFF
--- a/rehoboam/scoring/scorer.py
+++ b/rehoboam/scoring/scorer.py
@@ -35,12 +35,30 @@ _DEFAULT_FORM: tuple[float, float] = (10.0, 5.0)
 # ---------------------------------------------------------------------------
 
 
+def _parse_minutes(mp) -> int:
+    """Parse Kickbase ``mp`` minutes-played values (e.g. ``"13'"``) to int.
+
+    Kickbase ships minutes as a string with a trailing apostrophe.  Anything
+    that doesn't match the expected pattern (None, empty string, future
+    matches without minutes, extra-time formats we've never observed)
+    degrades silently to 0 — a single oddly-formatted entry must not
+    poison the whole player score.
+    """
+    if not mp:
+        return 0
+    s = str(mp).rstrip("'")
+    try:
+        return int(s)
+    except ValueError:
+        return 0
+
+
 def _extract_consistency(performance: dict) -> tuple[int, float | None]:
     """Extract games played and consistency score from performance data.
 
     Parses ``performance["it"]`` — a list of season dicts each containing
-    ``"ph"`` (list of match dicts with ``"p"`` = points and ``"t"`` =
-    minutes).
+    ``"ph"`` (list of match dicts with ``"p"`` = points and ``"mp"`` =
+    minutes-played string).
 
     Returns:
         (games_played, consistency_score)
@@ -60,8 +78,12 @@ def _extract_consistency(performance: dict) -> tuple[int, float | None]:
 
         matches = current_season.get("ph", [])
 
-        # Only count matches where the player actually appeared
-        matches_played = [m for m in matches if m.get("p", 0) != 0 or m.get("t", 0) > 0]
+        # Only count matches where the player actually appeared.  A 0-point
+        # appearance with non-zero minutes is still a played game (think
+        # late sub who didn't touch the ball) — keep those in the sample.
+        matches_played = [
+            m for m in matches if m.get("p", 0) != 0 or _parse_minutes(m.get("mp")) > 0
+        ]
         games_played = len(matches_played)
 
         if games_played == 0:
@@ -107,7 +129,7 @@ def _extract_minutes_trend(performance: dict) -> tuple[str | None, float | None]
             return None, None
 
         matches = current_season.get("ph", [])
-        minutes_data = [m["t"] for m in matches if "t" in m]
+        minutes_data = [_parse_minutes(m["mp"]) for m in matches if "mp" in m]
 
         if len(minutes_data) < 2:
             return None, None
@@ -152,7 +174,9 @@ def _extract_recent_form(performance: dict, window: int = 5) -> float | None:
             return None
 
         matches = current_season.get("ph", [])
-        matches_played = [m for m in matches if m.get("p", 0) != 0 or m.get("t", 0) > 0]
+        matches_played = [
+            m for m in matches if m.get("p", 0) != 0 or _parse_minutes(m.get("mp")) > 0
+        ]
 
         if len(matches_played) < 2:
             return None

--- a/rehoboam/scoring/scorer.py
+++ b/rehoboam/scoring/scorer.py
@@ -38,10 +38,12 @@ _DEFAULT_FORM: tuple[float, float] = (10.0, 5.0)
 def _parse_minutes(mp) -> int:
     """Parse Kickbase ``mp`` minutes-played values (e.g. ``"13'"``) to int.
 
-    Kickbase ships minutes as a string with a trailing apostrophe.  Anything
-    that doesn't match the expected pattern (None, empty string, future
-    matches without minutes, extra-time formats we've never observed)
-    degrades silently to 0 — a single oddly-formatted entry must not
+    Kickbase ships minutes as a string with a trailing apostrophe.
+    Extra-time matches arrive as ``"90+5'"`` per common football
+    convention (regulation + stoppage); both components are summed so
+    a 95-minute appearance counts as 95, not 0. Anything else (None,
+    empty string, future matches without minutes, truly malformed
+    entries) degrades silently to 0 — a single odd entry must not
     poison the whole player score.
     """
     if not mp:
@@ -50,7 +52,13 @@ def _parse_minutes(mp) -> int:
     try:
         return int(s)
     except ValueError:
-        return 0
+        pass
+    if "+" in s:
+        try:
+            return sum(int(part) for part in s.split("+"))
+        except ValueError:
+            return 0
+    return 0
 
 
 def _extract_consistency(performance: dict) -> tuple[int, float | None]:

--- a/rehoboam/value_calculator.py
+++ b/rehoboam/value_calculator.py
@@ -194,11 +194,12 @@ class PlayerValue:
             # matches contains ALL team games, but player might not have played in all
             # A player "played" if they have points != 0 (even negative) OR minutes > 0
             # Filter to only matches where player was on the field
+            from .scoring.scorer import _parse_minutes
+
             matches_played = []
             for match in matches:
                 points = match.get("p", 0)
-                # Some matches might have "t" (minutes) field, check that too
-                minutes = match.get("t", 0)
+                minutes = _parse_minutes(match.get("mp"))
                 # If player had points (positive or negative) OR had minutes, they played
                 if points != 0 or minutes > 0:
                     matches_played.append(match)
@@ -267,12 +268,9 @@ class PlayerValue:
 
             matches = current_season.get("ph", [])
 
-            # Get minutes from each match (field "t" = time/minutes)
-            minutes_data = []
-            for match in matches:
-                minutes = match.get("t", None)
-                if minutes is not None:
-                    minutes_data.append(minutes)
+            from .scoring.scorer import _parse_minutes
+
+            minutes_data = [_parse_minutes(match["mp"]) for match in matches if "mp" in match]
 
             if len(minutes_data) < 2:
                 return None, None, None

--- a/tests/test_scoring/test_scorer.py
+++ b/tests/test_scoring/test_scorer.py
@@ -6,6 +6,7 @@ from rehoboam.scoring.scorer import (
     _extract_consistency,
     _extract_minutes_trend,
     _grade_data_quality,
+    _parse_minutes,
     score_player,
 )
 
@@ -216,14 +217,14 @@ class TestExtractConsistency:
         assert consistency is None
 
     def test_single_game(self):
-        perf = self._make_perf([{"p": 30, "t": 90}])
+        perf = self._make_perf([{"p": 30, "mp": "90'"}])
         games, consistency = _extract_consistency(perf)
         assert games == 1
         assert consistency == 0.5  # medium confidence
 
     def test_consistent_player(self):
         # All same points → CV=0 → consistency=1.0
-        perf = self._make_perf([{"p": 20, "t": 90}] * 10)
+        perf = self._make_perf([{"p": 20, "mp": "90'"}] * 10)
         games, consistency = _extract_consistency(perf)
         assert games == 10
         assert consistency == 1.0
@@ -232,13 +233,27 @@ class TestExtractConsistency:
         # Games where player didn't play (0 points, 0 minutes) should be excluded
         perf = self._make_perf(
             [
-                {"p": 0, "t": 0},  # didn't play
-                {"p": 30, "t": 90},
-                {"p": 20, "t": 90},
+                {"p": 0, "mp": "0'"},  # didn't play
+                {"p": 30, "mp": "90'"},
+                {"p": 20, "mp": "90'"},
             ]
         )
         games, consistency = _extract_consistency(perf)
         assert games == 2
+
+    def test_brief_cameo_with_zero_points_still_counts(self):
+        # Player came in for 5 minutes, scored 0 — that IS playing.
+        # Pre-fix this was excluded because the t-field filter degraded
+        # to `p != 0`; with mp wired up, minutes>0 keeps the appearance.
+        perf = self._make_perf(
+            [
+                {"p": 0, "mp": "5'"},
+                {"p": 30, "mp": "90'"},
+                {"p": 20, "mp": "90'"},
+            ]
+        )
+        games, _ = _extract_consistency(perf)
+        assert games == 3
 
 
 class TestExtractMinutesTrend:
@@ -252,20 +267,62 @@ class TestExtractMinutesTrend:
 
     def test_increasing_minutes(self):
         # First half low, second half high
-        matches = [{"t": 30}] * 4 + [{"t": 90}] * 4
+        matches = [{"mp": "30'"}] * 4 + [{"mp": "90'"}] * 4
         perf = self._make_perf(matches)
         trend, avg = _extract_minutes_trend(perf)
         assert trend == "increasing"
 
     def test_decreasing_minutes(self):
-        matches = [{"t": 90}] * 4 + [{"t": 20}] * 4
+        matches = [{"mp": "90'"}] * 4 + [{"mp": "20'"}] * 4
         perf = self._make_perf(matches)
         trend, avg = _extract_minutes_trend(perf)
         assert trend == "decreasing"
 
     def test_stable_minutes(self):
-        matches = [{"t": 75}] * 8
+        matches = [{"mp": "75'"}] * 8
         perf = self._make_perf(matches)
         trend, avg = _extract_minutes_trend(perf)
         assert trend == "stable"
         assert avg == 75.0
+
+    def test_missing_mp_field_skipped(self):
+        # Future/scheduled matches in the API response have no `mp` —
+        # treat them as "no data" rather than letting them crash or
+        # falsely register as 0-minute appearances.
+        matches = [{"mp": "85'"}] * 4 + [{}, {"mp": "85'"}] + [{"mp": "85'"}] * 3
+        perf = self._make_perf(matches)
+        trend, avg = _extract_minutes_trend(perf)
+        # 8 valid minutes entries → still derives a trend
+        assert trend == "stable"
+        assert avg == 85.0
+
+
+class TestParseMinutes:
+    """The Kickbase API ships minutes as `mp` strings like `"13'"`.
+    Anything else we encounter should degrade to 0 rather than crash —
+    a single malformed match must not poison the whole player score.
+    """
+
+    def test_parses_apostrophe_suffix(self):
+        assert _parse_minutes("13'") == 13
+        assert _parse_minutes("90'") == 90
+        assert _parse_minutes("100'") == 100
+
+    def test_zero_minutes(self):
+        assert _parse_minutes("0'") == 0
+
+    def test_missing_returns_zero(self):
+        assert _parse_minutes(None) == 0
+
+    def test_empty_string_returns_zero(self):
+        assert _parse_minutes("") == 0
+
+    def test_unexpected_format_returns_zero(self):
+        # Whatever Kickbase ships in extra time / abandoned matches —
+        # don't crash, don't guess.
+        assert _parse_minutes("90+5'") == 0
+        assert _parse_minutes("garbage") == 0
+
+    def test_plain_int_string(self):
+        # Defensive: if Kickbase ever drops the apostrophe.
+        assert _parse_minutes("75") == 75

--- a/tests/test_scoring/test_scorer.py
+++ b/tests/test_scoring/test_scorer.py
@@ -317,11 +317,19 @@ class TestParseMinutes:
     def test_empty_string_returns_zero(self):
         assert _parse_minutes("") == 0
 
+    def test_extra_time_format_sums_components(self):
+        # `"90+5'"` means 90 minutes regulation + 5 stoppage = 95 played.
+        # We don't see this format in current cached data, but matches
+        # going to extra time can ship as `"N+M'"` per common football
+        # conventions — base + stoppage.
+        assert _parse_minutes("90+5'") == 95
+        assert _parse_minutes("45+2'") == 47
+
     def test_unexpected_format_returns_zero(self):
-        # Whatever Kickbase ships in extra time / abandoned matches —
-        # don't crash, don't guess.
-        assert _parse_minutes("90+5'") == 0
+        # Anything we genuinely can't make sense of degrades to 0
+        # rather than crashing.
         assert _parse_minutes("garbage") == 0
+        assert _parse_minutes("12abc'") == 0
 
     def test_plain_int_string(self):
         # Defensive: if Kickbase ever drops the apostrophe.


### PR DESCRIPTION
## Summary

The Kickbase performance API ships minutes-played as `mp` strings like `"13'"`. The EP scorer's three minutes-aware helpers all read `m["t"]` — a field that doesn't exist in any cached response (verified across 7969 sampled match dicts).

**This was the real bug behind the Svensson investigation.** REH-14 was filed on my misdiagnosis (I checked `seasons[:1]` by index, not sorted-by-title, and wrongly concluded the cache was missing the 25/26 season). The cache and the API are fine — the scorer was reading a field that doesn't exist.

## Impact before the fix

For **every player, ever**:
- `minutes_trend` always `None` → +10 "increasing minutes" bonus dead, -15 / -10 "collapsing minutes" penalties dead.
- `avg_minutes` always `None` → -8 "stable but <30 min" bench-warmer penalty dead.
- Two `decision.py` guards on `minutes_trend == "decreasing"` silently unreachable.
- "Matches played" filter degraded to `p != 0`, missing 0-point appearances (late subs who didn't touch the ball).

The bot has effectively been ignoring playing-time signal for the EP score. Bench-warmers kept their full score and stayed in best-11; emerging starters didn't get their bonus.

## Fix

Adds `_parse_minutes(mp)` that converts `"13'"` → `13` and degrades unknown formats / missing values to `0`. Fixes all three call sites.

## Verification on real data

Svensson (player_id 10115), live cached perf:

| | Before | After |
|---|---|---|
| games_played | 29 | 29 |
| consistency | 0.704 | 0.704 |
| recent_form | 61.8 pts/g | 61.8 pts/g |
| **minutes_trend** | **`None`** | **`"stable"`** |
| **avg_minutes** | **`None`** | **`85.6`** |

## Test plan

- [x] `tests/test_scoring/test_scorer.py` — updated existing tests to use real `mp` format (they were testing the same fictional `t` field as the impl, which is why the bug never surfaced).
- [x] 7 new tests for `_parse_minutes` + missing-mp edge case.
- [x] `pytest tests/` — 231 passed, 1 skipped.
- [x] `black --check` and `ruff check` clean.
- [ ] Live verification on next Azure run: confirm bench-warmers start dropping out of best-11 as their minutes_bonus turns negative.

## Linear

- Closes REH-14 (invalid as filed — replaced by this PR which fixes the real underlying issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)