### PR TITLE
feat: structured logging so we can audit bot decisions

### DIFF
--- a/rehoboam/auto_trader.py
+++ b/rehoboam/auto_trader.py
@@ -1,5 +1,6 @@
 """Automated trading - Execute trades without manual intervention"""
 
+import logging
 import time
 from dataclasses import dataclass
 from datetime import datetime
@@ -9,6 +10,7 @@ from rich.console import Console
 from .services import AutoTradeResult, ExecutionService
 
 console = Console()
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -201,6 +203,18 @@ class AutoTrader:
         pending_bid_total = sum(p.user_offer_price for p in my_bids)
         flip_budget = _compute_flip_budget(phase.phase, current_budget, pending_bid_total, max_debt)
 
+        logger.info(
+            "session-context phase=%s days_to_match=%s squad=%d/15 "
+            "budget=%d team_value=%d flip_budget=%d pending_bids=%d",
+            phase.phase,
+            phase.days_until_match,
+            len(squad),
+            int(current_budget),
+            int(team_value),
+            flip_budget,
+            len(my_bids),
+        )
+
         return EPSessionContext(
             ep_result=ep_result,
             matchday_phase=phase,
@@ -253,10 +267,16 @@ class AutoTrader:
             if self._is_wash_trade(target_id):
                 wash_skipped += 1
                 console.print(f"[dim]Skip {target_name} — wash-trade block (sold recently)[/dim]")
+                logger.info(
+                    "guard-wash-trade: skipped %s (id=%s) — sold within block window",
+                    target_name,
+                    target_id,
+                )
                 continue
             filtered.append((kind, ep_val, obj))
         if wash_skipped:
             console.print(f"[yellow]Wash-trade guard: skipped {wash_skipped} candidate(s)[/yellow]")
+            logger.info("guard-wash-trade total_skipped=%d", wash_skipped)
         candidates = filtered
 
         # Sort by EP gain descending — trade pairs compete directly with plain buys
@@ -930,6 +950,14 @@ class AutoTrader:
             console.print("[yellow]DRY RUN MODE - No trades will be executed[/yellow]")
         console.print(f"{'=' * 70}")
 
+        logger.info(
+            "session-start league=%s dry_run=%s max_trades=%d max_spend=%d",
+            getattr(league, "name", league.id),
+            self.dry_run,
+            self.max_trades_per_session,
+            self.max_daily_spend,
+        )
+
         # Step 0: Sync activity feed for competitive intelligence
         try:
             console.print("\n[dim]Syncing league activity feed...[/dim]")
@@ -977,6 +1005,7 @@ class AutoTrader:
                         )
         except Exception as e:
             console.print(f"[yellow]Auction resolution failed: {e}[/yellow]")
+            logger.exception("Auction resolution failed")
 
         # Step 2: Build session context (single EP pipeline + trends + matchday phase)
         try:
@@ -985,6 +1014,7 @@ class AutoTrader:
             error_msg = f"EP pipeline failed: {e!s}"
             console.print(f"[red]{error_msg}[/red]")
             errors.append(error_msg)
+            logger.exception("EP pipeline failed — falling back to lineup-only")
             # Fall back to just setting lineup
             self._set_optimal_lineup(league, errors)
             return AutoTradeSession(
@@ -1110,6 +1140,7 @@ class AutoTrader:
             error_msg = f"Trading error: {e!s}"
             console.print(f"[red]{error_msg}[/red]")
             errors.append(error_msg)
+            logger.exception("Unified trade phase failed")
 
         # Step 8: Set optimal lineup using EP pipeline scores from the session.
         # Players acquired mid-session (if any) fall back to the legacy
@@ -1145,6 +1176,20 @@ class AutoTrader:
             console.print(f"\n[red]Errors: {len(errors)}[/red]")
             for err in errors:
                 console.print(f"[red]  • {err}[/red]")
+
+        logger.info(
+            "session-end duration=%.1fs phase=%s sells=%d trades=%d/%d "
+            "spent=%d earned=%d net=%d errors=%d",
+            end_time - start_time,
+            ctx.matchday_phase.phase,
+            len([r for r in sell_results if r.success and r.action == "SELL"]),
+            len([r for r in trade_results if r.success]),
+            len(trade_results),
+            total_spent,
+            total_earned,
+            net_change,
+            len(errors),
+        )
 
         return AutoTradeSession(
             start_time=start_time,

--- a/rehoboam/bidding_strategy.py
+++ b/rehoboam/bidding_strategy.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -14,6 +15,8 @@ try:
 except ImportError:
     BidLearner = None
     ActivityFeedLearner = None
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -370,6 +373,10 @@ class SmartBidding:
             confidence = max(confidence, 0.9)
         # No improvement → no bid
         if marginal_ep_gain == 0:
+            logger.debug(
+                "ep-bid SKIP player=%s: marginal_ep_gain=0",
+                player_id,
+            )
             return BidRecommendation(
                 base_price=asking_price,
                 recommended_bid=0,
@@ -404,6 +411,14 @@ class SmartBidding:
             has_aggressive_competitors=has_aggressive_competitors,
         )
         if contested_skip_reason is not None:
+            logger.info(
+                "ep-bid SKIP player=%s tier=%s offers=%d aggressive=%s | %s",
+                player_id,
+                ep_tier,
+                offer_count,
+                has_aggressive_competitors,
+                contested_skip_reason,
+            )
             return BidRecommendation(
                 base_price=asking_price,
                 recommended_bid=0,
@@ -534,6 +549,29 @@ class SmartBidding:
         if sell_plan:
             reasoning_parts.append(f"sell plan: +€{sell_plan.total_recovery:,} recovery")
         reasoning = " | ".join(reasoning_parts)
+
+        logger.info(
+            "ep-bid player=%s tier=%s ep_gain=%+.1f conf=%.2f "
+            "ask=%d mv=%d bid=%d overbid=%.1f%% "
+            "trend=%s offers=%d dgw=%s demand_adj=%+.1f league_comp=%+.1f "
+            "ceiling=%d sell_plan=%s | %s",
+            player_id,
+            ep_tier,
+            marginal_ep_gain,
+            confidence,
+            asking_price,
+            market_value,
+            recommended_bid,
+            actual_overbid_pct,
+            trend_change_pct,
+            offer_count,
+            is_dgw,
+            demand_adjustment,
+            league_competitive_level,
+            budget_ceiling,
+            "yes" if sell_plan else "no",
+            reasoning,
+        )
 
         return BidRecommendation(
             base_price=asking_price,

--- a/rehoboam/cli.py
+++ b/rehoboam/cli.py
@@ -1,10 +1,15 @@
 """CLI interface for Rehoboam — minimal surface for auto + diagnostics."""
 
+import logging
+
 import typer
 from rich.console import Console
 
 from .api import KickbaseAPI
 from .config import get_settings
+from .logging_setup import setup_logging
+
+logger = logging.getLogger(__name__)
 
 app = typer.Typer(
     name="rehoboam",
@@ -156,6 +161,14 @@ def status(
 
 
 @app.callback()
-def callback():
+def callback(
+    verbose: bool = typer.Option(
+        False,
+        "--verbose",
+        "-v",
+        help="Enable DEBUG logging on the console (file log is always DEBUG).",
+    ),
+):
     """Rehoboam — KICKBASE trading bot with aggressive auto mode."""
-    pass
+    setup_logging(verbose=verbose)
+    logger.debug("CLI invoked (verbose=%s)", verbose)

--- a/rehoboam/logging_setup.py
+++ b/rehoboam/logging_setup.py
@@ -1,0 +1,87 @@
+"""Central logging configuration for rehoboam.
+
+Both the CLI and any background entry points (Azure Functions, daemon)
+call `setup_logging()` once at startup. Without this, decisions made
+during unattended runs leave no audit trail beyond what `compact_display`
+prints to stdout — and stdout disappears when the run ends.
+
+Two handlers:
+  - StreamHandler  → stderr at INFO (DEBUG when --verbose). Flows into
+    Azure Application Insights for live observation.
+  - RotatingFileHandler → logs/rehoboam.log at DEBUG always. Survives
+    locally for forensic replay even if upstream log retention drops it.
+    5 MiB × 5 backups = ~25 MiB ceiling, which the bot's 2x/day cadence
+    fills over roughly several weeks.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+_DEFAULT_LOG_DIR = Path("logs")
+_LOG_FILENAME = "rehoboam.log"
+_MAX_BYTES = 5 * 1024 * 1024
+_BACKUP_COUNT = 5
+
+_FORMAT = "%(asctime)s %(levelname)-7s %(name)s | %(message)s"
+_DATEFMT = "%Y-%m-%d %H:%M:%S"
+
+_configured = False
+
+
+def setup_logging(
+    *,
+    verbose: bool = False,
+    log_dir: Path | None = None,
+) -> None:
+    """Configure the root logger. Idempotent — safe to call multiple times.
+
+    The first call wins; later calls only adjust the console handler's level
+    so toggling `--verbose` mid-process is cheap.
+    """
+    global _configured
+
+    log_dir = log_dir or _DEFAULT_LOG_DIR
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / _LOG_FILENAME
+
+    root = logging.getLogger()
+    formatter = logging.Formatter(_FORMAT, datefmt=_DATEFMT)
+    console_level = logging.DEBUG if verbose else logging.INFO
+
+    if _configured:
+        for h in root.handlers:
+            if isinstance(h, logging.StreamHandler) and not isinstance(h, RotatingFileHandler):
+                h.setLevel(console_level)
+        return
+
+    root.setLevel(logging.DEBUG)
+
+    stream = logging.StreamHandler(stream=sys.stderr)
+    stream.setLevel(console_level)
+    stream.setFormatter(formatter)
+    root.addHandler(stream)
+
+    file_handler = RotatingFileHandler(
+        log_path,
+        maxBytes=_MAX_BYTES,
+        backupCount=_BACKUP_COUNT,
+        encoding="utf-8",
+    )
+    file_handler.setLevel(logging.DEBUG)
+    file_handler.setFormatter(formatter)
+    root.addHandler(file_handler)
+
+    # Quiet noisy third-party loggers — they bury our own decision logs.
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
+    logging.getLogger("requests").setLevel(logging.WARNING)
+
+    _configured = True
+    logging.getLogger(__name__).debug(
+        "Logging initialized (console=%s, file=%s)",
+        logging.getLevelName(console_level),
+        log_path,
+    )

--- a/rehoboam/scoring/decision.py
+++ b/rehoboam/scoring/decision.py
@@ -5,6 +5,8 @@ starting 11 from a squad, then calculates marginal EP gain for candidates,
 builds sell plans to fund purchases, and ranks squad players by expendability.
 """
 
+import logging
+
 from rehoboam.config import MAX_LINEUP_PROB_FOR_BUY, POSITION_MINIMUMS
 from rehoboam.formation import _POSITION_MAX_STARTERS, select_best_eleven
 from rehoboam.kickbase_client import MarketPlayer
@@ -18,6 +20,8 @@ from .models import (
     SellRecommendation,
     TradePair,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class DecisionEngine:
@@ -295,6 +299,12 @@ class DecisionEngine:
             # Filter by minimum EP threshold
             min_ep = 10.0 if is_emergency else self.min_ep_to_buy
             if ps.expected_points < min_ep:
+                logger.debug(
+                    "buy-skip %s: EP %.1f < min %.1f",
+                    player.last_name,
+                    ps.expected_points,
+                    min_ep,
+                )
                 continue
 
             # Skip players unlikely to start (prob 4-5)
@@ -302,10 +312,21 @@ class DecisionEngine:
                 ps.lineup_probability is not None
                 and ps.lineup_probability > MAX_LINEUP_PROB_FOR_BUY
             ):
+                logger.debug(
+                    "buy-skip %s: lineup_probability=%s > %s (unlikely starter)",
+                    player.last_name,
+                    ps.lineup_probability,
+                    MAX_LINEUP_PROB_FOR_BUY,
+                )
                 continue
 
             # Hard-block players with severely declining minutes
             if ps.minutes_trend == "decreasing" and ps.minutes_bonus <= -15.0:
+                logger.debug(
+                    "buy-skip %s: minutes_trend=decreasing, bonus=%.1f",
+                    player.last_name,
+                    ps.minutes_bonus,
+                )
                 continue
 
             # Calculate marginal EP gain using formation-aware logic
@@ -364,6 +385,12 @@ class DecisionEngine:
 
             # Only recommend if marginal gain meets threshold (or emergency)
             if not is_emergency and marginal < self.min_ep_upgrade and roster_impact != "fills_gap":
+                logger.debug(
+                    "buy-skip %s: marginal %.1f < threshold %.1f and not gap-fill",
+                    player.last_name,
+                    marginal,
+                    self.min_ep_upgrade,
+                )
                 continue
 
             # Build forced sell plan for dead-weight buys upfront so it's
@@ -463,7 +490,38 @@ class DecisionEngine:
 
         # Sort by marginal EP gain (primary), then by raw EP (secondary)
         final_recs.sort(key=lambda r: (r.marginal_ep_gain, r.score.expected_points), reverse=True)
-        return final_recs[:top_n]
+        top = final_recs[:top_n]
+        logger.info(
+            "recommend_buys: %d candidates considered, %d viable, returning top %d "
+            "(emergency=%s, budget=%d, min_ep=%.1f, min_upgrade=%.1f)",
+            len(market_scores),
+            len(final_recs),
+            len(top),
+            is_emergency,
+            int(budget),
+            self.min_ep_to_buy,
+            self.min_ep_upgrade,
+        )
+        for rec in top:
+            logger.info(
+                "  BUY %s (%s) price=%d EP=%.1f marginal=%+.1f impact=%s | %s",
+                rec.player.last_name,
+                rec.player.position,
+                rec.player.price,
+                rec.score.expected_points,
+                rec.marginal_ep_gain,
+                rec.roster_impact,
+                rec.reason,
+            )
+            if rec.sell_plan and rec.sell_plan.players_to_sell:
+                for entry in rec.sell_plan.players_to_sell:
+                    logger.info(
+                        "    + sell %s for ~€%d (EP=%.1f)",
+                        entry.player_name,
+                        entry.expected_sell_value,
+                        entry.player_ep,
+                    )
+        return top
 
     def build_trade_pairs(
         self,
@@ -586,6 +644,20 @@ class DecisionEngine:
                 break
 
         pairs.sort(key=lambda p: p.ep_gain, reverse=True)
+        logger.info(
+            "build_trade_pairs: built %d pair(s) from %d candidates / %d sellable",
+            len(pairs),
+            len(candidates),
+            len(sellable),
+        )
+        for pair in pairs[:top_n]:
+            logger.info(
+                "  TRADE %s -> %s | net €%d | EP %+.1f",
+                pair.sell_player.last_name,
+                pair.buy_player.last_name,
+                pair.net_cost,
+                pair.ep_gain,
+            )
         return pairs[:top_n]
 
     def recommend_sells(
@@ -668,6 +740,21 @@ class DecisionEngine:
             )
 
         recommendations.sort(key=lambda r: r.expendability, reverse=True)
+        protected_count = sum(1 for r in recommendations if r.is_protected)
+        logger.info(
+            "recommend_sells: ranked %d squad players (%d protected by position minimum)",
+            len(recommendations),
+            protected_count,
+        )
+        for r in recommendations[:5]:
+            tag = "[PROTECTED]" if r.is_protected else ""
+            logger.info(
+                "  SELL-rank %s expendability=%.1f %s | %s",
+                r.player.last_name if r.player else r.score.player_id,
+                r.expendability,
+                tag,
+                r.reason,
+            )
         return recommendations
 
 


### PR DESCRIPTION
## Summary

Adds end-to-end structured logging so we can answer **\"why did the bot pick X over Y?\"** without rerunning the session or spelunking the codebase. Particularly important for the unattended Azure 10am/10pm runs where stdout disappears.

- `rehoboam/logging_setup.py` — central `setup_logging()` with stderr handler (INFO; DEBUG via `-v`) + `RotatingFileHandler` at `logs/rehoboam.log` (always DEBUG, 5 MiB × 5 backups, ~25 MiB ceiling).
- Wired `--verbose` / `-v` into the Typer callback so the flag is global across `auto`, `status`, `login`.
- `scoring/decision.py` — DEBUG for every skipped candidate (low EP, lineup probability, decreasing minutes, sub-threshold marginal); INFO for each accepted buy/sell/trade-pair with ep, marginal, roster impact, sell-plan entries.
- `auto_trader.py` — session start/end snapshot, matchday phase + budget, wash-trade guard skips, full `logger.exception` traces on every error path.
- `bidding_strategy.calculate_ep_bid` — full bid audit (tier, marginal EP, ask/MV/bid/overbid%, demand & league-competitive adjustments, trend, contestedness, sell-plan flag).

Lazy `%`-formatting throughout so the DEBUG-level skip logs in the per-player hot loop are essentially free when not in verbose mode.

## DB note (out of band)

While investigating I found `logs/bid_learning.db` was missing the `pending_bids`, `pending_bid_sell_plans`, `tracked_purchases`, and `recently_sold` tables added in #23. They're guarded by `CREATE TABLE IF NOT EXISTS` so just instantiating `BidLearner()` materialized them — meaning the bot hadn't been run on this machine since #23 merged. Worth confirming Azure's DB has the tables too. No code change needed for this.

## Test plan

- [x] `python -m compileall` on all changed files — clean
- [x] `ruff check` on all changed files — passes
- [x] `pre-commit run` (black + ruff + bandit + pyupgrade) — passes
- [x] Smoke test of `setup_logging()` in isolation — both handlers attached, `--verbose` toggle correctly mutes DEBUG on stderr while preserving full DEBUG in the file, idempotent re-init works (no duplicate handlers).
- [ ] CI pytest run on Python 3.10/3.11/3.12 (local env has a pydantic-core/Python 3.14 mismatch unrelated to this branch)
- [ ] Run `rehoboam status -v` against the live league after merge and inspect `logs/rehoboam.log` for the full decision trail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)