### PR TITLE
feat: matchday outcome reconciliation (REH-20)

### DIFF
--- a/rehoboam/auto_trader.py
+++ b/rehoboam/auto_trader.py
@@ -1028,6 +1028,38 @@ class AutoTrader:
                 net_change=0,
             )
 
+        # Step 2a: Matchday self-calibration (REH-20).
+        #
+        # Reconcile finished matchdays FIRST using snapshots from prior
+        # sessions, THEN snapshot the current session. Order matters:
+        # snapshotting first would make the current run's prediction the
+        # "latest snapshot before kickoff" for any matchday whose `md`
+        # lies between this snapshot and the next reconcile — corrupting
+        # the actual-vs-predicted pairing.
+        #
+        # Both calls swallow exceptions internally so a learning-side
+        # failure never blocks the trading loop.
+        try:
+            squad_perf = ctx.ep_result.get("squad_performance") or {}
+            self.tracker.reconcile_finished_matchdays(ctx.squad, squad_perf)
+        except Exception:
+            logger.exception("reconcile_finished_matchdays failed (non-fatal)")
+        try:
+            squad_scores = ctx.ep_result.get("squad_scores") or []
+            lineup_map = ctx.ep_result.get("lineup_map") or {}
+            # Best-11 = top 11 player_ids by EP. lineup_map is {pid: ep}.
+            best_11 = {
+                pid
+                for pid, _ep in sorted(lineup_map.items(), key=lambda kv: kv[1], reverse=True)[:11]
+            }
+            self.tracker.snapshot_predictions(
+                league_id=league.id,
+                squad_scores=squad_scores,
+                best_11_ids=best_11,
+            )
+        except Exception:
+            logger.exception("snapshot_predictions failed (non-fatal)")
+
         # Step 3: If locked (match imminent), set lineup and exit — UNLESS the
         # squad is short. An empty lineup slot is worth -100 pts at kickoff;
         # the no-trade safety rule has to yield to the larger penalty.

--- a/rehoboam/bid_learner.py
+++ b/rehoboam/bid_learner.py
@@ -262,6 +262,32 @@ class BidLearner:
             """
             )
 
+            # Per-session EP prediction snapshots — required so post-matchday
+            # reconciliation can pair "what we predicted before kickoff" with
+            # "what actually happened" (matchday_outcomes). Without this
+            # table the scorer-self-calibration loop in
+            # get_position_calibration_multiplier has no input.
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS predicted_eps (
+                    player_id TEXT NOT NULL,
+                    league_id TEXT NOT NULL,
+                    predicted_at REAL NOT NULL,
+                    predicted_ep REAL NOT NULL,
+                    position TEXT NOT NULL,
+                    was_in_best_11 INTEGER NOT NULL DEFAULT 0,
+                    marginal_ep_gain REAL,
+                    PRIMARY KEY (player_id, predicted_at)
+                )
+            """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_predicted_eps_player_at
+                ON predicted_eps(player_id, predicted_at)
+            """
+            )
+
             conn.commit()
 
     def record_outcome(self, outcome: AuctionOutcome):
@@ -541,6 +567,80 @@ class BidLearner:
             cur = conn.execute("DELETE FROM recently_sold WHERE sold_at < ?", (cutoff,))
             conn.commit()
             return cur.rowcount
+
+    def snapshot_predictions(self, rows: list[dict]) -> int:
+        """Persist EP predictions for the current session.
+
+        Each row should provide: player_id, league_id, predicted_at (unix
+        seconds), predicted_ep, position, was_in_best_11, marginal_ep_gain.
+        Reconciliation later joins these against actual matchday points to
+        populate ``matchday_outcomes`` — without this snapshot, the scorer
+        has nothing to self-calibrate against.
+
+        Returns the number of rows inserted.
+        """
+        if not rows:
+            return 0
+        with sqlite3.connect(self.db_path) as conn:
+            conn.executemany(
+                """
+                INSERT OR REPLACE INTO predicted_eps (
+                    player_id, league_id, predicted_at, predicted_ep,
+                    position, was_in_best_11, marginal_ep_gain
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                [
+                    (
+                        r["player_id"],
+                        r["league_id"],
+                        r["predicted_at"],
+                        r["predicted_ep"],
+                        r["position"],
+                        1 if r.get("was_in_best_11") else 0,
+                        r.get("marginal_ep_gain"),
+                    )
+                    for r in rows
+                ],
+            )
+            conn.commit()
+        return len(rows)
+
+    def get_latest_prediction_before(self, player_id: str, before_ts: float) -> dict | None:
+        """Return the most recent prediction snapshot for *player_id* with
+        ``predicted_at <= before_ts``, or None if none exists.
+
+        Used by the matchday reconciliation path to find "what did we predict
+        for this player before kickoff?".
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cur = conn.execute(
+                """
+                SELECT player_id, league_id, predicted_at, predicted_ep,
+                       position, was_in_best_11, marginal_ep_gain
+                FROM predicted_eps
+                WHERE player_id = ? AND predicted_at <= ?
+                ORDER BY predicted_at DESC
+                LIMIT 1
+                """,
+                (player_id, before_ts),
+            )
+            row = cur.fetchone()
+            return dict(row) if row else None
+
+    def has_matchday_outcome(self, player_id: str, matchday_date: str) -> bool:
+        """True if ``matchday_outcomes`` already has a row for this player+date."""
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.execute(
+                """
+                SELECT 1 FROM matchday_outcomes
+                WHERE player_id = ? AND matchday_date = ?
+                LIMIT 1
+                """,
+                (player_id, matchday_date),
+            )
+            return cur.fetchone() is not None
 
     def record_matchday_outcome(
         self,

--- a/rehoboam/learning/tracker.py
+++ b/rehoboam/learning/tracker.py
@@ -22,6 +22,7 @@ into the BidLearner's history tables.
 
 import logging
 import time
+from datetime import datetime
 from pathlib import Path
 
 from ..bid_learner import AuctionOutcome, BidLearner, FlipOutcome
@@ -171,6 +172,153 @@ class LearningTracker:
     # ------------------------------------------------------------------
     # Flip outcome (bought + sold → profit recorded)
     # ------------------------------------------------------------------
+
+    # ------------------------------------------------------------------
+    # Matchday self-calibration (REH-20)
+    #
+    # `bid_learner.record_matchday_outcome` is the write side of the scorer
+    # self-calibration loop wired up in PR #17 — `get_position_calibration_multiplier`
+    # (read side) reads it back and corrects systematic per-position bias in
+    # the EP scorer.  Until this method existed nothing called the writer, so
+    # the read side has been returning the uncalibrated default of 1.0 since
+    # PR #17 merged.
+    # ------------------------------------------------------------------
+
+    def snapshot_predictions(
+        self,
+        league_id: str,
+        squad_scores: list,
+        best_11_ids: set[str],
+        predicted_at: float | None = None,
+    ) -> int:
+        """Persist this session's EP predictions for later reconciliation.
+
+        ``squad_scores`` is the list of :class:`~rehoboam.scoring.models.PlayerScore`
+        produced by the EP pipeline. We capture only what we need to evaluate
+        post-matchday: predicted_ep, position, and whether the player was in
+        the best-11 at prediction time.
+
+        Returns the number of rows written.
+        """
+        ts = predicted_at if predicted_at is not None else time.time()
+        rows = []
+        for ps in squad_scores:
+            try:
+                rows.append(
+                    {
+                        "player_id": ps.player_id,
+                        "league_id": league_id,
+                        "predicted_at": ts,
+                        "predicted_ep": ps.expected_points,
+                        "position": ps.position,
+                        "was_in_best_11": ps.player_id in best_11_ids,
+                        "marginal_ep_gain": None,
+                    }
+                )
+            except AttributeError:
+                # Defensive: skip any score row missing expected fields rather
+                # than blow up the session. Learning is best-effort.
+                continue
+        try:
+            count = self.bid_learner.snapshot_predictions(rows)
+            logger.info(
+                "snapshot_predictions: persisted %d EP predictions for league=%s at ts=%s",
+                count,
+                league_id,
+                int(ts),
+            )
+            return count
+        except Exception as e:
+            logger.warning("Failed to snapshot predictions: %s", e)
+            return 0
+
+    def reconcile_finished_matchdays(
+        self,
+        squad: list,
+        performance_by_player_id: dict[str, dict],
+    ) -> int:
+        """Pair past actual points with our pre-kickoff predictions.
+
+        Walks each squad player's ``performance['it'][0]['ph']`` (current-season
+        match history). For every match with ``mdst == 2`` (finished) that we
+        haven't already recorded into ``matchday_outcomes``, looks up the
+        snapshot prediction we made before that match's ``md`` timestamp and
+        writes a paired row.
+
+        Skips:
+          - matches without ``mdst == 2`` (still upcoming/in-progress)
+          - matches missing ``md`` or ``p`` (defensive)
+          - matchdays we already recorded (idempotent)
+          - players for whom we have no prior prediction snapshot
+
+        Returns the number of new ``matchday_outcomes`` rows written.
+        """
+        written = 0
+        for player in squad:
+            perf = performance_by_player_id.get(player.id)
+            if not perf:
+                continue
+            seasons = perf.get("it") or []
+            if not seasons:
+                continue
+            seasons_sorted = sorted(seasons, key=lambda s: s.get("ti", ""), reverse=True)
+            current_season = seasons_sorted[0]
+            matches = current_season.get("ph") or []
+
+            for match in matches:
+                if match.get("mdst") != 2:
+                    continue  # skip upcoming / in-progress
+                md_str = match.get("md")
+                actual_pts = match.get("p")
+                if not md_str or actual_pts is None:
+                    continue
+                if self.bid_learner.has_matchday_outcome(player.id, md_str):
+                    continue
+
+                try:
+                    md_dt = datetime.fromisoformat(md_str.replace("Z", "+00:00"))
+                    md_ts = md_dt.timestamp()
+                except (ValueError, AttributeError):
+                    continue
+
+                snapshot = self.bid_learner.get_latest_prediction_before(player.id, md_ts)
+                if snapshot is None:
+                    logger.debug(
+                        "reconcile: no prior prediction for %s before %s — skip",
+                        player.id,
+                        md_str,
+                    )
+                    continue
+
+                try:
+                    self.bid_learner.record_matchday_outcome(
+                        player_id=player.id,
+                        player_position=snapshot["position"],
+                        matchday_date=md_str,
+                        predicted_ep=snapshot["predicted_ep"],
+                        actual_points=float(actual_pts),
+                        was_in_best_11=bool(snapshot.get("was_in_best_11")),
+                    )
+                    written += 1
+                    logger.info(
+                        "reconcile: %s @ %s — predicted=%.1f actual=%s",
+                        getattr(player, "last_name", player.id),
+                        md_str,
+                        snapshot["predicted_ep"],
+                        actual_pts,
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "Failed to record matchday outcome for %s @ %s: %s",
+                        player.id,
+                        md_str,
+                        e,
+                    )
+        if written:
+            logger.info("reconcile_finished_matchdays: wrote %d new outcome row(s)", written)
+        else:
+            logger.debug("reconcile_finished_matchdays: no new outcomes to record")
+        return written
 
     def record_flip_outcome(self, player, sell_price: int, reason: str | None = None) -> None:
         """Compute and record a flip profit outcome for a sold player.

--- a/rehoboam/trader.py
+++ b/rehoboam/trader.py
@@ -241,9 +241,12 @@ class Trader:
 
         squad_scores: list = []
         squad_player_map: dict = {}
+        squad_performance: dict[str, dict] = {}
         for player in squad:
             try:
                 perf, details = _fetch_player_data(player)
+                if perf is not None:
+                    squad_performance[player.id] = perf
                 data = collector.collect(
                     player=player,
                     performance=perf,
@@ -367,6 +370,11 @@ class Trader:
             "squad_players": squad_player_map,
             "market_players": market_player_map,
             "competitor_player_ids": competitor_player_ids,
+            # Surfaced for matchday reconciliation (REH-20). Reconciliation
+            # needs raw performance dicts to read past actual points (`p`,
+            # `mdst`, `md`); piggybacking on the EP pipeline's existing
+            # fetch avoids a second round-trip.
+            "squad_performance": squad_performance,
         }
 
     def get_ep_recommendations_with_trends(self, league) -> dict:

--- a/tests/test_matchday_reconciliation.py
+++ b/tests/test_matchday_reconciliation.py
@@ -1,0 +1,333 @@
+"""Tests for REH-20: matchday outcome reconciliation.
+
+Covers the prediction snapshot path (`predicted_eps` table) and the
+reconciliation step that pairs prior snapshots with finished matchday
+performance (`mdst==2`) to populate `matchday_outcomes`.
+
+Without these, `BidLearner.get_position_calibration_multiplier()` always
+returns the uncalibrated default of 1.0 — the scorer self-calibration loop
+shipped in PR #17 is dead.
+"""
+
+import time
+from dataclasses import dataclass
+
+import pytest
+
+from rehoboam.bid_learner import BidLearner
+from rehoboam.learning.tracker import LearningTracker
+
+# ---------------------------------------------------------------------------
+# Lightweight stand-ins for production objects. We don't pull in MarketPlayer
+# or PlayerScore because both have many required fields irrelevant to this
+# code path.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakePlayer:
+    id: str
+    last_name: str = "Tester"
+
+
+@dataclass
+class FakeScore:
+    player_id: str
+    expected_points: float
+    position: str
+
+
+@pytest.fixture
+def learner(tmp_path):
+    return BidLearner(db_path=tmp_path / "bid_learning.db")
+
+
+@pytest.fixture
+def tracker(learner):
+    return LearningTracker(learner)
+
+
+# ---------------------------------------------------------------------------
+# BidLearner.snapshot_predictions / get_latest_prediction_before
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshotPredictions:
+    def test_round_trip_single_row(self, learner):
+        ts = 1_700_000_000.0
+        count = learner.snapshot_predictions(
+            [
+                {
+                    "player_id": "p1",
+                    "league_id": "L",
+                    "predicted_at": ts,
+                    "predicted_ep": 65.5,
+                    "position": "MID",
+                    "was_in_best_11": True,
+                    "marginal_ep_gain": 4.2,
+                }
+            ]
+        )
+        assert count == 1
+
+        snap = learner.get_latest_prediction_before("p1", ts + 1)
+        assert snap is not None
+        assert snap["predicted_ep"] == pytest.approx(65.5)
+        assert snap["position"] == "MID"
+        assert snap["was_in_best_11"] == 1
+
+    def test_empty_input_is_noop(self, learner):
+        assert learner.snapshot_predictions([]) == 0
+        assert learner.get_latest_prediction_before("p1", time.time()) is None
+
+    def test_picks_most_recent_prior_snapshot(self, learner):
+        # Three snapshots: oldest, middle, newest.
+        for ep, ts in [(40.0, 100), (50.0, 200), (60.0, 300)]:
+            learner.snapshot_predictions(
+                [
+                    {
+                        "player_id": "p1",
+                        "league_id": "L",
+                        "predicted_at": float(ts),
+                        "predicted_ep": ep,
+                        "position": "MID",
+                        "was_in_best_11": False,
+                    }
+                ]
+            )
+
+        # Asking for the snapshot before t=250 should return ts=200 (middle).
+        snap = learner.get_latest_prediction_before("p1", 250.0)
+        assert snap is not None
+        assert snap["predicted_ep"] == pytest.approx(50.0)
+
+        # Asking for the snapshot before t=400 should return ts=300 (newest).
+        snap = learner.get_latest_prediction_before("p1", 400.0)
+        assert snap["predicted_ep"] == pytest.approx(60.0)
+
+    def test_returns_none_when_no_prior_snapshot(self, learner):
+        learner.snapshot_predictions(
+            [
+                {
+                    "player_id": "p1",
+                    "league_id": "L",
+                    "predicted_at": 500.0,
+                    "predicted_ep": 60.0,
+                    "position": "MID",
+                    "was_in_best_11": False,
+                }
+            ]
+        )
+        # Snapshot is AFTER the requested cutoff — nothing returned.
+        assert learner.get_latest_prediction_before("p1", 100.0) is None
+
+    def test_replace_on_same_pk(self, learner):
+        ts = 1_700_000_000.0
+        learner.snapshot_predictions(
+            [
+                {
+                    "player_id": "p1",
+                    "league_id": "L",
+                    "predicted_at": ts,
+                    "predicted_ep": 50.0,
+                    "position": "MID",
+                    "was_in_best_11": False,
+                }
+            ]
+        )
+        # Re-snapshot at the same ts with a different EP — primary key
+        # (player_id, predicted_at) means the second write replaces the first.
+        learner.snapshot_predictions(
+            [
+                {
+                    "player_id": "p1",
+                    "league_id": "L",
+                    "predicted_at": ts,
+                    "predicted_ep": 70.0,
+                    "position": "MID",
+                    "was_in_best_11": True,
+                }
+            ]
+        )
+        snap = learner.get_latest_prediction_before("p1", ts + 1)
+        assert snap["predicted_ep"] == pytest.approx(70.0)
+        assert snap["was_in_best_11"] == 1
+
+
+class TestHasMatchdayOutcome:
+    def test_returns_false_when_empty(self, learner):
+        assert learner.has_matchday_outcome("p1", "2026-04-15T15:30:00Z") is False
+
+    def test_returns_true_after_record(self, learner):
+        learner.record_matchday_outcome(
+            player_id="p1",
+            player_position="MID",
+            matchday_date="2026-04-15T15:30:00Z",
+            predicted_ep=60.0,
+            actual_points=72.0,
+        )
+        assert learner.has_matchday_outcome("p1", "2026-04-15T15:30:00Z") is True
+        # Different date → still false.
+        assert learner.has_matchday_outcome("p1", "2026-04-22T15:30:00Z") is False
+
+
+# ---------------------------------------------------------------------------
+# LearningTracker.snapshot_predictions
+# ---------------------------------------------------------------------------
+
+
+class TestTrackerSnapshot:
+    def test_writes_one_row_per_squad_score(self, tracker, learner):
+        scores = [
+            FakeScore(player_id="p1", expected_points=60.0, position="MID"),
+            FakeScore(player_id="p2", expected_points=45.0, position="DEF"),
+        ]
+        n = tracker.snapshot_predictions(
+            league_id="L",
+            squad_scores=scores,
+            best_11_ids={"p1"},
+            predicted_at=1_000.0,
+        )
+        assert n == 2
+        snap1 = learner.get_latest_prediction_before("p1", 2_000.0)
+        snap2 = learner.get_latest_prediction_before("p2", 2_000.0)
+        assert snap1["was_in_best_11"] == 1
+        assert snap2["was_in_best_11"] == 0
+
+    def test_empty_squad_scores_is_zero_rows(self, tracker):
+        n = tracker.snapshot_predictions(
+            league_id="L",
+            squad_scores=[],
+            best_11_ids=set(),
+        )
+        assert n == 0
+
+
+# ---------------------------------------------------------------------------
+# LearningTracker.reconcile_finished_matchdays
+# ---------------------------------------------------------------------------
+
+
+def _perf_with_matches(matches: list[dict]) -> dict:
+    """Wrap a list of match dicts in the structure produced by
+    `get_player_performance` — `it[0].ph` is the current season's history."""
+    return {"it": [{"ti": "2026", "ph": matches}]}
+
+
+class TestReconcileFinishedMatchdays:
+    def test_records_finished_match_with_prior_snapshot(self, tracker, learner):
+        # Snapshot a prediction BEFORE the matchday's `md` timestamp.
+        # Match `md` = 2026-04-15T15:30:00Z = unix 1776264600
+        match_ts = 1_776_264_600
+        snapshot_ts = match_ts - 3600  # 1h before kickoff
+        tracker.snapshot_predictions(
+            league_id="L",
+            squad_scores=[FakeScore(player_id="p1", expected_points=60.0, position="MID")],
+            best_11_ids={"p1"},
+            predicted_at=float(snapshot_ts),
+        )
+
+        squad = [FakePlayer(id="p1")]
+        perf = {
+            "p1": _perf_with_matches(
+                [{"mi": "1", "p": 72, "md": "2026-04-15T15:30:00Z", "mdst": 2}]
+            )
+        }
+        n = tracker.reconcile_finished_matchdays(squad, perf)
+        assert n == 1
+        assert learner.has_matchday_outcome("p1", "2026-04-15T15:30:00Z")
+
+    def test_skips_unfinished_match(self, tracker, learner):
+        match_ts = 1_776_264_600
+        tracker.snapshot_predictions(
+            league_id="L",
+            squad_scores=[FakeScore(player_id="p1", expected_points=60.0, position="MID")],
+            best_11_ids=set(),
+            predicted_at=float(match_ts - 3600),
+        )
+
+        # mdst=0 = upcoming, mdst=1 = in progress; only mdst=2 should record.
+        perf = {
+            "p1": _perf_with_matches(
+                [
+                    {"mi": "1", "p": 0, "md": "2026-04-15T15:30:00Z", "mdst": 0},
+                    {"mi": "2", "p": 50, "md": "2026-04-22T15:30:00Z", "mdst": 1},
+                ]
+            )
+        }
+        n = tracker.reconcile_finished_matchdays([FakePlayer(id="p1")], perf)
+        assert n == 0
+
+    def test_idempotent_on_second_call(self, tracker, learner):
+        match_ts = 1_776_264_600
+        tracker.snapshot_predictions(
+            league_id="L",
+            squad_scores=[FakeScore(player_id="p1", expected_points=60.0, position="MID")],
+            best_11_ids=set(),
+            predicted_at=float(match_ts - 3600),
+        )
+        squad = [FakePlayer(id="p1")]
+        perf = {
+            "p1": _perf_with_matches(
+                [{"mi": "1", "p": 72, "md": "2026-04-15T15:30:00Z", "mdst": 2}]
+            )
+        }
+        first = tracker.reconcile_finished_matchdays(squad, perf)
+        second = tracker.reconcile_finished_matchdays(squad, perf)
+        assert first == 1
+        # Second pass sees the existing row via has_matchday_outcome and skips.
+        assert second == 0
+
+    def test_skips_player_without_prior_snapshot(self, tracker, learner):
+        # No snapshot persisted before reconciliation → cannot pair predicted
+        # with actual; row must NOT be written.
+        squad = [FakePlayer(id="p1")]
+        perf = {
+            "p1": _perf_with_matches(
+                [{"mi": "1", "p": 72, "md": "2026-04-15T15:30:00Z", "mdst": 2}]
+            )
+        }
+        n = tracker.reconcile_finished_matchdays(squad, perf)
+        assert n == 0
+        assert not learner.has_matchday_outcome("p1", "2026-04-15T15:30:00Z")
+
+    def test_skips_match_when_only_snapshot_is_after_kickoff(self, tracker, learner):
+        # The only snapshot we have was taken AFTER the matchday — that's
+        # a leak (post-kickoff prediction shouldn't count as "predicted").
+        # `get_latest_prediction_before` filters this out.
+        match_ts = 1_776_264_600
+        tracker.snapshot_predictions(
+            league_id="L",
+            squad_scores=[FakeScore(player_id="p1", expected_points=60.0, position="MID")],
+            best_11_ids=set(),
+            predicted_at=float(match_ts + 3600),  # 1h AFTER kickoff
+        )
+        squad = [FakePlayer(id="p1")]
+        perf = {
+            "p1": _perf_with_matches(
+                [{"mi": "1", "p": 72, "md": "2026-04-15T15:30:00Z", "mdst": 2}]
+            )
+        }
+        n = tracker.reconcile_finished_matchdays(squad, perf)
+        assert n == 0
+
+    def test_handles_missing_performance(self, tracker, learner):
+        # Player in squad but no perf data at all (e.g. fetch failed).
+        squad = [FakePlayer(id="p1"), FakePlayer(id="p2")]
+        perf = {}  # nothing
+        n = tracker.reconcile_finished_matchdays(squad, perf)
+        assert n == 0
+
+    def test_handles_malformed_md_string(self, tracker, learner):
+        # Snapshot exists, but `md` field on the match is unparseable —
+        # reconcile should swallow and continue without raising.
+        tracker.snapshot_predictions(
+            league_id="L",
+            squad_scores=[FakeScore(player_id="p1", expected_points=60.0, position="MID")],
+            best_11_ids=set(),
+            predicted_at=1_000.0,
+        )
+        squad = [FakePlayer(id="p1")]
+        perf = {"p1": _perf_with_matches([{"mi": "1", "p": 72, "md": "not-a-date", "mdst": 2}])}
+        n = tracker.reconcile_finished_matchdays(squad, perf)
+        assert n == 0


### PR DESCRIPTION
Closes [REH-20](https://linear.app/jovily/issue/REH-20).

## What's broken

The scorer self-calibration loop shipped in PR #17 (Apr 14) was half-wired in production:

- ✅ **Read side live**: `BidLearner.get_position_calibration_multiplier` is called once per session at `trader.py:215` and feeds the result into `score_player(..., calibration_multiplier=...)`.
- ❌ **Write side dead**: `BidLearner.record_matchday_outcome` had **zero callers** anywhere in the codebase.

So `matchday_outcomes` stayed empty on Azure for ~3 weeks, the read side returned the uncalibrated default of 1.0 every time, and the bot has been making bid/buy/lineup decisions on EP estimates that never self-corrected. CLAUDE.md confidently claims the loop was closed; it was not.

## What this PR does

End-to-end wire-up of the loop:

1. **New `predicted_eps` table** captures per-session EP predictions per squad player. The bot never persisted predictions before — without this, ``what did we predict before kickoff?'' is unanswerable.
2. **`BidLearner.snapshot_predictions`** (bulk insert) and **`get_latest_prediction_before(player_id, before_ts)`** (lookup). PK `(player_id, predicted_at)` so snapshots stack across runs.
3. **`BidLearner.has_matchday_outcome`** so reconciliation can short-circuit already-recorded matchdays. Keeps the per-session pass O(new only).
4. **`LearningTracker.snapshot_predictions`** translates `PlayerScore` rows into snapshots; best-11 flag comes from the EP pipeline's `lineup_map`.
5. **`LearningTracker.reconcile_finished_matchdays`** walks each squad player's `performance['it'][0]['ph']`, picks finished matches (`mdst == 2`), looks up the snapshot strictly *before* the match's `md` timestamp, and writes a paired `matchday_outcomes` row.
6. **`Trader.get_ep_recommendations`** now surfaces `squad_performance` (raw perf dicts keyed by player_id) so reconcile can read past actual points without a duplicate API round-trip.
7. **`auto_trader.run_full_session`** calls reconcile-then-snapshot right after `_build_session_context`, on the success path only.

### Why reconcile-then-snapshot, not snapshot-then-reconcile

If we snapshot first, the current run's prediction becomes the ``latest snapshot before kickoff'' for any matchday whose `md` lies between this snapshot and the next reconcile, contaminating the actual-vs-predicted pairing. Reconcile reads only snapshots from prior sessions, then we add today's snapshot last.

### Why both wrapped in try/except

Learning side effects must never block trading. A failed write is not worse than skipped data. Stack traces still flow into `logs/rehoboam.log` via `logger.exception` from the structured-logging PR.

## Tests

`tests/test_matchday_reconciliation.py` covers:

- snapshot round-trip + ordering (most-recent-prior wins)
- `INSERT OR REPLACE` on duplicate PK
- reconcile records finished matches with prior snapshots
- reconcile skips: unfinished matches (`mdst != 2`), malformed `md` strings, players with no prior snapshot, matches whose only snapshot is post-kickoff
- reconcile is idempotent — running twice produces same row count
- handles missing performance data gracefully

## Test plan

- [x] `python -m compileall` on all modified files — clean
- [x] `ruff check` — passes
- [x] `pre-commit run` (black + ruff + bandit + pyupgrade) — passes
- [x] End-to-end smoke script against a temp DB: 2 squad players × (1 finished + 1 upcoming) match → 2 outcome rows on first reconcile, 0 on second. Predicted/actual pairs correctly stored.
- [ ] CI pytest (3.10/3.11/3.12) — local pytest still blocked by pre-existing pydantic-core/Python 3.14 mismatch.
- [ ] After deploy + the next matchday completes, verify `sqlite3 bid_learning.db "SELECT COUNT(*) FROM matchday_outcomes"` grows by ~15 (one per squad player).

## Out of scope

- **Backfill** of historical matchdays before this PR lands — REH-20 marked as out of scope and stays that way. Calibration begins effective from the next matchday after deploy.
- **REH-21** (`update_position_statistics` has zero callers) is a separate fix.
- **REH-22** (drop dead-schema tables) is a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)