### PR TITLE
fix: wire EP-bid learned overbid override (REH-30)

### DIFF
--- a/rehoboam/bidding_strategy.py
+++ b/rehoboam/bidding_strategy.py
@@ -497,19 +497,40 @@ class SmartBidding:
         max_overbid = self.elite_max_overbid_pct if ep_tier == "must_have" else self.max_overbid_pct
         overbid_pct = min(overbid_pct, max_overbid)
 
-        # Try EP-specific learned overbid if available
+        # Try EP-specific learned overbid if available.
+        #
+        # The previous call here passed kwargs that didn't match the method
+        # signature and treated the dict return as a number, so every bid
+        # since the method was added went through with the EP-bid learner
+        # silently disabled by the surrounding `except Exception`. Result:
+        # `auction_outcomes` data accumulated but never influenced bids
+        # (REH-30).
         if self.bid_learner:
             try:
-                learned_pct = self.bid_learner.get_ep_recommended_overbid(
+                learned = self.bid_learner.get_ep_recommended_overbid(
+                    asking_price=asking_price,
                     marginal_ep_gain=marginal_ep_gain,
-                    confidence=confidence,
+                    market_value=market_value,
+                    budget_ceiling=budget_ceiling,
                 )
-                if learned_pct and learned_pct > 0:
+                learned_pct = learned.get("recommended_overbid_pct", 0.0)
+                if learned_pct > 0:
+                    stack_pct = overbid_pct
                     overbid_pct = min(learned_pct, max_overbid)
-            except AttributeError:
-                pass  # Method not yet implemented on BidLearner — expected
+                    logger.info(
+                        "ep-bid learned-override player=%s stack=%.1f%% "
+                        "learned=%.1f%% applied=%.1f%% | %s",
+                        player_id,
+                        stack_pct,
+                        learned_pct,
+                        overbid_pct,
+                        learned.get("reason", ""),
+                    )
             except Exception:
-                pass
+                logger.exception(
+                    "ep-bid learned-override failed for player=%s — using stack default",
+                    player_id,
+                )
 
         # Calculate raw bid from overbid percentage
         overbid_amount = int(asking_price * (overbid_pct / 100))


### PR DESCRIPTION
Closes [REH-30](https://linear.app/jovily/issue/REH-30).

## What was broken

The production call to `BidLearner.get_ep_recommended_overbid` in `SmartBidding.calculate_ep_bid` had **three** bugs, all hidden by a silent `except Exception: pass`:

1. Wrong kwargs — passed `marginal_ep_gain` + `confidence` to a method whose signature is `(asking_price, marginal_ep_gain, market_value, budget_ceiling)`.
2. Treated the dict return as a number — `if learned_pct and learned_pct > 0` against a `dict[str, Any]`.
3. Assigned the dict to `overbid_pct` if (2) had ever evaluated truthy.

The first failure raised `TypeError`, (2)/(3) never executed, and `except Exception: pass` swallowed everything. **The EP-learned overbid override has been silently disabled since the method was added** — `auction_outcomes` data accumulated for nothing.

## What this fixes

- Pass the four correct args (all already in scope at the call site).
- Unpack the dict via `.get(\"recommended_overbid_pct\", 0.0)` — matches the canonical test pattern at `tests/test_matchday_outcomes.py:481`.
- Drop the legacy ` except AttributeError ` guard (stale comment claimed the method ' isn't implemented yet ' — it has been for weeks).
- Replace the silent `except Exception: pass` with `logger.exception` so the next time something breaks, the stack trace lands in `logs/rehoboam.log` instead of vanishing.
- Add an `INFO` log line surfacing the override decision: pre-override stack value, raw learner value, post-cap applied value, plus the learner's reason string.

## Behavioral note (worth knowing)

With `auction_outcomes` at ~1 row today, the method's `win_rate` branch hits its `total_auctions >= 5` floor and returns roughly:

```
recommended = max(marginal_ep_gain * 0.3, 8.0) * 1.0 * 1.0  ≈ 8% floor
```

So as soon as this lands, the learner override fires at roughly an 8% floor regardless of tier+demand+trend stack — **the fix changes bid behavior immediately, not gradually as data accumulates.** As more auctions resolve and `matchday_outcomes` fills (REH-20 just wired the writes), the learner's signal sharpens.

Discussed with user before implementing — they accepted this trade-off in favour of the lean fix per the issue spec.

## Test plan

- [x] `python -m compileall` clean
- [x] `ruff check` clean
- [x] `pre-commit run` (black + ruff + bandit + pyupgrade) clean
- [x] Live smoke against a fresh `BidLearner` DB: confirms `get_ep_recommended_overbid(asking_price=10M, marginal_ep_gain=15.0, market_value=10M, budget_ceiling=50M)` returns `{recommended_overbid_pct: 8.0, reason: '…insufficient auction history…'}` — exact dict shape the call site now consumes.
- [x] Code-reviewer agent passed all 6 verification points (args match signature, dict unpack correct, side-effect order clear, logger context valid, error handling preserves graceful degradation, comment accurate).
- [ ] CI pytest (3.10/3.11/3.12) — local pytest still blocked by pre-existing pydantic-core/Python 3.14 mismatch.
- [ ] Post-deploy: confirm `grep \"ep-bid learned-override\" logs/rehoboam.log` shows non-empty applied values starting from the next session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)