### PR TITLE
feat: persist league rank + per-manager team_value/points (REH-24)

### DIFF
--- a/rehoboam/api.py
+++ b/rehoboam/api.py
@@ -177,10 +177,15 @@ class KickbaseAPI:
         except Exception as e:
             raise Exception(f"Failed to fetch manager squad: {e}") from e
 
-    def get_league_ranking(self, league: League) -> dict:
-        """Get league ranking/standings"""
+    def get_league_ranking(self, league: League, day_number: int | None = None) -> dict:
+        """Get league ranking/standings.
+
+        ``day_number`` returns historical rankings for that matchday (REH-24
+        capture writes the current snapshot only; backfill is a separate
+        concern handled outside the bot's session loop).
+        """
         try:
-            return self.client.get_league_ranking(league.id)
+            return self.client.get_league_ranking(league.id, day_number=day_number)
         except Exception as e:
             raise Exception(f"Failed to fetch league ranking: {e}") from e
 

--- a/rehoboam/bid_learner.py
+++ b/rehoboam/bid_learner.py
@@ -25,6 +25,14 @@ class AuctionOutcome:
     market_value: int | None = None
 
 
+def _opt_int(value: Any) -> int | None:
+    """None-preserving int coercion. Used by writers that accept partial
+    rows where any numeric column may legitimately be missing."""
+    if value is None:
+        return None
+    return int(value)
+
+
 @dataclass
 class FlipOutcome:
     """Record of a completed flip (buy + sell)"""
@@ -302,6 +310,37 @@ class BidLearner:
                     budget INTEGER NOT NULL,
                     squad_size INTEGER NOT NULL
                 )
+            """
+            )
+
+            # League rank snapshot per session — REH-24.
+            # The /ranking response already includes per-manager team_value
+            # (`tv`), season points (`sp`), season placement (`spl`),
+            # matchday points (`mdp`), matchday placement (`mdpl`) — all the
+            # data goals 3, 4, 5 need. trader.py:179 was already calling this
+            # for competitor_player_ids; we now persist what was discarded.
+            # Composite PK lets a single session insert one row per manager.
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS league_rank_history (
+                    snapshot_at REAL NOT NULL,
+                    league_id TEXT NOT NULL,
+                    manager_id TEXT NOT NULL,
+                    day_number INTEGER NOT NULL,
+                    rank_overall INTEGER,
+                    rank_matchday INTEGER,
+                    total_points INTEGER,
+                    matchday_points INTEGER,
+                    team_value INTEGER,
+                    is_self INTEGER NOT NULL DEFAULT 0,
+                    PRIMARY KEY (snapshot_at, manager_id)
+                )
+            """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_league_rank_self_at
+                ON league_rank_history(is_self, snapshot_at)
             """
             )
 
@@ -678,6 +717,59 @@ class BidLearner:
             )
             conn.commit()
             return cur.rowcount > 0
+
+    def record_league_rank_snapshot(self, rows: list[dict]) -> int:
+        """Bulk-persist one row per manager into ``league_rank_history``.
+
+        Each row should provide:
+            snapshot_at, league_id, manager_id, day_number, is_self
+            rank_overall, rank_matchday, total_points, matchday_points,
+            team_value
+        Missing optional fields default to None — the schema accepts NULL on
+        all the numeric columns so a partial response (e.g. mid-season the
+        previous-week's matchday placement is None) doesn't blow up the row.
+
+        Uses ``INSERT OR IGNORE`` so a same-second retry collapses
+        deterministically rather than overwriting; PK is
+        ``(snapshot_at, manager_id)``.
+
+        REH-24: feeds goals 3 (team value growth across the league),
+        4 (matchday points trajectory), and 5 (rank trajectory). Returns the
+        number of rows attempted (NOT the number actually inserted, since
+        sqlite3 doesn't expose per-row outcomes from executemany; tests
+        verify behavior by reading back).
+        """
+        if not rows:
+            return 0
+        with sqlite3.connect(self.db_path) as conn:
+            conn.executemany(
+                """
+                INSERT OR IGNORE INTO league_rank_history (
+                    snapshot_at, league_id, manager_id, day_number,
+                    rank_overall, rank_matchday,
+                    total_points, matchday_points,
+                    team_value, is_self
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                [
+                    (
+                        r["snapshot_at"],
+                        r["league_id"],
+                        r["manager_id"],
+                        int(r["day_number"]),
+                        _opt_int(r.get("rank_overall")),
+                        _opt_int(r.get("rank_matchday")),
+                        _opt_int(r.get("total_points")),
+                        _opt_int(r.get("matchday_points")),
+                        _opt_int(r.get("team_value")),
+                        1 if r.get("is_self") else 0,
+                    )
+                    for r in rows
+                ],
+            )
+            conn.commit()
+        return len(rows)
 
     def has_matchday_outcome(self, player_id: str, matchday_date: str) -> bool:
         """True if ``matchday_outcomes`` already has a row for this player+date."""

--- a/rehoboam/kickbase_client.py
+++ b/rehoboam/kickbase_client.py
@@ -692,12 +692,20 @@ class KickbaseV4Client:
                 f"Failed to fetch manager squad: {response.status_code} - {response.text}"
             )
 
-    def get_league_ranking(self, league_id: str) -> dict[str, Any]:
+    def get_league_ranking(self, league_id: str, day_number: int | None = None) -> dict[str, Any]:
         """
-        Get league ranking/standings
-        GET /v4/leagues/{league_id}/ranking
+        Get league ranking/standings.
+
+        ``day_number`` (optional) returns the historical state at the end of
+        that matchday — same response shape as the current call. Without it,
+        the response reflects the most recent completed matchday (and ``day``
+        in the response tells you which one).
+
+        GET /v4/leagues/{league_id}/ranking[?dayNumber=N]
         """
         url = f"{self.BASE_URL}/v4/leagues/{league_id}/ranking"
+        if day_number is not None:
+            url = f"{url}?dayNumber={int(day_number)}"
 
         response = self.session.get(url)
 

--- a/rehoboam/trader.py
+++ b/rehoboam/trader.py
@@ -173,14 +173,43 @@ class Trader:
 
             return perf_data, player_details
 
-        # --- 2b. Competitor scouting (best-effort) ---
+        # --- 2b. Competitor scouting + rank snapshot (best-effort) ---
+        # /ranking returns the full league standings — rank, points, team
+        # value per manager. Historically this loop only extracted manager
+        # IDs to drive squad scouting; REH-24 also persists the rank/points/
+        # team_value fields so we can measure goals 3, 4, 5 over time.
         competitor_player_ids: set[str] = set()
         try:
             ranking = self.api.get_league_ranking(league)
             managers = ranking.get("it", ranking.get("us", []))
+            # `day` may legitimately be None (pre-season) or absent. int(None)
+            # would raise inside the outer try/except and lose the
+            # competitor_player_ids set that was already built — None-guard
+            # explicitly so the surrounding scouting always succeeds.
+            _day_raw = ranking.get("day")
+            day_number = int(_day_raw) if _day_raw is not None else 0
             my_id = self.api.user.id
+
+            rank_rows: list[dict] = []
+            snapshot_at = datetime.now(tz=timezone.utc).timestamp()
             for mgr in managers:
                 mgr_id = mgr.get("i", mgr.get("id", ""))
+                if not mgr_id:
+                    continue
+                rank_rows.append(
+                    {
+                        "snapshot_at": snapshot_at,
+                        "league_id": league.id,
+                        "manager_id": str(mgr_id),
+                        "day_number": day_number,
+                        "rank_overall": mgr.get("spl"),
+                        "rank_matchday": mgr.get("mdpl"),
+                        "total_points": mgr.get("sp"),
+                        "matchday_points": mgr.get("mdp"),
+                        "team_value": mgr.get("tv"),
+                        "is_self": mgr_id == my_id,
+                    }
+                )
                 if mgr_id == my_id:
                     continue
                 try:
@@ -190,6 +219,13 @@ class Trader:
                         if pid:
                             competitor_player_ids.add(pid)
                 except Exception:
+                    pass
+
+            if self.bid_learner is not None and rank_rows:
+                try:
+                    self.bid_learner.record_league_rank_snapshot(rank_rows)
+                except Exception:
+                    # Learning side effects must never block the EP pipeline.
                     pass
         except Exception:
             pass

--- a/tests/test_league_rank_history.py
+++ b/tests/test_league_rank_history.py
@@ -1,0 +1,137 @@
+"""Tests for REH-24: league_rank_history persistence.
+
+The bot calls /ranking every session for competitor_player_ids but
+historically discarded the rest of the response. record_league_rank_snapshot()
+persists rank, points, and team_value per manager so goals 3 (team value
+growth), 4 (matchday points), and 5 (rank trajectory) become measurable.
+"""
+
+import sqlite3
+
+import pytest
+
+from rehoboam.bid_learner import BidLearner
+
+
+@pytest.fixture
+def learner(tmp_path):
+    return BidLearner(db_path=tmp_path / "bid_learning.db")
+
+
+def _row(
+    manager_id: str,
+    *,
+    snapshot_at: float = 1_000.0,
+    league_id: str = "L1",
+    day_number: int = 32,
+    rank_overall: int | None = 5,
+    rank_matchday: int | None = 7,
+    total_points: int | None = 23990,
+    matchday_points: int | None = 749,
+    team_value: int | None = 135_000_000,
+    is_self: bool = False,
+) -> dict:
+    return {
+        "snapshot_at": snapshot_at,
+        "league_id": league_id,
+        "manager_id": manager_id,
+        "day_number": day_number,
+        "rank_overall": rank_overall,
+        "rank_matchday": rank_matchday,
+        "total_points": total_points,
+        "matchday_points": matchday_points,
+        "team_value": team_value,
+        "is_self": is_self,
+    }
+
+
+class TestLeagueRankSnapshot:
+    def test_round_trip_one_row(self, learner):
+        n = learner.record_league_rank_snapshot([_row("m1", is_self=True)])
+        assert n == 1
+
+        with sqlite3.connect(learner.db_path) as conn:
+            row = conn.execute(
+                "SELECT manager_id, day_number, rank_overall, rank_matchday, "
+                "total_points, matchday_points, team_value, is_self "
+                "FROM league_rank_history"
+            ).fetchone()
+        assert row == ("m1", 32, 5, 7, 23990, 749, 135_000_000, 1)
+
+    def test_bulk_insert_multiple_managers(self, learner):
+        rows = [
+            _row("m1", rank_overall=1, is_self=True),
+            _row("m2", rank_overall=2),
+            _row("m3", rank_overall=3),
+        ]
+        learner.record_league_rank_snapshot(rows)
+
+        with sqlite3.connect(learner.db_path) as conn:
+            ranks = conn.execute(
+                "SELECT manager_id, rank_overall FROM league_rank_history " "ORDER BY rank_overall"
+            ).fetchall()
+        assert ranks == [("m1", 1), ("m2", 2), ("m3", 3)]
+
+    def test_empty_input_is_noop(self, learner):
+        assert learner.record_league_rank_snapshot([]) == 0
+
+    def test_collision_at_same_pk_is_silently_dropped(self, learner):
+        # Composite PK = (snapshot_at, manager_id). Same-second retry on the
+        # same manager → second write is dropped, first preserved.
+        learner.record_league_rank_snapshot([_row("m1", snapshot_at=42.0, rank_overall=5)])
+        learner.record_league_rank_snapshot(
+            [_row("m1", snapshot_at=42.0, rank_overall=999)],
+        )
+
+        with sqlite3.connect(learner.db_path) as conn:
+            rows = conn.execute(
+                "SELECT manager_id, rank_overall FROM league_rank_history"
+            ).fetchall()
+        assert rows == [("m1", 5)]
+
+    def test_optional_numeric_fields_accept_none(self, learner):
+        # Mid-season the ranking response may legitimately omit a manager's
+        # matchday placement (e.g., they didn't field a lineup that week).
+        # The schema and writer must tolerate None on those columns.
+        learner.record_league_rank_snapshot(
+            [
+                _row(
+                    "m1",
+                    rank_matchday=None,
+                    matchday_points=None,
+                )
+            ]
+        )
+        with sqlite3.connect(learner.db_path) as conn:
+            row = conn.execute(
+                "SELECT rank_matchday, matchday_points FROM league_rank_history"
+            ).fetchone()
+        assert row == (None, None)
+
+    def test_is_self_flag_round_trips_as_int(self, learner):
+        learner.record_league_rank_snapshot(
+            [
+                _row("m1", is_self=True),
+                _row("m2", is_self=False),
+            ]
+        )
+        with sqlite3.connect(learner.db_path) as conn:
+            self_row = conn.execute(
+                "SELECT manager_id FROM league_rank_history WHERE is_self=1"
+            ).fetchone()
+        assert self_row == ("m1",)
+
+    def test_float_team_value_coerced_to_int(self, learner):
+        # /ranking returned tv=135691003.0 in probe — schema is INTEGER, so
+        # coerce to keep round-trip equality predictable.
+        learner.record_league_rank_snapshot(
+            [
+                _row(
+                    "m1",
+                    team_value=135_691_003.5,  # type: ignore[arg-type]
+                )
+            ]
+        )
+        with sqlite3.connect(learner.db_path) as conn:
+            row = conn.execute("SELECT team_value FROM league_rank_history").fetchone()
+        assert row == (135_691_003,)


### PR DESCRIPTION
Closes [REH-24](https://linear.app/jovily/issue/REH-24). Foundation issue #2 of 4.

## What this captures

A single existing API call (`/v4/leagues/{lid}/ranking`) returns the full league standings with rank, points, and team_value per manager. The bot has been calling it every session for `competitor_player_ids` and discarding the rest. This PR persists the discarded fields and unlocks **three of your five north-star metrics**:

| Goal | Field |
|------|-------|
| Goal 3 — team value growth | `tv` (per manager) |
| Goal 4 — matchday point output | `sp` (cumulative) + `mdp` (last week) |
| Goal 5 — rank trajectory | `spl` (overall rank) + `mdpl` (weekly rank) |

## Probe-validated field decoding

Decoded by a one-off probe (`scripts/probe_ranking_and_manager.py`) against the live league on 2026-05-03. Top-level response: `{ti, cpi, ish, us[], day, ...}`. Each `us[]` item: `{i, n, tv, sp, spl, mdp, mdpl, ...}`. Saved as a session-durable reference in `~/.claude/.../memory/reference_kickbase_field_aliases.md` so future sessions don't re-probe.

## Schema

```sql
CREATE TABLE league_rank_history (
    snapshot_at REAL NOT NULL,
    league_id TEXT NOT NULL,
    manager_id TEXT NOT NULL,
    day_number INTEGER NOT NULL,
    rank_overall INTEGER,           -- spl
    rank_matchday INTEGER,          -- mdpl
    total_points INTEGER,           -- sp
    matchday_points INTEGER,        -- mdp
    team_value INTEGER,             -- tv
    is_self INTEGER NOT NULL DEFAULT 0,
    PRIMARY KEY (snapshot_at, manager_id)
);
CREATE INDEX idx_league_rank_self_at ON league_rank_history(is_self, snapshot_at);
```

Numeric columns nullable — mid-season the API may omit a manager's matchday placement (didn't field a lineup) and partial data > skipped row.

## Wire-up

`Trader.get_ep_recommendations` competitor-scouting block now BUILDS `rank_rows` from the same `us[]` array it iterates for `competitor_player_ids`, then calls `bid_learner.record_league_rank_snapshot(rank_rows)` once. Three nesting levels of best-effort try/except so a learner failure can never block the EP pipeline.

## Reviewer caught a real bug pre-commit

`int(ranking.get(\"day\", 0))` raises `TypeError` when the API returns `\"day\": null` (e.g. pre-season). That would silently kill the outer try/except and drop competitor_player_ids for the whole session. Fixed via explicit None-guard. Reviewer confidence 82, well above the 80 fix threshold.

## Other choices

- **INSERT OR IGNORE** on the bulk write — same-PK collision drops second row
- **`_opt_int`** module-level helper for None-preserving int coercion
- Returns `len(rows)` not actual inserted count — sqlite3.executemany doesn't expose per-row outcomes; tests verify behavior by reading back
- New `day_number=None` parameter on `get_league_ranking` accepts `?dayNumber=N` query for historical backfill — no call site uses it yet, scaffolding for a follow-up

## Test plan

- [x] `python -m compileall` clean
- [x] `ruff check` clean
- [x] `pre-commit run` (black + ruff + bandit + pyupgrade) clean
- [x] End-to-end smoke against temp DB: 14-manager batch inserts, retry of identical batch drops all silently (count stays at 14) ✓
- [x] 7 unit tests in `tests/test_league_rank_history.py`: round-trip, bulk, empty, collision, None-tolerance, is_self coercion, float→int coercion
- [x] Reviewer agent caught one real bug (None-handling), 5 other verification points clean
- [ ] CI pytest (3.10/3.11/3.12) — local pytest still blocked by the pydantic/Python 3.14 env mismatch
- [ ] Post-deploy: `sqlite3 bid_learning.db \"SELECT manager_id, rank_overall, team_value FROM league_rank_history WHERE is_self=1 ORDER BY snapshot_at DESC LIMIT 1\"` returns our current rank

## Follow-up

[REH-38](https://linear.app/jovily/issue/REH-38) (just filed, blocked by this PR) will add `/managers/{mid}/dashboard.prft` capture for per-manager transfer P&L — the only competitor-intelligence signal `/ranking` doesn't include.

🤖 Generated with [Claude Code](https://claude.com/claude-code)