### PR TITLE
fix: lineup-emergency, wash-trade, and same-day-flip guards

### DIFF
--- a/rehoboam/auto_trader.py
+++ b/rehoboam/auto_trader.py
@@ -241,6 +241,24 @@ class AutoTrader:
             if pair.recommended_bid and pair.recommended_bid > 0:
                 candidates.append(("pair", pair.ep_gain, pair))
 
+        # Wash-trade guard: refuse to re-bid on a player we sold within the
+        # configured window. Without this, the same player can be sold and
+        # re-bought within hours — paying the bid spread on both legs for
+        # zero EP gain.
+        wash_skipped = 0
+        filtered: list = []
+        for kind, ep_val, obj in candidates:
+            target_id = obj.player.id if kind == "buy" else obj.buy_player.id
+            target_name = obj.player.last_name if kind == "buy" else obj.buy_player.last_name
+            if self._is_wash_trade(target_id):
+                wash_skipped += 1
+                console.print(f"[dim]Skip {target_name} — wash-trade block (sold recently)[/dim]")
+                continue
+            filtered.append((kind, ep_val, obj))
+        if wash_skipped:
+            console.print(f"[yellow]Wash-trade guard: skipped {wash_skipped} candidate(s)[/yellow]")
+        candidates = filtered
+
         # Sort by EP gain descending — trade pairs compete directly with plain buys
         candidates.sort(key=lambda x: x[1], reverse=True)
 
@@ -308,8 +326,12 @@ class AutoTrader:
 
                 skipped_long_hold = 0
                 skipped_unfieldable = 0
+                skipped_wash = 0
                 for opp in profit_opps:
                     if opp.player.id in ep_player_ids:
+                        continue
+                    if self._is_wash_trade(opp.player.id):
+                        skipped_wash += 1
                         continue
                     if max_hold_days is not None and opp.hold_days > max_hold_days:
                         skipped_long_hold += 1
@@ -342,6 +364,8 @@ class AutoTrader:
                         f"[dim]Skipped {skipped_unfieldable} flip(s) — "
                         f"would make squad unfieldable[/dim]"
                     )
+                if skipped_wash > 0:
+                    console.print(f"[dim]Skipped {skipped_wash} flip(s) — wash-trade block[/dim]")
             except Exception as e:
                 console.print(f"[yellow]Profit flip search failed: {e}[/yellow]")
 
@@ -491,6 +515,124 @@ class AutoTrader:
         )
         return results
 
+    def _run_emergency_squad_fill(
+        self,
+        league,
+        ctx: EPSessionContext,
+        fresh_squad: list,
+        slots_short: int,
+    ) -> list[AutoTradeResult]:
+        """Buy enough players to reach 11, even when phase is "locked".
+
+        Locked phase normally blocks all buys to keep budget liquid at kickoff,
+        but an empty lineup slot is -100 pts per match — a far worse failure
+        mode than a few hours of leftover debt. This path:
+
+        - Buys only plain in-budget candidates (no sell plans, no flips, no
+          trade pairs — those all add complexity right before kickoff).
+        - Prioritizes positions below the formation minimum.
+        - Honors wash-trade and active-bid guards.
+        - Caps spend at ``slots_short`` purchases.
+        """
+        from .config import POSITION_MINIMUMS
+
+        results: list[AutoTradeResult] = []
+        buy_recs = ctx.ep_result.get("buy_recs", [])
+        if not buy_recs:
+            console.print("[red]No buy candidates available — cannot fill emergency slots[/red]")
+            return results
+
+        position_counts: dict[str, int] = {}
+        for p in fresh_squad:
+            position_counts[p.position] = position_counts.get(p.position, 0) + 1
+        gap_positions = {
+            pos
+            for pos, minimum in POSITION_MINIMUMS.items()
+            if position_counts.get(pos, 0) < minimum
+        }
+
+        active_bid_ids = set(ctx.my_bid_amounts.keys())
+        budget_remaining = int(ctx.current_budget)
+
+        # Score each candidate: gap-filling positions first, then by EP.
+        # Tuple sort: (-fills_gap, -marginal_ep_gain) so gap fills sort to front.
+        scored = []
+        for rec in buy_recs:
+            if not rec.recommended_bid or rec.recommended_bid <= 0:
+                continue
+            if rec.player.id in active_bid_ids:
+                continue
+            if self._is_wash_trade(rec.player.id):
+                console.print(f"[dim]Skip {rec.player.last_name} — wash-trade block[/dim]")
+                continue
+            # Only plain in-budget candidates — sell plans add execution risk
+            # at kickoff that the emergency path explicitly avoids.
+            if rec.recommended_bid > budget_remaining:
+                continue
+            fills_gap = 1 if rec.player.position in gap_positions else 0
+            scored.append((fills_gap, rec.marginal_ep_gain or 0.0, rec))
+
+        scored.sort(key=lambda t: (-t[0], -t[1]))
+
+        if not scored:
+            console.print(
+                "[red]No affordable wash-trade-clean candidates " "to fill empty slot(s)[/red]"
+            )
+            return results
+
+        bought = 0
+        for _gap, _ep, rec in scored:
+            if bought >= slots_short:
+                break
+            if rec.recommended_bid > budget_remaining:
+                continue
+
+            result = self.execution.buy(
+                league,
+                rec.player,
+                rec.recommended_bid,
+                f"Emergency lineup fill (squad short by {slots_short})",
+            )
+            results.append(result)
+            if result.success:
+                bought += 1
+                budget_remaining -= rec.recommended_bid
+                self.daily_spend += rec.recommended_bid
+                # Track the position so subsequent picks deprioritize the gap.
+                gap_positions.discard(rec.player.position)
+
+        console.print(f"[green]✓ Emergency fill: bought {bought}/{slots_short} player(s)[/green]")
+        return results
+
+    def _wash_trade_block_seconds(self) -> float:
+        return float(getattr(self.settings, "wash_trade_block_hours", 168.0)) * 3600.0
+
+    def _min_hold_seconds(self) -> float:
+        return float(getattr(self.settings, "min_hold_hours_before_sell", 48.0)) * 3600.0
+
+    def _is_wash_trade(self, player_id: str) -> bool:
+        """True if we sold this player within the wash-trade block window."""
+        try:
+            return self.learner.was_recently_sold(player_id, self._wash_trade_block_seconds())
+        except Exception:
+            return False  # Guard never blocks trading on infrastructure errors
+
+    def _was_recently_bought(self, player_id: str) -> tuple[bool, float | None]:
+        """Return (held_too_briefly, hours_held). hours_held is None if untracked."""
+        try:
+            purchase = self.learner.get_tracked_purchase(player_id)
+        except Exception:
+            return (False, None)
+        if not purchase:
+            return (False, None)
+        buy_date = purchase.get("buy_date")
+        if not buy_date:
+            return (False, None)
+        held_seconds = time.time() - float(buy_date)
+        if held_seconds < self._min_hold_seconds():
+            return (True, held_seconds / 3600.0)
+        return (False, held_seconds / 3600.0)
+
     @staticmethod
     def _sell_threshold_for_trend(trend_7d_pct: float | None) -> float:
         """Profit% threshold required before selling, based on price momentum.
@@ -626,6 +768,18 @@ class AutoTrader:
             if not player.buy_price or player.buy_price <= 0:
                 continue
 
+            # Min-hold guard: refuse to sell a player we just bought. Same-
+            # session reversals (bid → win → instant-sell at -71% within 7h
+            # for Niang in production) cost both the bid spread and a
+            # market-value loss, with no signal change to justify them.
+            held_too_briefly, hours_held = self._was_recently_bought(player.id)
+            if held_too_briefly:
+                console.print(
+                    f"[dim]Hold-period guard {player.last_name} — "
+                    f"held {hours_held:.1f}h (< {self._min_hold_seconds() / 3600:.0f}h min)[/dim]"
+                )
+                continue
+
             # Hard block: never sell if it would drop a position below its
             # formation minimum. A squad with 0 FW loses -100 pts every matchday.
             pos_min = POSITION_MINIMUMS.get(player.position, 0)
@@ -691,6 +845,10 @@ class AutoTrader:
                 continue
             if not player.buy_price or player.buy_price <= 0:
                 continue
+
+            held_too_briefly, _ = self._was_recently_bought(player.id)
+            if held_too_briefly:
+                continue  # Already logged in the loop above; skip silently here.
 
             max_starters = _POSITION_MAX_STARTERS.get(player.position, 3)
             if position_counts.get(player.position, 0) <= max_starters:
@@ -840,22 +998,44 @@ class AutoTrader:
                 net_change=0,
             )
 
-        # Step 3: If locked (match imminent), just set lineup and exit
+        # Step 3: If locked (match imminent), set lineup and exit — UNLESS the
+        # squad is short. An empty lineup slot is worth -100 pts at kickoff;
+        # the no-trade safety rule has to yield to the larger penalty.
         if ctx.matchday_phase.phase == "locked":
-            console.print(
-                f"[yellow]Match imminent ({ctx.matchday_phase.days_until_match}d) "
-                f"— setting lineup only, no trading[/yellow]"
-            )
+            fresh_squad = self.api.get_squad(league)
+            slots_short = 11 - len(fresh_squad)
+            if slots_short > 0:
+                console.print(
+                    f"[bold red]⚠ LINEUP EMERGENCY — squad has {len(fresh_squad)}/11 "
+                    f"({slots_short} empty slot(s)). Locked-phase trading override.[/bold red]"
+                )
+                try:
+                    emergency_results = self._run_emergency_squad_fill(
+                        league, ctx, fresh_squad, slots_short
+                    )
+                    trade_results.extend(emergency_results)
+                except Exception as e:
+                    error_msg = f"Emergency squad fill failed: {e!s}"
+                    console.print(f"[red]{error_msg}[/red]")
+                    errors.append(error_msg)
+            else:
+                console.print(
+                    f"[yellow]Match imminent ({ctx.matchday_phase.days_until_match}d) "
+                    f"— setting lineup only, no trading[/yellow]"
+                )
+
             self._set_optimal_lineup(league, errors, squad_scores=ctx.ep_result.get("squad_scores"))
+            total_spent = sum(r.price for r in trade_results if r.action == "BUY" and r.success)
+            total_earned = sum(r.price for r in trade_results if r.action == "SELL" and r.success)
             return AutoTradeSession(
                 start_time=start_time,
                 end_time=time.time(),
-                profit_trades=[],
+                profit_trades=trade_results,
                 lineup_trades=[],
                 errors=errors,
-                total_spent=0,
-                total_earned=0,
-                net_change=0,
+                total_spent=total_spent,
+                total_earned=total_earned,
+                net_change=total_earned - total_spent,
             )
 
         # Step 4: Trend-aware profit selling

--- a/rehoboam/bid_learner.py
+++ b/rehoboam/bid_learner.py
@@ -240,6 +240,28 @@ class BidLearner:
             """
             )
 
+            # Wash-trade guard — every sell is recorded here so the buy path
+            # can refuse to re-bid on a player we just dumped. Without this
+            # the same player can be sold and re-bought within hours,
+            # paying the bid spread on both legs for no EP gain.
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS recently_sold (
+                    player_id TEXT PRIMARY KEY,
+                    player_name TEXT NOT NULL,
+                    sold_price INTEGER NOT NULL,
+                    sold_at REAL NOT NULL,
+                    reason TEXT
+                )
+            """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_recently_sold_sold_at
+                ON recently_sold(sold_at)
+            """
+            )
+
             conn.commit()
 
     def record_outcome(self, outcome: AuctionOutcome):
@@ -458,6 +480,67 @@ class BidLearner:
                 (player_id,),
             )
             conn.commit()
+
+    # ------------------------------------------------------------------
+    # Wash-trade guard
+    # ------------------------------------------------------------------
+
+    def record_recent_sell(
+        self,
+        *,
+        player_id: str,
+        player_name: str,
+        sold_price: int,
+        sold_at: float,
+        reason: str | None = None,
+    ) -> None:
+        """Remember that we just sold this player.
+
+        Re-selling the same player overwrites the row — the latest sell
+        timestamp is what the wash-trade check needs.
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO recently_sold (
+                    player_id, player_name, sold_price, sold_at, reason
+                )
+                VALUES (?, ?, ?, ?, ?)
+            """,
+                (player_id, player_name, sold_price, sold_at, reason),
+            )
+            conn.commit()
+
+    def was_recently_sold(self, player_id: str, within_seconds: float) -> bool:
+        """True iff we sold this player within the last *within_seconds*."""
+        cutoff = datetime.now(tz=timezone.utc).timestamp() - within_seconds
+        with sqlite3.connect(self.db_path) as conn:
+            row = conn.execute(
+                "SELECT sold_at FROM recently_sold WHERE player_id = ?",
+                (player_id,),
+            ).fetchone()
+        return bool(row and row[0] >= cutoff)
+
+    def get_recent_sell(self, player_id: str) -> dict[str, Any] | None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute(
+                """
+                SELECT player_id, player_name, sold_price, sold_at, reason
+                FROM recently_sold
+                WHERE player_id = ?
+            """,
+                (player_id,),
+            ).fetchone()
+        return dict(row) if row else None
+
+    def prune_recent_sells(self, older_than_seconds: float) -> int:
+        """Drop wash-trade-guard rows older than the given age. Returns rows deleted."""
+        cutoff = datetime.now(tz=timezone.utc).timestamp() - older_than_seconds
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.execute("DELETE FROM recently_sold WHERE sold_at < ?", (cutoff,))
+            conn.commit()
+            return cur.rowcount
 
     def record_matchday_outcome(
         self,

--- a/rehoboam/config.py
+++ b/rehoboam/config.py
@@ -116,6 +116,16 @@ class Settings(BaseSettings):
         description="Max trades per auto session in aggressive mode",
     )
 
+    # Wash-trade + churn guards
+    wash_trade_block_hours: float = Field(
+        default=168.0,  # 7 days
+        description="Refuse to re-bid on a player we sold within this window",
+    )
+    min_hold_hours_before_sell: float = Field(
+        default=48.0,
+        description="Refuse to instant-sell a player held less than this (overridden when budget is critically negative)",
+    )
+
     # Safety Settings
     dry_run: bool = Field(
         default=True,

--- a/rehoboam/learning/tracker.py
+++ b/rehoboam/learning/tracker.py
@@ -172,11 +172,27 @@ class LearningTracker:
     # Flip outcome (bought + sold → profit recorded)
     # ------------------------------------------------------------------
 
-    def record_flip_outcome(self, player, sell_price: int) -> None:
+    def record_flip_outcome(self, player, sell_price: int, reason: str | None = None) -> None:
         """Compute and record a flip profit outcome for a sold player.
 
-        Silently skips if we have no record of buying this player.
+        Always records into ``recently_sold`` (the wash-trade guard) even when
+        we have no purchase record — selling a player we never tracked still
+        means we shouldn't re-bid on them within the guard window.
         """
+        sell_date = time.time()
+        player_name = f"{player.first_name} {player.last_name}"
+
+        try:
+            self.bid_learner.record_recent_sell(
+                player_id=player.id,
+                player_name=player_name,
+                sold_price=sell_price,
+                sold_at=sell_date,
+                reason=reason,
+            )
+        except Exception as e:
+            logger.warning("Failed to record recent sell: %s", e)
+
         try:
             purchase = self.bid_learner.get_tracked_purchase(player.id)
             if purchase is None:
@@ -184,7 +200,6 @@ class LearningTracker:
 
             buy_price = purchase["buy_price"]
             buy_date = purchase["buy_date"]
-            sell_date = time.time()
 
             profit = sell_price - buy_price
             profit_pct = (profit / buy_price * 100) if buy_price > 0 else 0
@@ -192,7 +207,7 @@ class LearningTracker:
 
             outcome = FlipOutcome(
                 player_id=player.id,
-                player_name=f"{player.first_name} {player.last_name}",
+                player_name=player_name,
                 buy_price=buy_price,
                 sell_price=sell_price,
                 profit=profit,

--- a/rehoboam/services/execution.py
+++ b/rehoboam/services/execution.py
@@ -105,7 +105,7 @@ class ExecutionService:
             ),
             success_msg=f"{player.first_name} {player.last_name} sold instantly to Kickbase",
             api_call=lambda: self.api.sell_player_instant(league=league, player=player),
-            on_success=lambda: self.tracker.record_flip_outcome(player, price),
+            on_success=lambda: self.tracker.record_flip_outcome(player, price, reason=reason),
         )
 
     # ------------------------------------------------------------------

--- a/tests/test_min_hold_and_emergency_fill.py
+++ b/tests/test_min_hold_and_emergency_fill.py
@@ -1,0 +1,326 @@
+"""Tests for the min-hold-period guard and locked-phase emergency squad fill.
+
+These two guards exist because of a real production incident: the bot won
+Niang at €2.0M at 13:24, then dead-weight-sold him at €0.57M at 20:00 the
+same day (-71% in 7h). Around the same date, the squad was sitting at
+9/11 with cash idle because the locked-phase exit short-circuits before
+any buying logic ever runs.
+
+We test the two helper layers (``_was_recently_bought`` + the emergency
+squad-fill candidate filter) directly, without standing up a full
+KickbaseAPI mock — those would dwarf the signal we actually care about.
+"""
+
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from rehoboam.auto_trader import AutoTrader
+from rehoboam.bid_learner import BidLearner
+from rehoboam.config import Settings
+
+
+@pytest.fixture
+def settings(monkeypatch):
+    monkeypatch.setenv("KICKBASE_EMAIL", "test@example.com")
+    monkeypatch.setenv("KICKBASE_PASSWORD", "test")
+    return Settings()
+
+
+@pytest.fixture
+def trader(tmp_path, settings, monkeypatch):
+    """An AutoTrader stitched together with a real BidLearner on a temp DB.
+
+    The Kickbase API isn't touched in these tests — the helpers under test
+    only read from settings + the learner. Building a full API mock would
+    add noise without coverage.
+    """
+    monkeypatch.chdir(tmp_path)  # so logs/ goes to tmp
+    api = SimpleNamespace()
+    t = AutoTrader(api=api, settings=settings, dry_run=True)
+    t.learner = BidLearner(db_path=tmp_path / "bid_learning.db")
+    return t
+
+
+def _player(pid: str, position: str = "Forward", price: int = 1_000_000):
+    return SimpleNamespace(
+        id=pid,
+        first_name="X",
+        last_name=f"P{pid}",
+        position=position,
+        price=price,
+        market_value=price,
+        average_points=10.0,
+        status=0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Min-hold guard
+# ---------------------------------------------------------------------------
+
+
+class TestMinHoldGuard:
+    def test_no_purchase_record_does_not_block(self, trader):
+        # Player we never tracked buying — guard can't tell, so don't block.
+        held_too_briefly, hours = trader._was_recently_bought("never-bought")
+        assert held_too_briefly is False
+        assert hours is None
+
+    def test_recently_bought_blocks_sell(self, trader):
+        trader.learner.add_tracked_purchase(
+            player_id="12333",
+            player_name="Niang",
+            buy_price=2_000_000,
+            buy_date=time.time() - 3 * 3600,  # 3h ago
+        )
+        held_too_briefly, hours = trader._was_recently_bought("12333")
+        assert held_too_briefly is True
+        assert hours is not None
+        assert 2.5 < hours < 3.5
+
+    def test_old_purchase_does_not_block(self, trader):
+        trader.learner.add_tracked_purchase(
+            player_id="12333",
+            player_name="Niang",
+            buy_price=2_000_000,
+            buy_date=time.time() - 5 * 86400,  # 5 days
+        )
+        held_too_briefly, hours = trader._was_recently_bought("12333")
+        assert held_too_briefly is False
+        assert hours is not None
+        assert hours > 24
+
+    def test_min_hold_setting_drives_threshold(self, trader, settings):
+        # Drop the min-hold to 1h and verify the same 3h-old purchase no
+        # longer blocks. The setting is the source of truth, not a
+        # constant baked into the helper.
+        settings.min_hold_hours_before_sell = 1.0
+        trader.learner.add_tracked_purchase(
+            player_id="12333",
+            player_name="Niang",
+            buy_price=2_000_000,
+            buy_date=time.time() - 3 * 3600,
+        )
+        held_too_briefly, _ = trader._was_recently_bought("12333")
+        assert held_too_briefly is False
+
+
+# ---------------------------------------------------------------------------
+# Wash-trade guard wiring (helper)
+# ---------------------------------------------------------------------------
+
+
+class TestWashTradeHelper:
+    def test_clean_player_passes(self, trader):
+        assert trader._is_wash_trade("12333") is False
+
+    def test_recent_sell_blocks(self, trader):
+        trader.learner.record_recent_sell(
+            player_id="12333",
+            player_name="Niang",
+            sold_price=572_468,
+            sold_at=time.time() - 3600,  # 1h ago
+        )
+        assert trader._is_wash_trade("12333") is True
+
+    def test_old_sell_does_not_block(self, trader, settings):
+        settings.wash_trade_block_hours = 24.0
+        trader.learner.record_recent_sell(
+            player_id="12333",
+            player_name="Niang",
+            sold_price=572_468,
+            sold_at=time.time() - 48 * 3600,  # 2 days ago, window is 1 day
+        )
+        assert trader._is_wash_trade("12333") is False
+
+
+# ---------------------------------------------------------------------------
+# Emergency squad fill — at locked phase + squad < 11
+# ---------------------------------------------------------------------------
+
+
+class _StubExecution:
+    """Records every buy/sell call without hitting the API."""
+
+    def __init__(self):
+        self.calls: list = []
+
+    def buy(self, league, player, price, reason, sell_plan_player_ids=None):
+        self.calls.append(("buy", player.id, price, reason))
+        return SimpleNamespace(
+            success=True,
+            player_name=player.last_name,
+            action="BUY",
+            price=price,
+            reason=reason,
+            timestamp=time.time(),
+            error=None,
+        )
+
+    def instant_sell(self, league, player, reason):
+        self.calls.append(("sell", player.id, player.market_value, reason))
+        return SimpleNamespace(
+            success=True,
+            player_name=player.last_name,
+            action="SELL",
+            price=player.market_value,
+            reason=reason,
+            timestamp=time.time(),
+            error=None,
+        )
+
+
+def _ctx(buy_recs, current_budget, my_bid_amounts=None):
+    """Build the slimmest EPSessionContext-shaped object _run_emergency_squad_fill needs."""
+    return SimpleNamespace(
+        ep_result={"buy_recs": buy_recs, "trade_pairs": [], "squad_scores": []},
+        my_bid_amounts=my_bid_amounts or {},
+        current_budget=current_budget,
+    )
+
+
+def _rec(pid, position, price, ep_gain=10.0):
+    return SimpleNamespace(
+        player=_player(pid, position=position, price=price),
+        recommended_bid=price,
+        marginal_ep_gain=ep_gain,
+        sell_plan=None,
+    )
+
+
+class TestEmergencySquadFill:
+    def test_fills_to_eleven_when_short(self, trader):
+        trader.execution = _StubExecution()
+
+        # Squad has 9 players (missing 1 GK + 1 forward = formation broken)
+        squad = (
+            [_player(f"def{i}", "Defender") for i in range(4)]
+            + [_player(f"mid{i}", "Midfielder") for i in range(3)]
+            + [_player("fwd0", "Forward")]
+            + [_player("gk0", "Goalkeeper")]
+        )
+        assert len(squad) == 9
+
+        buy_recs = [
+            _rec("forward1", "Forward", price=2_000_000, ep_gain=15.0),
+            _rec("forward2", "Forward", price=1_500_000, ep_gain=12.0),
+            _rec("def_extra", "Defender", price=900_000, ep_gain=18.0),
+        ]
+        ctx = _ctx(buy_recs, current_budget=10_000_000)
+
+        results = trader._run_emergency_squad_fill(
+            league=SimpleNamespace(id="L"), ctx=ctx, fresh_squad=squad, slots_short=2
+        )
+
+        assert sum(1 for r in results if r.success) == 2
+        bought_ids = [pid for kind, pid, *_ in trader.execution.calls if kind == "buy"]
+        # Both bought slots are filled with affordable, non-active-bid candidates
+        assert len(bought_ids) == 2
+
+    def test_skips_wash_trade_blocked_candidates(self, trader):
+        trader.execution = _StubExecution()
+        squad = [_player(f"p{i}", "Defender") for i in range(10)]
+
+        trader.learner.record_recent_sell(
+            player_id="forward1",
+            player_name="P forward1",
+            sold_price=2_000_000,
+            sold_at=time.time() - 3600,
+        )
+
+        buy_recs = [
+            _rec("forward1", "Forward", price=2_000_000, ep_gain=20.0),  # blocked
+            _rec("forward2", "Forward", price=1_500_000, ep_gain=10.0),
+        ]
+        ctx = _ctx(buy_recs, current_budget=5_000_000)
+
+        results = trader._run_emergency_squad_fill(
+            league=SimpleNamespace(id="L"), ctx=ctx, fresh_squad=squad, slots_short=1
+        )
+
+        bought_ids = [pid for kind, pid, *_ in trader.execution.calls if kind == "buy"]
+        assert bought_ids == ["forward2"]
+        assert sum(1 for r in results if r.success) == 1
+
+    def test_skips_already_bid_candidates(self, trader):
+        trader.execution = _StubExecution()
+        squad = [_player(f"p{i}", "Defender") for i in range(10)]
+
+        buy_recs = [
+            _rec("forward1", "Forward", price=2_000_000, ep_gain=20.0),
+            _rec("forward2", "Forward", price=1_500_000, ep_gain=10.0),
+        ]
+        ctx = _ctx(
+            buy_recs,
+            current_budget=5_000_000,
+            my_bid_amounts={"forward1": 2_000_000},  # already in flight
+        )
+
+        trader._run_emergency_squad_fill(
+            league=SimpleNamespace(id="L"), ctx=ctx, fresh_squad=squad, slots_short=1
+        )
+
+        bought_ids = [pid for kind, pid, *_ in trader.execution.calls if kind == "buy"]
+        assert bought_ids == ["forward2"]
+
+    def test_skips_unaffordable_candidates(self, trader):
+        trader.execution = _StubExecution()
+        squad = [_player(f"p{i}", "Defender") for i in range(10)]
+
+        buy_recs = [
+            _rec("forward1", "Forward", price=20_000_000, ep_gain=30.0),  # too pricey
+            _rec("forward2", "Forward", price=1_500_000, ep_gain=10.0),
+        ]
+        ctx = _ctx(buy_recs, current_budget=2_000_000)
+
+        trader._run_emergency_squad_fill(
+            league=SimpleNamespace(id="L"), ctx=ctx, fresh_squad=squad, slots_short=2
+        )
+
+        bought_ids = [pid for kind, pid, *_ in trader.execution.calls if kind == "buy"]
+        assert bought_ids == ["forward2"]
+
+    def test_prioritises_gap_positions_over_raw_ep(self, trader):
+        trader.execution = _StubExecution()
+        # 0 forwards, 5 defenders, 3 midfielders, 1 GK = 9 players, FW gap.
+        squad = (
+            [_player(f"def{i}", "Defender") for i in range(5)]
+            + [_player(f"mid{i}", "Midfielder") for i in range(3)]
+            + [_player("gk0", "Goalkeeper")]
+        )
+        assert len(squad) == 9
+
+        buy_recs = [
+            # Higher-EP defender, but defender is already saturated.
+            _rec("def_top", "Defender", price=1_000_000, ep_gain=25.0),
+            # Lower-EP forward, but it fills the formation gap.
+            _rec("fwd_gap", "Forward", price=1_000_000, ep_gain=12.0),
+        ]
+        ctx = _ctx(buy_recs, current_budget=5_000_000)
+
+        trader._run_emergency_squad_fill(
+            league=SimpleNamespace(id="L"), ctx=ctx, fresh_squad=squad, slots_short=1
+        )
+
+        # The gap-filling forward must come first, even though raw EP gain
+        # would have ranked the defender above it.
+        bought_ids = [pid for kind, pid, *_ in trader.execution.calls if kind == "buy"]
+        assert bought_ids[0] == "fwd_gap"
+
+    def test_no_buys_when_no_affordable_clean_candidates(self, trader):
+        trader.execution = _StubExecution()
+        squad = [_player(f"p{i}", "Defender") for i in range(10)]
+
+        buy_recs = [
+            _rec("forward1", "Forward", price=20_000_000, ep_gain=30.0),  # too pricey
+        ]
+        ctx = _ctx(buy_recs, current_budget=2_000_000)
+
+        results = trader._run_emergency_squad_fill(
+            league=SimpleNamespace(id="L"), ctx=ctx, fresh_squad=squad, slots_short=1
+        )
+
+        assert results == []
+        assert trader.execution.calls == []

--- a/tests/test_wash_trade_guard.py
+++ b/tests/test_wash_trade_guard.py
@@ -1,0 +1,131 @@
+"""Tests for the wash-trade guard in BidLearner + LearningTracker.
+
+A wash trade is selling a player and re-bidding on them shortly after,
+paying the bid spread on both legs for no EP gain. The guard records
+every sell into ``recently_sold`` and lets the buy path query the table
+to refuse repeat bids inside the configured window.
+"""
+
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from rehoboam.bid_learner import BidLearner
+from rehoboam.learning.tracker import LearningTracker
+
+
+@pytest.fixture
+def learner(tmp_path):
+    return BidLearner(db_path=tmp_path / "bid_learning.db")
+
+
+@pytest.fixture
+def tracker(learner):
+    return LearningTracker(learner)
+
+
+def _player(pid: str = "12333", name: str = "Niang"):
+    return SimpleNamespace(
+        id=pid,
+        first_name="M.",
+        last_name=name,
+        average_points=12.0,
+        position="Forward",
+        status=0,
+    )
+
+
+class TestRecentlySoldTable:
+    def test_empty_by_default(self, learner):
+        assert learner.was_recently_sold("12333", within_seconds=86400) is False
+        assert learner.get_recent_sell("12333") is None
+
+    def test_record_then_query_within_window(self, learner):
+        learner.record_recent_sell(
+            player_id="12333",
+            player_name="Niang",
+            sold_price=572_468,
+            sold_at=time.time(),
+            reason="dead-weight surplus",
+        )
+        assert learner.was_recently_sold("12333", within_seconds=86400) is True
+        row = learner.get_recent_sell("12333")
+        assert row["player_name"] == "Niang"
+        assert row["sold_price"] == 572_468
+        assert row["reason"] == "dead-weight surplus"
+
+    def test_record_then_query_outside_window(self, learner):
+        # Sold 8 days ago; default block window is 7 days
+        learner.record_recent_sell(
+            player_id="12333",
+            player_name="Niang",
+            sold_price=572_468,
+            sold_at=time.time() - 8 * 86400,
+        )
+        assert learner.was_recently_sold("12333", within_seconds=7 * 86400) is False
+
+    def test_repeat_sell_overwrites_previous_row(self, learner):
+        learner.record_recent_sell(
+            player_id="12333",
+            player_name="Niang",
+            sold_price=2_000_000,
+            sold_at=time.time() - 86400,
+        )
+        learner.record_recent_sell(
+            player_id="12333",
+            player_name="Niang",
+            sold_price=572_468,
+            sold_at=time.time(),
+        )
+        row = learner.get_recent_sell("12333")
+        # Latest sell wins — wash-trade window restarts from the most
+        # recent sell, which is the conservative behaviour for the guard.
+        assert row["sold_price"] == 572_468
+
+    def test_prune_drops_old_rows_only(self, learner):
+        learner.record_recent_sell(
+            player_id="old",
+            player_name="Old",
+            sold_price=1,
+            sold_at=time.time() - 30 * 86400,
+        )
+        learner.record_recent_sell(
+            player_id="new",
+            player_name="New",
+            sold_price=1,
+            sold_at=time.time(),
+        )
+        deleted = learner.prune_recent_sells(older_than_seconds=14 * 86400)
+        assert deleted == 1
+        assert learner.get_recent_sell("old") is None
+        assert learner.get_recent_sell("new") is not None
+
+
+class TestLearningTrackerHook:
+    def test_record_flip_outcome_writes_recently_sold(self, tracker, learner):
+        # Buy first so the flip outcome has a cost basis to use.
+        learner.add_tracked_purchase(
+            player_id="12333",
+            player_name="M. Niang",
+            buy_price=2_000_000,
+            buy_date=time.time() - 7 * 3600,  # bought 7h ago — same-day flip
+        )
+
+        tracker.record_flip_outcome(_player(), sell_price=572_468, reason="stop-loss")
+
+        # Wash-trade guard sees the sell
+        assert learner.was_recently_sold("12333", within_seconds=86400) is True
+        row = learner.get_recent_sell("12333")
+        assert row["sold_price"] == 572_468
+        assert row["reason"] == "stop-loss"
+        # Tracked purchase is consumed after the flip outcome
+        assert learner.get_tracked_purchase("12333") is None
+
+    def test_record_flip_outcome_records_even_without_purchase(self, tracker, learner):
+        # No tracked_purchase row — e.g. the player was bought before the
+        # tracker existed (Azure wiped JSON state). The flip outcome can't
+        # be computed but the wash-trade guard still has to fire.
+        tracker.record_flip_outcome(_player("99999", "Pieper"), sell_price=3_034_839)
+
+        assert learner.was_recently_sold("99999", within_seconds=86400) is True


### PR DESCRIPTION
## Summary

Three real points-cost defects observed in production over the last 60 days:

1. **Locked-phase blocks emergency squad fill.** When the bot ran with squad < 11 within 1 day of kickoff, it logged a warning and exited without buying anyone — leaving cash idle while every empty slot cost -100 pts at kickoff. Now the locked exit checks squad size first and runs an emergency fill (gap positions prioritized, wash-trade-clean candidates only) before setting the lineup.
2. **No anti-wash-trade memory.** The buy path could re-bid on a player it sold hours earlier, paying the bid spread on both legs for zero EP gain. Confirmed in `league_transfers`: Niang sold and re-bid same-day, plus Süle / Pieper / Pedersen / Rexhbecaj / Siersleben across longer windows. Adds a `recently_sold` table inside `bid_learning.db` (so Azure's existing blob sync covers it), wires it through `ExecutionService.instant_sell`, and filters the unified candidate list + profit flip search.
3. **Same-day buy → instant-sell loop.** Niang: bought €2.0M at 13:24, dead-weight-sold €0.57M at 20:00 — -71% in 7 hours. The profit-sell phase had no concept of "we just bought this." Adds `min_hold_hours_before_sell` (default 48h). The squad-optimization path is intentionally exempt — negative budget at kickoff = 0 pts entire matchday, which beats any wash-trade hit.

## Test plan

- [x] `pytest` — 260 passed, 1 skipped, no regressions
- [x] `ruff check` — clean
- [x] `black --check` — clean (touched files)
- [x] New tests cover: `recently_sold` table CRUD + window query, `LearningTracker.record_flip_outcome` writing to it, `_was_recently_bought` threshold-driven by setting, `_is_wash_trade` window logic, emergency-fill candidate selection (affordability, wash-trade skip, active-bid skip, gap-position priority over raw EP, no-buy when nothing affordable)
- [ ] Real session run on Azure / locally with `rehoboam auto` to confirm the new logs appear and behave on live data

## Behavior changes worth flagging

- Locked phase now allows up to `(11 - len(squad))` plain buys when squad is short. Sell plans, trade pairs, and flips remain blocked in locked phase.
- `min_hold_hours_before_sell=48` is conservative; tune via `.env` if it ever gets in the way of a legitimate stop-loss.
- `wash_trade_block_hours=168` (7 days). On a multi-week-long auction cycle a 7-day block is short enough to allow re-entry once price has stabilized but long enough to prevent the documented same-week churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)