### PR TITLE
feat: add fetch-azure-state CLI for prod blob debugging (REH-15)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,12 @@ MIN_POINTS_TO_KEEP=50  # Protect high performers above this threshold
 
 # Safety settings
 DRY_RUN=true  # Set to false to enable actual trading
+
+# External data — API-Football (free tier, 100 req/day)
+# Sign up at https://www.api-football.com/ (no credit card)
+API_FOOTBALL_KEY=your-api-football-key
+
+# Azure Blob Storage — only needed for `rehoboam fetch-azure-state` /
+# `push-azure-state` and the deployed Azure Function. Leave unset for local-only dev.
+# AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=https;AccountName=...
+# BLOB_CONTAINER=rehoboam-data

--- a/deploy/azure_function/function_app.py
+++ b/deploy/azure_function/function_app.py
@@ -14,71 +14,50 @@ sys.path.insert(0, str(Path(__file__).parent))
 
 # Azure Functions writable directory
 TEMP_DIR = "/tmp"
+LOGS_DIR = Path(TEMP_DIR) / "logs"
 
-# SQLite databases to persist in Azure Blob Storage
-DB_FILES = [
-    "bid_learning.db",
-    "value_tracking.db",
-    "market_prices.db",
-    "player_history.db",
-]
+
+def _blob_settings() -> tuple[str | None, str]:
+    return (
+        os.getenv("AZURE_STORAGE_CONNECTION_STRING"),
+        os.getenv("BLOB_CONTAINER", "rehoboam-data"),
+    )
 
 
 def download_databases():
-    """Download learning databases from Azure Blob Storage"""
-    connection_string = os.getenv("AZURE_STORAGE_CONNECTION_STRING")
-    container_name = os.getenv("BLOB_CONTAINER", "rehoboam-data")
+    """Download learning databases from Azure Blob Storage."""
+    from rehoboam.azure_blob import fetch_state
 
-    if not connection_string:
+    conn_str, container = _blob_settings()
+    if not conn_str:
         logging.info("No AZURE_STORAGE_CONNECTION_STRING - skipping DB download")
         return
 
-    from azure.storage.blob import BlobServiceClient
-
-    blob_service = BlobServiceClient.from_connection_string(connection_string)
-    container = blob_service.get_container_client(container_name)
-
-    os.makedirs(f"{TEMP_DIR}/logs", exist_ok=True)
-
-    for db_file in DB_FILES:
-        db_path = f"{TEMP_DIR}/logs/{db_file}"
-        try:
-            blob_client = container.get_blob_client(db_file)
-            with open(db_path, "wb") as f:
-                f.write(blob_client.download_blob().readall())
-            logging.info(f"Downloaded {db_file}")
-        except Exception as e:
-            if "BlobNotFound" in str(e):
-                logging.info(f"No existing {db_file} in blob storage - will create new")
-            else:
-                logging.warning(f"Could not download {db_file}: {e}")
+    results = fetch_state(conn_str, container, LOGS_DIR, backup=False, dry_run=False)
+    for r in results:
+        if r.status == "downloaded":
+            logging.info(f"Downloaded {r.db_file} ({r.blob.size} bytes)")
+        elif r.status == "missing_in_blob":
+            logging.info(f"No existing {r.db_file} in blob storage - will create new")
+        elif r.status == "error":
+            logging.warning(f"Could not download {r.db_file}: {r.error}")
 
 
 def upload_databases():
-    """Upload learning databases to Azure Blob Storage"""
-    connection_string = os.getenv("AZURE_STORAGE_CONNECTION_STRING")
-    container_name = os.getenv("BLOB_CONTAINER", "rehoboam-data")
+    """Upload learning databases to Azure Blob Storage."""
+    from rehoboam.azure_blob import push_state
 
-    if not connection_string:
+    conn_str, container = _blob_settings()
+    if not conn_str:
         logging.info("No AZURE_STORAGE_CONNECTION_STRING - skipping DB upload")
         return
 
-    from azure.storage.blob import BlobServiceClient
-
-    blob_service = BlobServiceClient.from_connection_string(connection_string)
-    container = blob_service.get_container_client(container_name)
-
-    for db_file in DB_FILES:
-        db_path = f"{TEMP_DIR}/logs/{db_file}"
-        if not os.path.exists(db_path):
-            continue
-        try:
-            blob_client = container.get_blob_client(db_file)
-            with open(db_path, "rb") as f:
-                blob_client.upload_blob(f, overwrite=True)
-            logging.info(f"Uploaded {db_file}")
-        except Exception as e:
-            logging.warning(f"Could not upload {db_file}: {e}")
+    results = push_state(conn_str, container, LOGS_DIR, dry_run=False)
+    for r in results:
+        if r.status == "uploaded":
+            logging.info(f"Uploaded {r.db_file} ({r.local_size} bytes)")
+        elif r.status == "error":
+            logging.warning(f"Could not upload {r.db_file}: {r.error}")
 
 
 # Timer trigger: runs 2x daily at 08:00 and 20:00 UTC

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "pydantic>=2.0.0",  # Configuration validation
     "pydantic-settings>=2.0.0",
     "python-dotenv>=1.0.0",
+    "azure-storage-blob>=12.19.0",  # Prod state debugging via fetch-azure-state
 ]
 
 [project.optional-dependencies]

--- a/rehoboam/azure_blob.py
+++ b/rehoboam/azure_blob.py
@@ -1,0 +1,243 @@
+"""Shared Azure Blob Storage helpers for SQLite state persistence.
+
+The bot runs on Azure Functions and persists its SQLite databases to Azure Blob
+Storage between invocations. This module is the single source of truth for
+which DBs are persisted (`DB_FILES`) and exposes `fetch_state` / `push_state`
+used by both the Azure Function and the `rehoboam fetch-azure-state` /
+`rehoboam push-azure-state` CLI commands for prod debugging.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Literal
+
+logger = logging.getLogger(__name__)
+
+DB_FILES: tuple[str, ...] = (
+    "bid_learning.db",
+    "value_tracking.db",
+    "market_prices.db",
+    "player_history.db",
+)
+
+BACKUP_SUFFIX = ".local-bak"
+
+FetchStatus = Literal["downloaded", "missing_in_blob", "skipped_dry_run", "error"]
+PushStatus = Literal["uploaded", "missing_local", "skipped_dry_run", "error"]
+
+
+class MissingAzureCredentials(RuntimeError):
+    """Raised when AZURE_STORAGE_CONNECTION_STRING is not configured."""
+
+
+@dataclass(frozen=True)
+class BlobInfo:
+    name: str
+    last_modified: datetime | None
+    size: int | None
+
+
+@dataclass(frozen=True)
+class FetchResult:
+    db_file: str
+    blob: BlobInfo
+    local_path: Path
+    backed_up_to: Path | None
+    status: FetchStatus
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class PushResult:
+    db_file: str
+    local_path: Path
+    local_size: int | None
+    status: PushStatus
+    error: str | None = None
+
+
+def _backup_path(local_path: Path) -> Path:
+    return local_path.with_name(local_path.name + BACKUP_SUFFIX)
+
+
+def _get_container(connection_string: str | None, container_name: str):
+    if not connection_string:
+        raise MissingAzureCredentials(
+            "AZURE_STORAGE_CONNECTION_STRING is not set. "
+            "Add it to your .env to fetch or push prod state."
+        )
+
+    from azure.storage.blob import BlobServiceClient
+
+    return BlobServiceClient.from_connection_string(connection_string).get_container_client(
+        container_name
+    )
+
+
+def _probe_blob(container, name: str) -> BlobInfo:
+    try:
+        props = container.get_blob_client(name).get_blob_properties()
+        return BlobInfo(name=name, last_modified=props.last_modified, size=props.size)
+    except Exception as e:  # noqa: BLE001
+        if "BlobNotFound" in str(e):
+            return BlobInfo(name=name, last_modified=None, size=None)
+        raise
+
+
+def list_blobs(connection_string: str | None, container_name: str) -> list[BlobInfo]:
+    container = _get_container(connection_string, container_name)
+    return [_probe_blob(container, name) for name in DB_FILES]
+
+
+def fetch_state(
+    connection_string: str | None,
+    container_name: str,
+    dest_dir: Path,
+    *,
+    backup: bool = True,
+    dry_run: bool = False,
+) -> list[FetchResult]:
+    """Download each DB blob into ``dest_dir``.
+
+    For each file:
+    - Missing in blob → status ``missing_in_blob``.
+    - ``dry_run`` → status ``skipped_dry_run``, no file I/O.
+    - Otherwise: when ``backup`` and the local file exists, rename it to
+      ``<name>.local-bak`` (overwriting any prior backup), then write the blob.
+    """
+    container = _get_container(connection_string, container_name)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    results: list[FetchResult] = []
+
+    for name in DB_FILES:
+        blob = _probe_blob(container, name)
+        local_path = dest_dir / name
+
+        if blob.last_modified is None:
+            results.append(
+                FetchResult(
+                    db_file=name,
+                    blob=blob,
+                    local_path=local_path,
+                    backed_up_to=None,
+                    status="missing_in_blob",
+                )
+            )
+            continue
+
+        if dry_run:
+            would_back_up = _backup_path(local_path) if (backup and local_path.exists()) else None
+            results.append(
+                FetchResult(
+                    db_file=name,
+                    blob=blob,
+                    local_path=local_path,
+                    backed_up_to=would_back_up,
+                    status="skipped_dry_run",
+                )
+            )
+            continue
+
+        backup_path: Path | None = None
+        try:
+            if backup and local_path.exists():
+                backup_path = _backup_path(local_path)
+                local_path.replace(backup_path)
+            data = container.get_blob_client(name).download_blob().readall()
+            local_path.write_bytes(data)
+            results.append(
+                FetchResult(
+                    db_file=name,
+                    blob=blob,
+                    local_path=local_path,
+                    backed_up_to=backup_path,
+                    status="downloaded",
+                )
+            )
+            logger.info("Downloaded %s (%d bytes)", name, len(data))
+        except Exception as e:  # noqa: BLE001
+            results.append(
+                FetchResult(
+                    db_file=name,
+                    blob=blob,
+                    local_path=local_path,
+                    backed_up_to=backup_path,
+                    status="error",
+                    error=str(e),
+                )
+            )
+            logger.warning("Failed to download %s: %s", name, e)
+
+    return results
+
+
+def push_state(
+    connection_string: str | None,
+    container_name: str,
+    source_dir: Path,
+    *,
+    dry_run: bool = False,
+) -> list[PushResult]:
+    """Upload each local DB to the corresponding blob (overwrite).
+
+    Files missing locally are skipped (status ``missing_local``).
+    """
+    container = _get_container(connection_string, container_name)
+    results: list[PushResult] = []
+
+    for name in DB_FILES:
+        local_path = source_dir / name
+
+        if not local_path.exists():
+            results.append(
+                PushResult(
+                    db_file=name,
+                    local_path=local_path,
+                    local_size=None,
+                    status="missing_local",
+                )
+            )
+            continue
+
+        size = local_path.stat().st_size
+
+        if dry_run:
+            results.append(
+                PushResult(
+                    db_file=name,
+                    local_path=local_path,
+                    local_size=size,
+                    status="skipped_dry_run",
+                )
+            )
+            continue
+
+        try:
+            with open(local_path, "rb") as f:
+                container.get_blob_client(name).upload_blob(f, overwrite=True)
+            results.append(
+                PushResult(
+                    db_file=name,
+                    local_path=local_path,
+                    local_size=size,
+                    status="uploaded",
+                )
+            )
+            logger.info("Uploaded %s (%d bytes)", name, size)
+        except Exception as e:  # noqa: BLE001
+            results.append(
+                PushResult(
+                    db_file=name,
+                    local_path=local_path,
+                    local_size=size,
+                    status="error",
+                    error=str(e),
+                )
+            )
+            logger.warning("Failed to upload %s: %s", name, e)
+
+    return results

--- a/rehoboam/cli.py
+++ b/rehoboam/cli.py
@@ -1,12 +1,16 @@
 """CLI interface for Rehoboam — minimal surface for auto + diagnostics."""
 
 import logging
+from datetime import datetime
+from pathlib import Path
 
 import typer
 from rich.console import Console
+from rich.table import Table
 
+from . import azure_blob
 from .api import KickbaseAPI
-from .config import get_settings
+from .config import AzureBlobSettings, get_settings
 from .logging_setup import setup_logging
 
 logger = logging.getLogger(__name__)
@@ -158,6 +162,153 @@ def status(
         dry_run=True,
     )
     auto_trader.run_full_session(league)
+
+
+def _fmt_size(n: int | None) -> str:
+    if n is None:
+        return "—"
+    if n < 1024:
+        return f"{n} B"
+    if n < 1024 * 1024:
+        return f"{n / 1024:.1f} KiB"
+    return f"{n / (1024 * 1024):.1f} MiB"
+
+
+def _fmt_dt(dt: datetime | None) -> str:
+    return dt.strftime("%Y-%m-%d %H:%M:%S UTC") if dt else "—"
+
+
+_FETCH_STATUS_STYLE = {
+    "downloaded": "green",
+    "missing_in_blob": "yellow",
+    "skipped_dry_run": "cyan",
+    "error": "red",
+}
+
+_PUSH_STATUS_STYLE = {
+    "uploaded": "green",
+    "missing_local": "yellow",
+    "skipped_dry_run": "cyan",
+    "error": "red",
+}
+
+
+def _render_fetch_table(results: list[azure_blob.FetchResult], *, dry_run: bool) -> Table:
+    title = "Would fetch" if dry_run else "Fetched"
+    table = Table(title=title)
+    table.add_column("DB", style="bold")
+    table.add_column("Blob last modified")
+    table.add_column("Blob size", justify="right")
+    table.add_column("Local target")
+    table.add_column("Backup")
+    table.add_column("Status")
+
+    for r in results:
+        backup = str(r.backed_up_to) if r.backed_up_to else "—"
+        status_label = r.status.replace("_", " ")
+        if r.status == "error" and r.error:
+            status_label = f"error: {r.error[:40]}"
+        table.add_row(
+            r.db_file,
+            _fmt_dt(r.blob.last_modified),
+            _fmt_size(r.blob.size),
+            str(r.local_path),
+            backup,
+            f"[{_FETCH_STATUS_STYLE[r.status]}]{status_label}[/{_FETCH_STATUS_STYLE[r.status]}]",
+        )
+    return table
+
+
+def _render_push_table(results: list[azure_blob.PushResult], *, dry_run: bool) -> Table:
+    title = "Would push" if dry_run else "Pushed"
+    table = Table(title=title)
+    table.add_column("DB", style="bold")
+    table.add_column("Local path")
+    table.add_column("Local size", justify="right")
+    table.add_column("Status")
+
+    for r in results:
+        status_label = r.status.replace("_", " ")
+        if r.status == "error" and r.error:
+            status_label = f"error: {r.error[:40]}"
+        table.add_row(
+            r.db_file,
+            str(r.local_path),
+            _fmt_size(r.local_size),
+            f"[{_PUSH_STATUS_STYLE[r.status]}]{status_label}[/{_PUSH_STATUS_STYLE[r.status]}]",
+        )
+    return table
+
+
+@app.command("fetch-azure-state")
+def fetch_azure_state(
+    dry_run: bool = typer.Option(False, "--dry-run", help="List blobs without downloading"),
+    backup: bool = typer.Option(
+        True,
+        "--backup/--no-backup",
+        help="Rename existing local files to .local-bak before overwriting",
+    ),
+):
+    """Pull SQLite state from Azure Blob Storage into ./logs/ for prod debugging."""
+    blob_settings = AzureBlobSettings()
+    try:
+        results = azure_blob.fetch_state(
+            connection_string=blob_settings.azure_storage_connection_string,
+            container_name=blob_settings.blob_container,
+            dest_dir=Path("logs"),
+            backup=backup,
+            dry_run=dry_run,
+        )
+    except azure_blob.MissingAzureCredentials as e:
+        console.print(f"[red]✗ {e}[/red]")
+        raise typer.Exit(code=1) from e
+
+    console.print(_render_fetch_table(results, dry_run=dry_run))
+
+    if not dry_run and any(r.status == "error" for r in results):
+        raise typer.Exit(code=1)
+
+
+@app.command("push-azure-state")
+def push_azure_state(
+    confirm: bool = typer.Option(
+        False,
+        "--i-know-what-im-doing",
+        help="Required to actually upload — without it the command refuses.",
+    ),
+    dry_run: bool = typer.Option(False, "--dry-run", help="List local files without uploading"),
+):
+    """Push local ./logs/ SQLite state to Azure Blob Storage (DANGEROUS).
+
+    Overwrites the live bot's persistent state. Refuses to run without
+    --i-know-what-im-doing. Use --dry-run to preview.
+    """
+    if not confirm:
+        console.print(
+            "[red]⛔ Refusing to overwrite prod state from local.[/red]\n"
+            "This will replace the live bot's databases (bid_learning.db, "
+            "value_tracking.db, market_prices.db, player_history.db) with "
+            "whatever is in ./logs/.\n"
+            "Re-run with [bold]--i-know-what-im-doing[/bold] if you actually want this."
+        )
+        raise typer.Exit(code=1)
+
+    blob_settings = AzureBlobSettings()
+    try:
+        results = azure_blob.push_state(
+            connection_string=blob_settings.azure_storage_connection_string,
+            container_name=blob_settings.blob_container,
+            source_dir=Path("logs"),
+            dry_run=dry_run,
+        )
+    except azure_blob.MissingAzureCredentials as e:
+        console.print(f"[red]✗ {e}[/red]")
+        raise typer.Exit(code=1) from e
+
+    console.print(_render_push_table(results, dry_run=dry_run))
+
+    if not dry_run and any(r.status == "error" for r in results):
+        raise typer.Exit(code=1)
 
 
 @app.callback()

--- a/rehoboam/config.py
+++ b/rehoboam/config.py
@@ -136,3 +136,28 @@ class Settings(BaseSettings):
 def get_settings() -> Settings:
     """Get application settings"""
     return Settings()
+
+
+class AzureBlobSettings(BaseSettings):
+    """Azure Blob Storage settings — used by both the Azure Function and the
+    `rehoboam fetch-azure-state` / `push-azure-state` CLI commands.
+
+    Kept separate from `Settings` so debugging commands don't require
+    KICKBASE credentials to be present in `.env`.
+    """
+
+    model_config = SettingsConfigDict(
+        env_file=find_env_file(),
+        env_file_encoding="utf-8",
+        case_sensitive=False,
+        extra="ignore",
+    )
+
+    azure_storage_connection_string: str | None = Field(
+        default=None,
+        description="Azure Blob Storage connection string (set in .env or app settings)",
+    )
+    blob_container: str = Field(
+        default="rehoboam-data",
+        description="Container holding the persisted SQLite databases",
+    )

--- a/tests/test_azure_blob.py
+++ b/tests/test_azure_blob.py
@@ -1,0 +1,272 @@
+"""Tests for rehoboam.azure_blob — fetch_state / push_state state-machine logic.
+
+Tests patch ``_get_container`` so they don't depend on the live Azure SDK call
+chain. ``MissingAzureCredentials`` is exercised separately by leaving
+``connection_string`` empty.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from rehoboam import azure_blob
+from rehoboam.azure_blob import (
+    DB_FILES,
+    MissingAzureCredentials,
+    fetch_state,
+    list_blobs,
+    push_state,
+)
+
+
+def _props(last_modified: datetime, size: int) -> MagicMock:
+    p = MagicMock()
+    p.last_modified = last_modified
+    p.size = size
+    return p
+
+
+def _blob_not_found() -> Exception:
+    return Exception("BlobNotFound: The specified blob does not exist.")
+
+
+def _make_container(per_blob: dict) -> MagicMock:
+    """Build a fake ContainerClient.
+
+    ``per_blob`` keys are blob names. Values are dicts with optional keys:
+      - ``props``: MagicMock to return from ``get_blob_properties``
+      - ``props_error``: Exception to raise from ``get_blob_properties``
+      - ``data``: bytes to return from ``download_blob().readall()``
+      - ``download_error``: Exception to raise from ``download_blob``
+      - ``upload_error``: Exception to raise from ``upload_blob``
+    """
+    container = MagicMock()
+
+    def get_blob_client(name):
+        bc = MagicMock()
+        spec = per_blob.get(name, {})
+
+        if "props_error" in spec:
+            bc.get_blob_properties.side_effect = spec["props_error"]
+        else:
+            bc.get_blob_properties.return_value = spec.get("props")
+
+        if "download_error" in spec:
+            bc.download_blob.side_effect = spec["download_error"]
+        else:
+            blob_obj = MagicMock()
+            blob_obj.readall.return_value = spec.get("data", b"")
+            bc.download_blob.return_value = blob_obj
+
+        if "upload_error" in spec:
+            bc.upload_blob.side_effect = spec["upload_error"]
+
+        return bc
+
+    container.get_blob_client.side_effect = get_blob_client
+    return container
+
+
+def _patch_container(monkeypatch, container):
+    monkeypatch.setattr(azure_blob, "_get_container", lambda *a, **kw: container)
+
+
+# --- credential handling --------------------------------------------------
+
+
+def test_missing_credentials_raises():
+    with pytest.raises(MissingAzureCredentials):
+        list_blobs(connection_string=None, container_name="rehoboam-data")
+
+    with pytest.raises(MissingAzureCredentials):
+        list_blobs(connection_string="", container_name="rehoboam-data")
+
+
+# --- fetch_state ----------------------------------------------------------
+
+
+def test_fetch_state_downloads_all_files(monkeypatch, tmp_path):
+    ts = datetime(2026, 5, 8, 8, 1, 32, tzinfo=timezone.utc)
+    container = _make_container(
+        {
+            name: {"props": _props(ts, 1024 * (i + 1)), "data": f"db-{name}".encode()}
+            for i, name in enumerate(DB_FILES)
+        }
+    )
+    _patch_container(monkeypatch, container)
+
+    results = fetch_state("conn", "rehoboam-data", tmp_path)
+
+    assert [r.status for r in results] == ["downloaded"] * len(DB_FILES)
+    for r in results:
+        assert (tmp_path / r.db_file).read_bytes() == f"db-{r.db_file}".encode()
+        assert r.backed_up_to is None
+        assert r.blob.last_modified == ts
+
+
+def test_fetch_state_backs_up_existing_local_file(monkeypatch, tmp_path):
+    name = DB_FILES[0]
+    existing = tmp_path / name
+    existing.write_bytes(b"OLD-LOCAL-DATA")
+
+    container = _make_container(
+        {
+            n: {"props": _props(datetime(2026, 5, 8, tzinfo=timezone.utc), 100), "data": b"NEW"}
+            for n in DB_FILES
+        }
+    )
+    _patch_container(monkeypatch, container)
+
+    results = fetch_state("conn", "rehoboam-data", tmp_path, backup=True)
+
+    first = next(r for r in results if r.db_file == name)
+    assert first.status == "downloaded"
+    assert first.backed_up_to == tmp_path / f"{name}.local-bak"
+    assert first.backed_up_to.read_bytes() == b"OLD-LOCAL-DATA"
+    assert (tmp_path / name).read_bytes() == b"NEW"
+
+
+def test_fetch_state_no_backup_clobbers_local(monkeypatch, tmp_path):
+    name = DB_FILES[0]
+    (tmp_path / name).write_bytes(b"OLD")
+
+    container = _make_container(
+        {
+            n: {"props": _props(datetime(2026, 5, 8, tzinfo=timezone.utc), 100), "data": b"NEW"}
+            for n in DB_FILES
+        }
+    )
+    _patch_container(monkeypatch, container)
+
+    results = fetch_state("conn", "rehoboam-data", tmp_path, backup=False)
+    first = next(r for r in results if r.db_file == name)
+
+    assert first.backed_up_to is None
+    assert not (tmp_path / f"{name}.local-bak").exists()
+    assert (tmp_path / name).read_bytes() == b"NEW"
+
+
+def test_fetch_state_dry_run_writes_no_files(monkeypatch, tmp_path):
+    name = DB_FILES[0]
+    (tmp_path / name).write_bytes(b"UNTOUCHED")
+    ts = datetime(2026, 5, 8, tzinfo=timezone.utc)
+
+    container = _make_container(
+        {n: {"props": _props(ts, 555), "data": b"would-be-new"} for n in DB_FILES}
+    )
+    _patch_container(monkeypatch, container)
+
+    results = fetch_state("conn", "rehoboam-data", tmp_path, dry_run=True)
+
+    assert all(r.status == "skipped_dry_run" for r in results)
+    assert (tmp_path / name).read_bytes() == b"UNTOUCHED"
+    # Backup target reported only when local file exists.
+    first = next(r for r in results if r.db_file == name)
+    assert first.backed_up_to == tmp_path / f"{name}.local-bak"
+    assert all(r.blob.size == 555 for r in results)
+
+
+def test_fetch_state_handles_blob_not_found_per_file(monkeypatch, tmp_path):
+    missing = DB_FILES[1]
+    spec = {}
+    for n in DB_FILES:
+        if n == missing:
+            spec[n] = {"props_error": _blob_not_found()}
+        else:
+            spec[n] = {
+                "props": _props(datetime(2026, 5, 8, tzinfo=timezone.utc), 200),
+                "data": b"ok",
+            }
+    container = _make_container(spec)
+    _patch_container(monkeypatch, container)
+
+    results = fetch_state("conn", "rehoboam-data", tmp_path)
+
+    statuses = {r.db_file: r.status for r in results}
+    assert statuses[missing] == "missing_in_blob"
+    assert all(s == "downloaded" for n, s in statuses.items() if n != missing)
+    assert not (tmp_path / missing).exists()
+
+
+def test_fetch_state_isolates_download_failures(monkeypatch, tmp_path):
+    failing = DB_FILES[2]
+    spec = {}
+    for n in DB_FILES:
+        spec[n] = {
+            "props": _props(datetime(2026, 5, 8, tzinfo=timezone.utc), 200),
+            "data": b"ok",
+        }
+        if n == failing:
+            spec[n]["download_error"] = RuntimeError("transient network error")
+    container = _make_container(spec)
+    _patch_container(monkeypatch, container)
+
+    results = fetch_state("conn", "rehoboam-data", tmp_path)
+    statuses = {r.db_file: r.status for r in results}
+
+    assert statuses[failing] == "error"
+    assert all(s == "downloaded" for n, s in statuses.items() if n != failing)
+    bad = next(r for r in results if r.db_file == failing)
+    assert "transient" in bad.error
+
+
+# --- push_state -----------------------------------------------------------
+
+
+def test_push_state_uploads_existing_files(monkeypatch, tmp_path):
+    for n in DB_FILES:
+        (tmp_path / n).write_bytes(b"local-" + n.encode())
+    container = _make_container({n: {} for n in DB_FILES})
+    _patch_container(monkeypatch, container)
+
+    results = push_state("conn", "rehoboam-data", tmp_path)
+
+    assert all(r.status == "uploaded" for r in results)
+    assert container.get_blob_client.call_count == len(DB_FILES)
+
+
+def test_push_state_skips_missing_local(monkeypatch, tmp_path):
+    present = DB_FILES[0]
+    (tmp_path / present).write_bytes(b"x")
+    container = _make_container({n: {} for n in DB_FILES})
+    _patch_container(monkeypatch, container)
+
+    results = push_state("conn", "rehoboam-data", tmp_path)
+    statuses = {r.db_file: r.status for r in results}
+
+    assert statuses[present] == "uploaded"
+    for n in DB_FILES:
+        if n != present:
+            assert statuses[n] == "missing_local"
+
+
+def test_push_state_dry_run_does_not_upload(monkeypatch, tmp_path):
+    for n in DB_FILES:
+        (tmp_path / n).write_bytes(b"x")
+    container = _make_container({n: {} for n in DB_FILES})
+    _patch_container(monkeypatch, container)
+
+    results = push_state("conn", "rehoboam-data", tmp_path, dry_run=True)
+
+    assert all(r.status == "skipped_dry_run" for r in results)
+    # get_blob_client may still be called for setup but upload_blob shouldn't fire
+    for blob_client_call in container.get_blob_client.return_value.upload_blob.call_args_list:
+        raise AssertionError(f"upload_blob called unexpectedly with {blob_client_call}")
+
+
+def test_push_state_isolates_upload_failures(monkeypatch, tmp_path):
+    failing = DB_FILES[1]
+    for n in DB_FILES:
+        (tmp_path / n).write_bytes(b"x")
+
+    spec = {n: {} for n in DB_FILES}
+    spec[failing]["upload_error"] = RuntimeError("upload boom")
+    container = _make_container(spec)
+    _patch_container(monkeypatch, container)
+
+    results = push_state("conn", "rehoboam-data", tmp_path)
+    statuses = {r.db_file: r.status for r in results}
+
+    assert statuses[failing] == "error"
+    assert all(s == "uploaded" for n, s in statuses.items() if n != failing)


### PR DESCRIPTION
## Summary
- New `rehoboam fetch-azure-state` (and guarded `push-azure-state`) pulls live blob state into `./logs/` in seconds, replacing manual `az storage blob download`. `--dry-run` shows blob `last_modified` + size so prod freshness is immediately visible — directly addresses the Svensson-investigation friction referenced in REH-15.
- Extracts blob I/O into `rehoboam/azure_blob.py` as the single source of truth for `DB_FILES`; both the Azure Function and the new CLI now use structured `FetchResult` / `PushResult` types instead of duplicated procedural logic (~50 LoC removed from `function_app.py`).
- Sibling `AzureBlobSettings(BaseSettings)` keeps the new commands usable without `KICKBASE_EMAIL` / `KICKBASE_PASSWORD` in `.env`.
- Push counterpart is guarded behind `--i-know-what-im-doing` to prevent accidental clobbering of live state.

Resolves REH-15.

## Test plan
- [x] `pytest tests/test_azure_blob.py` — 11/11 pass (missing-creds, happy path, backup/no-backup, dry-run, per-file BlobNotFound, per-file download/upload error isolation)
- [x] `ruff check` clean on changed files
- [x] `black` clean on new files
- [ ] Manual: `rehoboam fetch-azure-state --dry-run` against live blob to confirm Rich table renders correctly
- [ ] Manual: confirm Azure Function still uploads/downloads correctly on next scheduled run

🤖 Generated with [Claude Code](https://claude.com/claude-code)