### PR TITLE
feat: capture per-manager transfer P&L + history (REH-38)

### DIFF
--- a/rehoboam/api.py
+++ b/rehoboam/api.py
@@ -177,6 +177,20 @@ class KickbaseAPI:
         except Exception as e:
             raise Exception(f"Failed to fetch manager squad: {e}") from e
 
+    def get_manager_dashboard(self, league: League, manager_id: str) -> dict:
+        """Per-manager dashboard with `prft` (transfer P&L) and `mdw`. REH-38."""
+        try:
+            return self.client.get_manager_dashboard(league.id, manager_id)
+        except Exception as e:
+            raise Exception(f"Failed to fetch manager dashboard: {e}") from e
+
+    def get_manager_transfer_history(self, league: League, manager_id: str, start: int = 0) -> dict:
+        """Per-manager transfer history, paginated 25 per page. REH-38."""
+        try:
+            return self.client.get_manager_transfer_history(league.id, manager_id, start=start)
+        except Exception as e:
+            raise Exception(f"Failed to fetch manager transfer history: {e}") from e
+
     def get_league_ranking(self, league: League, day_number: int | None = None) -> dict:
         """Get league ranking/standings.
 

--- a/rehoboam/bid_learner.py
+++ b/rehoboam/bid_learner.py
@@ -381,6 +381,58 @@ class BidLearner:
             """
             )
 
+            # Per-manager transfer P&L snapshot — REH-38.
+            # /managers/{mid}/dashboard returns `prft` (cumulative transfer
+            # P&L) and `mdw` (matchday wins) — neither is in /ranking. We
+            # snapshot both per session so we can plot trajectory and
+            # benchmark the bot's flip P&L against leaguemates.
+            # Composite PK matches league_rank_history for symmetry.
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS manager_profile_history (
+                    snapshot_at REAL NOT NULL,
+                    league_id TEXT NOT NULL,
+                    manager_id TEXT NOT NULL,
+                    transfer_pnl INTEGER NOT NULL,
+                    matchday_wins INTEGER,
+                    is_self INTEGER NOT NULL DEFAULT 0,
+                    PRIMARY KEY (snapshot_at, manager_id)
+                )
+            """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_manager_profile_self_at
+                ON manager_profile_history(is_self, snapshot_at)
+            """
+            )
+
+            # Per-manager transfer history — REH-38.
+            # /managers/{mid}/transfer returns each completed buy/sell with
+            # price + datetime. PK on (league, manager, dt, player) makes
+            # re-imports idempotent: the same trade always collapses to one
+            # row regardless of how many sessions see it.
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS manager_transfers (
+                    league_id TEXT NOT NULL,
+                    manager_id TEXT NOT NULL,
+                    transfer_dt TEXT NOT NULL,
+                    player_id TEXT NOT NULL,
+                    player_name TEXT NOT NULL,
+                    transfer_type INTEGER,
+                    transfer_price INTEGER,
+                    PRIMARY KEY (league_id, manager_id, transfer_dt, player_id)
+                )
+            """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_manager_transfers_mgr_dt
+                ON manager_transfers(manager_id, transfer_dt)
+            """
+            )
+
             # REH-22: drop legacy tables that no live code references.
             # `position_bidding_stats` was orphaned by REH-27 (writer + reader
             # methods deleted). The other three are stale residue from
@@ -918,6 +970,93 @@ class BidLearner:
                         _opt_int(r.get("matchday_points")),
                         _opt_int(r.get("team_value")),
                         1 if r.get("is_self") else 0,
+                    )
+                    for r in rows
+                ],
+            )
+            conn.commit()
+        return len(rows)
+
+    def record_manager_profile_snapshot(self, rows: list[dict]) -> int:
+        """Bulk-persist one row per manager into ``manager_profile_history``.
+
+        Each row should provide:
+            snapshot_at, league_id, manager_id, transfer_pnl, is_self
+            matchday_wins (optional)
+
+        ``transfer_pnl`` (the dashboard `prft` field) is required — it is
+        the entire reason this snapshot exists. Missing values would defeat
+        the purpose of the table, so callers must coerce or skip explicitly
+        rather than passing None through.
+
+        Uses ``INSERT OR IGNORE`` matching ``record_league_rank_snapshot``
+        so a same-second retry collapses deterministically.
+
+        REH-38: feeds goals 1 (flip revenue) and 2 (loss avoidance), and
+        gives competitive intel on which leaguemates are bleeding transfer
+        P&L. Returns the number of rows attempted.
+        """
+        if not rows:
+            return 0
+        with sqlite3.connect(self.db_path) as conn:
+            conn.executemany(
+                """
+                INSERT OR IGNORE INTO manager_profile_history (
+                    snapshot_at, league_id, manager_id,
+                    transfer_pnl, matchday_wins, is_self
+                )
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                [
+                    (
+                        r["snapshot_at"],
+                        r["league_id"],
+                        r["manager_id"],
+                        int(r["transfer_pnl"]),
+                        _opt_int(r.get("matchday_wins")),
+                        1 if r.get("is_self") else 0,
+                    )
+                    for r in rows
+                ],
+            )
+            conn.commit()
+        return len(rows)
+
+    def record_manager_transfers(self, rows: list[dict]) -> int:
+        """Bulk-upsert per-trade rows into ``manager_transfers``.
+
+        Each row should provide:
+            league_id, manager_id, transfer_dt, player_id, player_name
+            transfer_type (optional), transfer_price (optional)
+
+        Uses ``INSERT OR IGNORE`` so re-importing the same transfer history
+        page doesn't error or duplicate rows. The PK
+        ``(league_id, manager_id, transfer_dt, player_id)`` collapses
+        duplicates from overlapping pages during backfill.
+
+        REH-38. Returns the number of rows attempted.
+        """
+        if not rows:
+            return 0
+        with sqlite3.connect(self.db_path) as conn:
+            conn.executemany(
+                """
+                INSERT OR IGNORE INTO manager_transfers (
+                    league_id, manager_id, transfer_dt,
+                    player_id, player_name,
+                    transfer_type, transfer_price
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                [
+                    (
+                        r["league_id"],
+                        r["manager_id"],
+                        r["transfer_dt"],
+                        r["player_id"],
+                        r["player_name"],
+                        _opt_int(r.get("transfer_type")),
+                        _opt_int(r.get("transfer_price")),
                     )
                     for r in rows
                 ],

--- a/rehoboam/kickbase_client.py
+++ b/rehoboam/kickbase_client.py
@@ -692,6 +692,47 @@ class KickbaseV4Client:
                 f"Failed to fetch manager squad: {response.status_code} - {response.text}"
             )
 
+    def get_manager_dashboard(self, league_id: str, manager_id: str) -> dict[str, Any]:
+        """
+        Per-manager dashboard, includes cumulative transfer P&L (`prft`) and
+        matchday wins (`mdw`) — neither is in /ranking. REH-38.
+
+        GET /v4/leagues/{league_id}/managers/{manager_id}/dashboard
+        """
+        url = f"{self.BASE_URL}/v4/leagues/{league_id}/managers/{manager_id}/dashboard"
+
+        response = self.session.get(url)
+
+        if response.status_code == 200:
+            return response.json()
+        else:
+            raise Exception(
+                f"Failed to fetch manager dashboard: {response.status_code} - {response.text}"
+            )
+
+    def get_manager_transfer_history(
+        self, league_id: str, manager_id: str, start: int = 0
+    ) -> dict[str, Any]:
+        """
+        Per-manager transfer history, paginated 25 per page in reverse
+        chronological order. ``start`` is the zero-indexed offset; pass 25,
+        50, ... to walk backward through history. REH-38.
+
+        GET /v4/leagues/{league_id}/managers/{manager_id}/transfer[?start=N]
+        """
+        url = f"{self.BASE_URL}/v4/leagues/{league_id}/managers/{manager_id}/transfer"
+        if start:
+            url = f"{url}?start={int(start)}"
+
+        response = self.session.get(url)
+
+        if response.status_code == 200:
+            return response.json()
+        else:
+            raise Exception(
+                f"Failed to fetch manager transfer history: {response.status_code} - {response.text}"
+            )
+
     def get_league_ranking(self, league_id: str, day_number: int | None = None) -> dict[str, Any]:
         """
         Get league ranking/standings.

--- a/rehoboam/trader.py
+++ b/rehoboam/trader.py
@@ -191,6 +191,11 @@ class Trader:
             my_id = self.api.user.id
 
             rank_rows: list[dict] = []
+            # REH-38: per-manager dashboard (`prft`, `mdw`) + transfer
+            # history. Only collected when a learner is attached — skipping
+            # the extra HTTP calls when nothing would be persisted.
+            profile_rows: list[dict] = []
+            transfer_rows: list[dict] = []
             snapshot_at = datetime.now(tz=timezone.utc).timestamp()
             for mgr in managers:
                 mgr_id = mgr.get("i", mgr.get("id", ""))
@@ -210,22 +215,80 @@ class Trader:
                         "is_self": mgr_id == my_id,
                     }
                 )
-                if mgr_id == my_id:
-                    continue
-                try:
-                    mgr_squad = self.api.get_manager_squad(league, mgr_id)
-                    for p in mgr_squad.get("it", []):
-                        pid = p.get("i", p.get("id", ""))
-                        if pid:
-                            competitor_player_ids.add(pid)
-                except Exception:
-                    pass
+                if mgr_id != my_id:
+                    try:
+                        mgr_squad = self.api.get_manager_squad(league, mgr_id)
+                        for p in mgr_squad.get("it", []):
+                            pid = p.get("i", p.get("id", ""))
+                            if pid:
+                                competitor_player_ids.add(pid)
+                    except Exception:
+                        pass
+
+                # REH-38: dashboard pull for prft + mdw. Done for every
+                # manager (including self — `prft` is not exposed in
+                # /ranking, so we cannot get our own P&L from the loop's
+                # ranking response). Best-effort per-manager.
+                if self.bid_learner is not None:
+                    try:
+                        dash = self.api.get_manager_dashboard(league, str(mgr_id))
+                        prft = dash.get("prft")
+                        if prft is not None:
+                            profile_rows.append(
+                                {
+                                    "snapshot_at": snapshot_at,
+                                    "league_id": league.id,
+                                    "manager_id": str(mgr_id),
+                                    "transfer_pnl": int(prft),
+                                    "matchday_wins": dash.get("mdw"),
+                                    "is_self": mgr_id == my_id,
+                                }
+                            )
+                    except Exception:
+                        pass
+
+                    # REH-38: transfer history page 0 (latest 25 trades).
+                    # We run 2x/day; 25 trades in a 12h window is highly
+                    # improbable for a single manager, so page 0 catches
+                    # every new transfer in steady state. Older history
+                    # (start=25, 50, ...) is a backfill concern handled
+                    # outside the session loop.
+                    try:
+                        th = self.api.get_manager_transfer_history(league, str(mgr_id))
+                        for t in th.get("it", []):
+                            pid = t.get("pi", "")
+                            tdt = t.get("dt", "")
+                            if not pid or not tdt:
+                                continue
+                            transfer_rows.append(
+                                {
+                                    "league_id": league.id,
+                                    "manager_id": str(mgr_id),
+                                    "transfer_dt": tdt,
+                                    "player_id": str(pid),
+                                    "player_name": t.get("pn", ""),
+                                    "transfer_type": t.get("tty"),
+                                    "transfer_price": t.get("trp"),
+                                }
+                            )
+                    except Exception:
+                        pass
 
             if self.bid_learner is not None and rank_rows:
                 try:
                     self.bid_learner.record_league_rank_snapshot(rank_rows)
                 except Exception:
                     # Learning side effects must never block the EP pipeline.
+                    pass
+            if self.bid_learner is not None and profile_rows:
+                try:
+                    self.bid_learner.record_manager_profile_snapshot(profile_rows)
+                except Exception:
+                    pass
+            if self.bid_learner is not None and transfer_rows:
+                try:
+                    self.bid_learner.record_manager_transfers(transfer_rows)
+                except Exception:
                     pass
 
             # REH-25: capture the actual fielded lineup + total points for

--- a/tests/test_manager_profile_history.py
+++ b/tests/test_manager_profile_history.py
@@ -1,0 +1,215 @@
+"""Tests for REH-38: manager_profile_history + manager_transfers persistence.
+
+`/ranking` exposes per-manager `tv`, `sp`, `mdp`, but NOT cumulative transfer
+P&L (`prft`). REH-38 adds two writers — `record_manager_profile_snapshot`
+captures the dashboard's `prft` + `mdw` per session; `record_manager_transfers`
+ingests the per-trade history from /managers/{mid}/transfer.
+"""
+
+import sqlite3
+
+import pytest
+
+from rehoboam.bid_learner import BidLearner
+
+
+@pytest.fixture
+def learner(tmp_path):
+    return BidLearner(db_path=tmp_path / "bid_learning.db")
+
+
+def _profile_row(
+    manager_id: str,
+    *,
+    snapshot_at: float = 1_000.0,
+    league_id: str = "L1",
+    transfer_pnl: int = -34_812_837,
+    matchday_wins: int | None = 0,
+    is_self: bool = False,
+) -> dict:
+    return {
+        "snapshot_at": snapshot_at,
+        "league_id": league_id,
+        "manager_id": manager_id,
+        "transfer_pnl": transfer_pnl,
+        "matchday_wins": matchday_wins,
+        "is_self": is_self,
+    }
+
+
+def _transfer_row(
+    *,
+    manager_id: str = "m1",
+    league_id: str = "L1",
+    transfer_dt: str = "2026-05-04T09:57:07Z",
+    player_id: str = "10049",
+    player_name: str = "Behrens",
+    transfer_type: int | None = 1,
+    transfer_price: int | None = 1_926_310,
+) -> dict:
+    return {
+        "league_id": league_id,
+        "manager_id": manager_id,
+        "transfer_dt": transfer_dt,
+        "player_id": player_id,
+        "player_name": player_name,
+        "transfer_type": transfer_type,
+        "transfer_price": transfer_price,
+    }
+
+
+class TestRecordManagerProfileSnapshot:
+    def test_round_trip_one_row(self, learner):
+        n = learner.record_manager_profile_snapshot([_profile_row("m1", is_self=True)])
+        assert n == 1
+
+        with sqlite3.connect(learner.db_path) as conn:
+            row = conn.execute(
+                "SELECT manager_id, transfer_pnl, matchday_wins, is_self "
+                "FROM manager_profile_history"
+            ).fetchone()
+        assert row == ("m1", -34_812_837, 0, 1)
+
+    def test_bulk_insert_multiple_managers(self, learner):
+        rows = [
+            _profile_row("m1", transfer_pnl=-34_812_837, is_self=True),
+            _profile_row("m2", transfer_pnl=-48_555_897),
+            _profile_row("m3", transfer_pnl=12_500_000),
+        ]
+        learner.record_manager_profile_snapshot(rows)
+
+        with sqlite3.connect(learner.db_path) as conn:
+            data = conn.execute(
+                "SELECT manager_id, transfer_pnl FROM manager_profile_history "
+                "ORDER BY transfer_pnl"
+            ).fetchall()
+        assert data == [
+            ("m2", -48_555_897),
+            ("m1", -34_812_837),
+            ("m3", 12_500_000),
+        ]
+
+    def test_empty_input_is_noop(self, learner):
+        assert learner.record_manager_profile_snapshot([]) == 0
+
+    def test_collision_at_same_pk_is_silently_dropped(self, learner):
+        # PK (snapshot_at, manager_id) — same-second retry preserves the first.
+        learner.record_manager_profile_snapshot(
+            [_profile_row("m1", snapshot_at=42.0, transfer_pnl=-1)]
+        )
+        learner.record_manager_profile_snapshot(
+            [_profile_row("m1", snapshot_at=42.0, transfer_pnl=-999)]
+        )
+        with sqlite3.connect(learner.db_path) as conn:
+            rows = conn.execute(
+                "SELECT manager_id, transfer_pnl FROM manager_profile_history"
+            ).fetchall()
+        assert rows == [("m1", -1)]
+
+    def test_matchday_wins_accepts_none(self, learner):
+        # Pre-season the dashboard may legitimately omit `mdw`.
+        learner.record_manager_profile_snapshot([_profile_row("m1", matchday_wins=None)])
+        with sqlite3.connect(learner.db_path) as conn:
+            row = conn.execute("SELECT matchday_wins FROM manager_profile_history").fetchone()
+        assert row == (None,)
+
+    def test_is_self_flag_round_trips_as_int(self, learner):
+        learner.record_manager_profile_snapshot(
+            [_profile_row("m1", is_self=True), _profile_row("m2", is_self=False)]
+        )
+        with sqlite3.connect(learner.db_path) as conn:
+            self_row = conn.execute(
+                "SELECT manager_id FROM manager_profile_history WHERE is_self=1"
+            ).fetchone()
+        assert self_row == ("m1",)
+
+    def test_trajectory_query_for_self(self, learner):
+        # The canonical post-deploy verification query: read self's prft trend.
+        learner.record_manager_profile_snapshot(
+            [
+                _profile_row("m1", snapshot_at=100.0, transfer_pnl=-31_764_953, is_self=True),
+                _profile_row("m1", snapshot_at=200.0, transfer_pnl=-34_812_837, is_self=True),
+            ]
+        )
+        with sqlite3.connect(learner.db_path) as conn:
+            latest = conn.execute(
+                "SELECT manager_id, transfer_pnl FROM manager_profile_history "
+                "WHERE is_self=1 ORDER BY snapshot_at DESC LIMIT 1"
+            ).fetchone()
+        assert latest == ("m1", -34_812_837)
+
+
+class TestRecordManagerTransfers:
+    def test_round_trip_one_row(self, learner):
+        n = learner.record_manager_transfers([_transfer_row()])
+        assert n == 1
+
+        with sqlite3.connect(learner.db_path) as conn:
+            row = conn.execute(
+                "SELECT league_id, manager_id, transfer_dt, player_id, "
+                "player_name, transfer_type, transfer_price FROM manager_transfers"
+            ).fetchone()
+        assert row == (
+            "L1",
+            "m1",
+            "2026-05-04T09:57:07Z",
+            "10049",
+            "Behrens",
+            1,
+            1_926_310,
+        )
+
+    def test_empty_input_is_noop(self, learner):
+        assert learner.record_manager_transfers([]) == 0
+
+    def test_collision_on_pk_is_silently_dropped(self, learner):
+        # PK (league_id, manager_id, transfer_dt, player_id) — re-importing
+        # an overlapping page during backfill must NOT error or duplicate.
+        original = _transfer_row(transfer_price=1_926_310)
+        rewritten = _transfer_row(transfer_price=999_999_999)
+        learner.record_manager_transfers([original])
+        learner.record_manager_transfers([rewritten])
+
+        with sqlite3.connect(learner.db_path) as conn:
+            rows = conn.execute(
+                "SELECT player_id, transfer_price FROM manager_transfers"
+            ).fetchall()
+        assert rows == [("10049", 1_926_310)]
+
+    def test_distinct_dts_for_same_player_create_separate_rows(self, learner):
+        # The same player can be bought and sold multiple times — each
+        # transfer is a distinct event keyed on transfer_dt.
+        learner.record_manager_transfers(
+            [
+                _transfer_row(transfer_dt="2026-04-01T10:00:00Z", transfer_type=1),
+                _transfer_row(transfer_dt="2026-04-15T20:00:00Z", transfer_type=2),
+            ]
+        )
+        with sqlite3.connect(learner.db_path) as conn:
+            rows = conn.execute(
+                "SELECT transfer_dt, transfer_type FROM manager_transfers " "ORDER BY transfer_dt"
+            ).fetchall()
+        assert rows == [
+            ("2026-04-01T10:00:00Z", 1),
+            ("2026-04-15T20:00:00Z", 2),
+        ]
+
+    def test_optional_numeric_fields_accept_none(self, learner):
+        learner.record_manager_transfers([_transfer_row(transfer_type=None, transfer_price=None)])
+        with sqlite3.connect(learner.db_path) as conn:
+            row = conn.execute(
+                "SELECT transfer_type, transfer_price FROM manager_transfers"
+            ).fetchone()
+        assert row == (None, None)
+
+    def test_bulk_insert_across_managers(self, learner):
+        learner.record_manager_transfers(
+            [
+                _transfer_row(manager_id="m1", player_id="p1"),
+                _transfer_row(manager_id="m2", player_id="p1"),
+                _transfer_row(manager_id="m1", player_id="p2"),
+            ]
+        )
+        with sqlite3.connect(learner.db_path) as conn:
+            count = conn.execute("SELECT COUNT(*) FROM manager_transfers").fetchone()[0]
+        assert count == 3


### PR DESCRIPTION
## Summary

- Persist per-manager `prft` (cumulative transfer P&L) and `mdw` (matchday wins) from `/managers/{mid}/dashboard` into a new `manager_profile_history` table — neither field lives in `/ranking`.
- Ingest per-trade buy/sell history from `/managers/{mid}/transfer` (page 0) into `manager_transfers`. Idempotent via composite PK `(league_id, manager_id, transfer_dt, player_id)`.
- Wire both into the existing competitor-scouting loop in `Trader.get_ep_recommendations` so the data is captured on every session, gated on `bid_learner is not None` and exception-wrapped per-manager.

This unblocks the [Linear issue REH-38](https://linear.app/jovily/issue/REH-38). Closes the gap to north-star goals 1 (flip revenue) and 2 (loss avoidance) — `flip_outcomes` only tracks closed flips, while `prft` captures unrealized P&L on currently-held players too. Also gives competitive intel on which leaguemates are bleeding transfer money.

## Cost

~28 extra HTTP calls per session (one dashboard + one transfer-history page per league manager). 14-manager league × 2 sessions/day = ~56 calls/day. Well within Azure free tier.

## Probe-validated 2026-05-04 against the live API

- Dashboard: `prft=-34812837`, `mdw=0` — drifted from -€31.76M (probed 2026-05-03) confirming the field is dynamic.
- Transfer: 25 items, fields `pi`, `pn`, `tid`, `tty`, `trp`, `dt` all present. `tty` is a 2-value flag (1, 2) — buy/sell.
- Pagination via `?start=N` confirmed working (page 0/25/50 returned distinct date ranges).
- Competitor manager dashboard returns same shape — pille at -€48.5M vs us at -€34.8M.

## Test plan

- [x] 13 new unit tests for both writers (round-trip, bulk, PK collisions, optional fields, trajectory query)
- [x] Existing REH-24/25 tests still pass (27 writer tests green together)
- [x] Ruff + Black + pre-commit hooks pass
- [ ] After deploy + one session: `SELECT manager_id, transfer_pnl FROM manager_profile_history WHERE is_self=1 ORDER BY snapshot_at DESC LIMIT 1` returns our current `prft`
- [ ] After deploy + one session: `manager_transfers` row count grows by ~14×25 (or fewer if managers have <25 lifetime transfers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)