### PR TITLE
feat: persist daily MV time-series for held players (REH-26)

### DIFF
--- a/rehoboam/bid_learner.py
+++ b/rehoboam/bid_learner.py
@@ -314,6 +314,37 @@ class BidLearner:
             """
             )
 
+            # Daily market-value snapshots for held players — REH-26.
+            # The bot fetches /player/{id}/marketValue history every session
+            # via TrendService (cached 24h) and consumes it transiently for
+            # trend computation. The current MV plus 30-day peak/trough are
+            # discarded after that, so we have no daily series to detect
+            # slow drift on held positions (goal 2: loss avoidance).
+            # Constrained to squad players to avoid blowing up DB size —
+            # market players (~50/session) would multiply rows ~3x.
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS player_mv_history (
+                    player_id TEXT NOT NULL,
+                    snapshot_at REAL NOT NULL,
+                    market_value INTEGER NOT NULL,
+                    peak_mv_30d INTEGER,
+                    trough_mv_30d INTEGER,
+                    PRIMARY KEY (player_id, snapshot_at)
+                )
+            """
+            )
+            # Explicit index matches the convention of every other time-series
+            # table in this file. The composite PK already covers
+            # (player_id, snapshot_at) lookups, but the named index makes
+            # REH-33's "sold X% off peak" join obvious to readers.
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_mv_history_player
+                ON player_mv_history(player_id, snapshot_at)
+            """
+            )
+
             # Matchday lineup actual results — REH-25.
             # One row per (league, matchday) capturing the lineup the bot
             # actually fielded that week and what it scored. Source: the
@@ -740,6 +771,45 @@ class BidLearner:
             )
             conn.commit()
             return cur.rowcount > 0
+
+    def record_player_mv_snapshot(self, rows: list[dict]) -> int:
+        """Bulk-persist one row per held player into ``player_mv_history``.
+
+        Each row should provide: player_id, snapshot_at, market_value,
+        peak_mv_30d, trough_mv_30d. Peak/trough are optional (the API may
+        legitimately return an empty history for newly-listed players),
+        coerced via ``_opt_int``.
+
+        Uses ``INSERT OR IGNORE`` keyed on ``(player_id, snapshot_at)``;
+        same-second retry on the same player is a no-op.
+
+        REH-26: feeds goal 2 (loss avoidance) via daily drift detection
+        and unblocks REH-33 (sell-timing peak-MV regret).
+        """
+        if not rows:
+            return 0
+        with sqlite3.connect(self.db_path) as conn:
+            conn.executemany(
+                """
+                INSERT OR IGNORE INTO player_mv_history (
+                    player_id, snapshot_at, market_value,
+                    peak_mv_30d, trough_mv_30d
+                )
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                [
+                    (
+                        r["player_id"],
+                        r["snapshot_at"],
+                        int(r["market_value"]),
+                        _opt_int(r.get("peak_mv_30d")),
+                        _opt_int(r.get("trough_mv_30d")),
+                    )
+                    for r in rows
+                ],
+            )
+            conn.commit()
+        return len(rows)
 
     def has_matchday_lineup_result(self, league_id: str, day_number: int) -> bool:
         """True if ``matchday_lineup_results`` already has a row for this

--- a/rehoboam/trader.py
+++ b/rehoboam/trader.py
@@ -306,6 +306,12 @@ class Trader:
         squad_scores: list = []
         squad_player_map: dict = {}
         squad_performance: dict[str, dict] = {}
+        # REH-26: collect daily MV rows for each held player. Persist after
+        # the squad loop (single bulk INSERT). The trend_service.get_history
+        # call uses the same 24h-cached data already fetched for trend
+        # analysis — no extra HTTP traffic.
+        mv_rows: list[dict] = []
+        snapshot_at = datetime.now(tz=timezone.utc).timestamp()
         for player in squad:
             try:
                 perf, details = _fetch_player_data(player)
@@ -321,9 +327,35 @@ class Trader:
                     score_player(data, calibration_multiplier=_calibration_for(player))
                 )
                 squad_player_map[player.id] = player
+
+                try:
+                    mvh = self.trend_service.get_history(player.id, league.id)
+                    recent = mvh.points[-30:] if mvh.points else []
+                    peak_30d = max((p.value for p in recent), default=None)
+                    trough_30d = min((p.value for p in recent), default=None)
+                    mv_rows.append(
+                        {
+                            "player_id": player.id,
+                            "snapshot_at": snapshot_at,
+                            "market_value": player.market_value,
+                            "peak_mv_30d": peak_30d,
+                            "trough_mv_30d": trough_30d,
+                        }
+                    )
+                except Exception:
+                    # MV-history fetch is best-effort; keep scoring this
+                    # player even if persistence fails.
+                    pass
             except Exception as e:
                 if self.verbose:
                     console.print(f"[dim]EP: scoring failed for {player.last_name}: {e}[/dim]")
+
+        if self.bid_learner is not None and mv_rows:
+            try:
+                self.bid_learner.record_player_mv_snapshot(mv_rows)
+            except Exception:
+                # Learning side effects must never block the EP pipeline.
+                pass
 
         # --- 4. Make decisions ---
         # roster_context is legacy — DecisionEngine accepts it but doesn't

--- a/tests/test_player_mv_history.py
+++ b/tests/test_player_mv_history.py
@@ -1,0 +1,123 @@
+"""Tests for REH-26: player_mv_history persistence.
+
+The bot fetches /player/{id}/marketValue history every session via
+TrendService (cached 24h) and discarded the result after trend computation.
+record_player_mv_snapshot() persists today's MV plus 30-day peak/trough so
+goal 2 (loss avoidance) becomes measurable on slow drift, and REH-33's
+"sold X% off peak" calculation has historical data to join against.
+"""
+
+import sqlite3
+
+import pytest
+
+from rehoboam.bid_learner import BidLearner
+
+
+@pytest.fixture
+def learner(tmp_path):
+    return BidLearner(db_path=tmp_path / "bid_learning.db")
+
+
+def _row(
+    player_id: str,
+    *,
+    snapshot_at: float = 1_000.0,
+    market_value: int = 10_000_000,
+    peak_mv_30d: int | None = 11_000_000,
+    trough_mv_30d: int | None = 9_500_000,
+) -> dict:
+    return {
+        "player_id": player_id,
+        "snapshot_at": snapshot_at,
+        "market_value": market_value,
+        "peak_mv_30d": peak_mv_30d,
+        "trough_mv_30d": trough_mv_30d,
+    }
+
+
+class TestPlayerMvSnapshot:
+    def test_round_trip_one_row(self, learner):
+        n = learner.record_player_mv_snapshot([_row("p1")])
+        assert n == 1
+        with sqlite3.connect(learner.db_path) as conn:
+            row = conn.execute(
+                "SELECT player_id, snapshot_at, market_value, "
+                "peak_mv_30d, trough_mv_30d FROM player_mv_history"
+            ).fetchone()
+        assert row == ("p1", 1_000.0, 10_000_000, 11_000_000, 9_500_000)
+
+    def test_bulk_insert_squad(self, learner):
+        rows = [
+            _row("p1", market_value=10_000_000),
+            _row("p2", market_value=12_000_000),
+            _row("p3", market_value=8_000_000),
+        ]
+        learner.record_player_mv_snapshot(rows)
+
+        with sqlite3.connect(learner.db_path) as conn:
+            count = conn.execute("SELECT COUNT(*) FROM player_mv_history").fetchone()[0]
+        assert count == 3
+
+    def test_empty_input_is_noop(self, learner):
+        assert learner.record_player_mv_snapshot([]) == 0
+
+    def test_collision_at_same_pk_silently_dropped(self, learner):
+        # PK = (player_id, snapshot_at). Same-second retry on the same player
+        # → second write is dropped, first preserved.
+        learner.record_player_mv_snapshot([_row("p1", snapshot_at=42.0, market_value=10_000_000)])
+        learner.record_player_mv_snapshot([_row("p1", snapshot_at=42.0, market_value=99_999_999)])
+
+        with sqlite3.connect(learner.db_path) as conn:
+            rows = conn.execute("SELECT player_id, market_value FROM player_mv_history").fetchall()
+        assert rows == [("p1", 10_000_000)]
+
+    def test_peak_and_trough_optional(self, learner):
+        # Newly-listed players may have no history → peak/trough come back
+        # as None. Schema must accept NULLs without raising.
+        learner.record_player_mv_snapshot(
+            [
+                _row(
+                    "p1",
+                    peak_mv_30d=None,
+                    trough_mv_30d=None,
+                )
+            ]
+        )
+        with sqlite3.connect(learner.db_path) as conn:
+            row = conn.execute(
+                "SELECT peak_mv_30d, trough_mv_30d FROM player_mv_history"
+            ).fetchone()
+        assert row == (None, None)
+
+    def test_float_market_value_coerced_to_int(self, learner):
+        # MV history occasionally returns floats; INTEGER column should
+        # round-trip cleanly via int() coercion in the writer.
+        learner.record_player_mv_snapshot(
+            [
+                _row(
+                    "p1",
+                    market_value=10_500_000.7,  # type: ignore[arg-type]
+                )
+            ]
+        )
+        with sqlite3.connect(learner.db_path) as conn:
+            row = conn.execute("SELECT market_value FROM player_mv_history").fetchone()
+        assert row == (10_500_000,)
+
+    def test_multiple_snapshots_same_player_different_times(self, learner):
+        # The whole point of the table — daily series for one player.
+        for i, ts in enumerate([100.0, 200.0, 300.0]):
+            learner.record_player_mv_snapshot(
+                [_row("p1", snapshot_at=ts, market_value=10_000_000 + i * 250_000)]
+            )
+        with sqlite3.connect(learner.db_path) as conn:
+            rows = conn.execute(
+                "SELECT snapshot_at, market_value FROM player_mv_history "
+                "WHERE player_id = 'p1' ORDER BY snapshot_at"
+            ).fetchall()
+        assert rows == [
+            (100.0, 10_000_000),
+            (200.0, 10_250_000),
+            (300.0, 10_500_000),
+        ]


### PR DESCRIPTION
Closes [REH-26](https://linear.app/jovily/issue/REH-26). **Foundation issue #4 of 4 — completes the foundation tier.**

## What was missing

The bot already fetches `/player/{id}/marketValue/{timeframe}` for every squad player every session via `TrendService` (24h cached) and consumed the result transiently for trend computation. Today's MV plus 30-day peak/trough were discarded after that, so we had **no daily series to detect slow drift on held positions**. `ActivityFeedLearner.market_value_snapshots` is event-driven and sparse — it only fires on notable changes, so a player quietly drifting downward generated no data.

This PR persists what was already in memory.

## Schema

```sql
CREATE TABLE player_mv_history (
    player_id TEXT NOT NULL,
    snapshot_at REAL NOT NULL,
    market_value INTEGER NOT NULL,
    peak_mv_30d INTEGER,                 -- NULL for newly-listed players
    trough_mv_30d INTEGER,
    PRIMARY KEY (player_id, snapshot_at)
);
CREATE INDEX idx_mv_history_player ON player_mv_history(player_id, snapshot_at);
```

Index added per reviewer feedback (conf 85) — every other time-series table in `bid_learner.py` has a companion index, and REH-33's "sold X% off peak" join will use exactly this access pattern.

## Wire-up

Inside the squad loop in `Trader.get_ep_recommendations`. For each held player:

```python
mvh = self.trend_service.get_history(player.id, league.id)  # 24h cached
recent = mvh.points[-30:] if mvh.points else []             # ASC sorted
peak_30d = max((p.value for p in recent), default=None)
trough_30d = min((p.value for p in recent), default=None)
mv_rows.append({...})
```

After loop: single bulk `INSERT OR IGNORE` via `record_player_mv_snapshot`. Three layers of best-effort error handling matching existing pattern.

## Cost

- **Zero new HTTP calls** — `get_history` is the same cached fetch the trend pipeline already uses
- 15 rows/session × 2 sessions/day = 30 rows/day
- Over a Bundesliga season: ~5,400 rows. Trivial for SQLite

## Why squad-only (not market)

Constrains DB size. ~50 market players/session would 3-4× row count for data flip P&L doesn't currently need. REH-26's spec was explicit about held-only; this preserves that intent.

## Test plan

- [x] `python -m compileall` clean
- [x] `ruff check` clean
- [x] `pre-commit run` (black + ruff + bandit + pyupgrade) clean
- [x] End-to-end smoke vs temp DB: 15 mv_rows with 30-point synthetic histories insert correctly; retry batch drops all silently; peak/trough math returns expected max/min from the last-30 slice ✓
- [x] 7 unit tests covering round-trip, bulk, empty, collision drop, nullable peak/trough, float coercion, multi-snapshot daily series
- [x] Reviewer agent flagged one schema-consistency item (missing index, conf 85) → applied. Two other observations (snapshot_at PK fragility, missing test for None market_value) explicitly below threshold and not fixed
- [ ] CI pytest (3.10/3.11/3.12) — local pytest still blocked by the pydantic/Python 3.14 env mismatch
- [ ] Post-deploy: `sqlite3 bid_learning.db \"SELECT player_id, market_value, peak_mv_30d, trough_mv_30d FROM player_mv_history WHERE snapshot_at > strftime('%s', 'now', '-1 day') LIMIT 5\"` returns ~15 rows

## Foundation tier complete 🎉

| Foundation | Goal coverage |
|------------|---------------|
| REH-23 ✅ | Goal 3 — own team value |
| REH-24 ✅ | Goals 3 + 4 + 5 — rank + per-manager team value |
| REH-25 ✅ | Goal 4 — matchday lineup actuals |
| **REH-26 ✅** | **Goal 2 — daily MV drift detection per held player** |

All five north-star metrics are now measurable from data the bot writes itself. Learning loops (REH-32 through REH-37) can now ship — REH-33 (sell-timing peak detection) is unblocked specifically by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)