### PR TITLE
feat: persist team_value time-series per session (REH-23)

### DIFF
--- a/rehoboam/auto_trader.py
+++ b/rehoboam/auto_trader.py
@@ -1059,6 +1059,18 @@ class AutoTrader:
             )
         except Exception:
             logger.exception("snapshot_predictions failed (non-fatal)")
+        try:
+            # REH-23: persist the team_value/budget snapshot the bot already
+            # fetched in _build_session_context. Provides the longitudinal
+            # series for goal 3 (team value growth) and feeds REH-37.
+            self.learner.record_team_value_snapshot(
+                league_id=league.id,
+                team_value=ctx.team_value,
+                budget=ctx.current_budget,
+                squad_size=len(ctx.squad),
+            )
+        except Exception:
+            logger.exception("record_team_value_snapshot failed (non-fatal)")
 
         # Step 3: If locked (match imminent), set lineup and exit — UNLESS the
         # squad is short. An empty lineup slot is worth -100 pts at kickoff;

--- a/rehoboam/bid_learner.py
+++ b/rehoboam/bid_learner.py
@@ -288,6 +288,23 @@ class BidLearner:
             """
             )
 
+            # Per-session team-value snapshot — REH-23.
+            # The bot fetches budget + team_value every run via get_team_info()
+            # but throws the result away after logging it. Persisting it gives
+            # us a longitudinal series for goal 3 (team value increases over
+            # time) and feeds REH-37 (rank-trajectory regression).
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS team_value_history (
+                    snapshot_at REAL PRIMARY KEY,
+                    league_id TEXT NOT NULL,
+                    team_value INTEGER NOT NULL,
+                    budget INTEGER NOT NULL,
+                    squad_size INTEGER NOT NULL
+                )
+            """
+            )
+
             conn.commit()
 
     def record_outcome(self, outcome: AuctionOutcome):
@@ -628,6 +645,39 @@ class BidLearner:
             )
             row = cur.fetchone()
             return dict(row) if row else None
+
+    def record_team_value_snapshot(
+        self,
+        league_id: str,
+        team_value: int,
+        budget: int,
+        squad_size: int,
+        snapshot_at: float | None = None,
+    ) -> bool:
+        """Persist one row of team_value_history for the current session.
+
+        Returns True if a row was inserted, False if a row already existed at
+        the same ``snapshot_at`` (theoretical collision when two sessions land
+        in the same float second — the second is silently dropped via
+        ``INSERT OR IGNORE``). Caller does not need to check the return value;
+        it's exposed for tests.
+
+        REH-23: feeds goal 3 (team value increases over time) and unblocks
+        REH-37 (rank-trajectory regression).
+        """
+        ts = snapshot_at if snapshot_at is not None else datetime.now().timestamp()
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.execute(
+                """
+                INSERT OR IGNORE INTO team_value_history (
+                    snapshot_at, league_id, team_value, budget, squad_size
+                )
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (ts, league_id, int(team_value), int(budget), int(squad_size)),
+            )
+            conn.commit()
+            return cur.rowcount > 0
 
     def has_matchday_outcome(self, player_id: str, matchday_date: str) -> bool:
         """True if ``matchday_outcomes`` already has a row for this player+date."""

--- a/tests/test_team_value_history.py
+++ b/tests/test_team_value_history.py
@@ -1,0 +1,114 @@
+"""Tests for REH-23: team_value_history persistence.
+
+The bot fetches budget + team_value every session via get_team_info() but
+historically discarded the result. record_team_value_snapshot() persists
+one row per session into team_value_history, giving us a longitudinal
+series for goal 3 (team value growth) and feeding REH-37 (rank-trajectory
+regression).
+"""
+
+import sqlite3
+
+import pytest
+
+from rehoboam.bid_learner import BidLearner
+
+
+@pytest.fixture
+def learner(tmp_path):
+    return BidLearner(db_path=tmp_path / "bid_learning.db")
+
+
+class TestTeamValueSnapshot:
+    def test_round_trip_single_row(self, learner):
+        inserted = learner.record_team_value_snapshot(
+            league_id="L1",
+            team_value=85_000_000,
+            budget=12_500_000,
+            squad_size=15,
+            snapshot_at=1_700_000_000.0,
+        )
+        assert inserted is True
+
+        with sqlite3.connect(learner.db_path) as conn:
+            row = conn.execute(
+                "SELECT snapshot_at, league_id, team_value, budget, squad_size "
+                "FROM team_value_history"
+            ).fetchone()
+        assert row == (1_700_000_000.0, "L1", 85_000_000, 12_500_000, 15)
+
+    def test_default_timestamp_is_now(self, learner):
+        # When snapshot_at is omitted, should default to roughly current time.
+        # Don't assert exact; assert > a fixed past sentinel.
+        learner.record_team_value_snapshot(
+            league_id="L1",
+            team_value=50_000_000,
+            budget=5_000_000,
+            squad_size=11,
+        )
+        with sqlite3.connect(learner.db_path) as conn:
+            ts = conn.execute("SELECT snapshot_at FROM team_value_history").fetchone()[0]
+        # 2026-01-01 = 1767225600. Anything written today is well past that.
+        assert ts > 1_767_225_600
+
+    def test_multiple_snapshots_ordered_monotonically(self, learner):
+        for i, ts in enumerate([100.0, 200.0, 300.0]):
+            learner.record_team_value_snapshot(
+                league_id="L1",
+                team_value=50_000_000 + i * 1_000_000,
+                budget=5_000_000,
+                squad_size=15,
+                snapshot_at=ts,
+            )
+        with sqlite3.connect(learner.db_path) as conn:
+            rows = conn.execute(
+                "SELECT snapshot_at, team_value FROM team_value_history " "ORDER BY snapshot_at"
+            ).fetchall()
+        assert rows == [
+            (100.0, 50_000_000),
+            (200.0, 51_000_000),
+            (300.0, 52_000_000),
+        ]
+
+    def test_collision_at_same_timestamp_silently_dropped(self, learner):
+        # PK is snapshot_at. Two writes at the same timestamp (e.g. Azure
+        # cold-start retry) should not raise; second insert returns False.
+        first = learner.record_team_value_snapshot(
+            league_id="L1",
+            team_value=50_000_000,
+            budget=5_000_000,
+            squad_size=15,
+            snapshot_at=42.0,
+        )
+        second = learner.record_team_value_snapshot(
+            league_id="L1",
+            team_value=99_999_999,  # different values — should NOT overwrite
+            budget=99_999_999,
+            squad_size=99,
+            snapshot_at=42.0,
+        )
+        assert first is True
+        assert second is False
+
+        # Verify the first row was preserved (INSERT OR IGNORE — not REPLACE).
+        with sqlite3.connect(learner.db_path) as conn:
+            count = conn.execute("SELECT COUNT(*) FROM team_value_history").fetchone()[0]
+            kept = conn.execute(
+                "SELECT team_value FROM team_value_history WHERE snapshot_at = 42.0"
+            ).fetchone()[0]
+        assert count == 1
+        assert kept == 50_000_000
+
+    def test_int_coercion_for_team_value_and_budget(self, learner):
+        # Caller might pass float (Kickbase API sometimes returns floats).
+        # Schema is INTEGER — record method should coerce.
+        learner.record_team_value_snapshot(
+            league_id="L1",
+            team_value=85_500_000.5,  # type: ignore[arg-type]
+            budget=12_500_000.7,  # type: ignore[arg-type]
+            squad_size=15,
+            snapshot_at=999.0,
+        )
+        with sqlite3.connect(learner.db_path) as conn:
+            row = conn.execute("SELECT team_value, budget FROM team_value_history").fetchone()
+        assert row == (85_500_000, 12_500_000)


### PR DESCRIPTION
Closes [REH-23](https://linear.app/jovily/issue/REH-23). Foundation issue #1 of 4 for the bot's learning roadmap.

## What was missing

The bot calls `get_team_info(league)` every session in `auto_trader._build_session_context` and reads `budget` + `team_value` from the response. Until now those values were logged once and discarded — no longitudinal record of how team value has changed. Goal 3 ("team value increases over time") was unmeasurable.

## What this PR does

Free-data win: persists what we already fetch. One INSERT per session.

1. **New table** `team_value_history` in `bid_learning.db`:
   ```sql
   CREATE TABLE IF NOT EXISTS team_value_history (
       snapshot_at REAL PRIMARY KEY,
       league_id TEXT NOT NULL,
       team_value INTEGER NOT NULL,
       budget INTEGER NOT NULL,
       squad_size INTEGER NOT NULL
   )
   ```

2. **Writer** `BidLearner.record_team_value_snapshot(league_id, team_value, budget, squad_size, snapshot_at=None) -> bool`. Returns `True` on insert, `False` on PK collision (caller doesn't have to check).

3. **Wire-up** in `auto_trader.run_full_session` Step 2a, alongside the REH-20 reconcile + snapshot_predictions calls. Wrapped in try/except so a learning-side failure cannot block trading.

## Design choices (worth scrutinising)

- **`INSERT OR IGNORE`** rather than `OR REPLACE`. Two retries within the same float second are the same logical snapshot — dropping the second write is correct, and `test_collision_at_same_timestamp_silently_dropped` explicitly verifies the original row is preserved.
- **Direct `self.learner.record_*` call** rather than routing through `LearningTracker`. Tracker mediates lifecycle state (pending bids, tracked purchases) and operations that require transformation (PlayerScore → row dict). Pure plumbing writes go direct — matches the existing pattern at `auto_trader.py:636` where `self.learner.was_recently_sold` is also called direct.
- **`int()` coercion** on monetary values. Kickbase API occasionally returns floats; SQLite would silently store those as REAL into an INTEGER column, breaking round-trip equality assertions.

## Reviewer flagged (declined for now)

The PK is `snapshot_at` alone — not `(snapshot_at, league_id)`. If the bot ever supports multiple leagues simultaneously, two leagues running in the same second would collide. Single-league deployment per CLAUDE.md, so YAGNI. If REH-37's multi-league plans materialise, swap to a composite PK then.

## Test plan

- [x] `python -m compileall` clean
- [x] `ruff check` clean
- [x] `pre-commit run` (black + ruff + bandit + pyupgrade) clean
- [x] End-to-end smoke against temp DB: 1 insert + 1 collision (returns False, original preserved) + 3 more inserts = 4 rows in monotonic order ✓
- [x] 5 unit tests in `tests/test_team_value_history.py`: round-trip, default-timestamp now, multi-snapshot ordering, collision drop, int coercion
- [x] Reviewer agent passed all 5 verification points (schema, INSERT OR IGNORE, wire-up placement, pattern consistency vs tracker, int coercion)
- [ ] CI pytest (3.10/3.11/3.12) — local pytest still blocked by pre-existing pydantic-core/Python 3.14 mismatch
- [ ] Post-deploy: `sqlite3 bid_learning.db \"SELECT COUNT(*) FROM team_value_history\"` grows by 1 per session, monotonically

🤖 Generated with [Claude Code](https://claude.com/claude-code)