### PR TITLE
feat: backfill foundation tables from KICKBASE history (REH-39)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,31 @@ uv run pre-commit install
 uv run pre-commit run --all-files
 ```
 
+## Prod-state debugging workflow (REH-15 / REH-39)
+
+The bot's state lives in Azure Blob Storage. To inspect, mutate, and re-publish:
+
+```bash
+# 1. Pull the live blob into local ./logs/ (writes a .fetch_state.json sidecar)
+uv run rehoboam fetch-azure-state
+
+# 2. Mutate locally — examples:
+#    - Open SQLite directly: sqlite3 logs/bid_learning.db
+#    - One-shot historical backfill: uv run rehoboam backfill-history
+#    - Anything else (manual queries, REPL exploration, etc.)
+
+# 3. Push back during a quiet window between Function runs
+uv run rehoboam push-azure-state --i-know-what-im-doing
+```
+
+The Azure Function runs at 08:00 / 20:00 UTC. **Push during the quiet window**
+(roughly 08:02–19:58 UTC, or after 20:02). `push-azure-state` enforces this
+automatically: it compares each blob's current `last_modified` against the
+sidecar from `fetch-azure-state` and refuses if the Function ran in between.
+On refusal, re-run `fetch-azure-state` (preserves your local work as
+`.local-bak`), redo your mutations, and push again. Pass `--force` only as a
+last resort — it clobbers the Function's writes.
+
 ## Architecture
 
 ### Core Components

--- a/rehoboam/azure_blob.py
+++ b/rehoboam/azure_blob.py
@@ -9,6 +9,7 @@ used by both the Azure Function and the `rehoboam fetch-azure-state` /
 
 from __future__ import annotations
 
+import json
 import logging
 from dataclasses import dataclass
 from datetime import datetime
@@ -25,6 +26,7 @@ DB_FILES: tuple[str, ...] = (
 )
 
 BACKUP_SUFFIX = ".local-bak"
+FETCH_SIDECAR = ".fetch_state.json"
 
 FetchStatus = Literal["downloaded", "missing_in_blob", "skipped_dry_run", "error"]
 PushStatus = Literal["uploaded", "missing_local", "skipped_dry_run", "error"]
@@ -32,6 +34,30 @@ PushStatus = Literal["uploaded", "missing_local", "skipped_dry_run", "error"]
 
 class MissingAzureCredentials(RuntimeError):
     """Raised when AZURE_STORAGE_CONNECTION_STRING is not configured."""
+
+
+@dataclass(frozen=True)
+class StaleBlob:
+    """One blob whose live last_modified is newer than our recorded fetch."""
+
+    db_file: str
+    fetched_last_modified: datetime
+    current_last_modified: datetime
+
+
+class BlobChangedSinceFetch(RuntimeError):
+    """Raised by ``push_state`` when the blob has been modified since the
+    most recent ``fetch_state``. Carries the list of stale files so the CLI
+    can render an actionable message.
+    """
+
+    def __init__(self, stale: list[StaleBlob]):
+        self.stale = stale
+        names = ", ".join(s.db_file for s in stale)
+        super().__init__(
+            f"{len(stale)} blob(s) modified since last fetch ({names}). "
+            "Re-fetch and re-run any local mutations, or pass force=True to clobber."
+        )
 
 
 @dataclass(frozen=True)
@@ -108,10 +134,15 @@ def fetch_state(
     - ``dry_run`` → status ``skipped_dry_run``, no file I/O.
     - Otherwise: when ``backup`` and the local file exists, rename it to
       ``<name>.local-bak`` (overwriting any prior backup), then write the blob.
+
+    On a successful (non-dry-run) fetch, also writes a ``.fetch_state.json``
+    sidecar capturing each blob's ``last_modified`` so a later
+    ``push_state`` can detect drift.
     """
     container = _get_container(connection_string, container_name)
     dest_dir.mkdir(parents=True, exist_ok=True)
     results: list[FetchResult] = []
+    sidecar_updates: dict[str, str] = {}
 
     for name in DB_FILES:
         blob = _probe_blob(container, name)
@@ -149,6 +180,8 @@ def fetch_state(
                 local_path.replace(backup_path)
             data = container.get_blob_client(name).download_blob().readall()
             local_path.write_bytes(data)
+            if blob.last_modified is not None:
+                sidecar_updates[name] = blob.last_modified.isoformat()
             results.append(
                 FetchResult(
                     db_file=name,
@@ -172,7 +205,66 @@ def fetch_state(
             )
             logger.warning("Failed to download %s: %s", name, e)
 
+    if sidecar_updates:
+        sidecar_path = dest_dir / FETCH_SIDECAR
+        existing: dict[str, str] = {}
+        if sidecar_path.exists():
+            try:
+                existing = json.loads(sidecar_path.read_text())
+            except (json.JSONDecodeError, OSError):
+                existing = {}
+        existing.update(sidecar_updates)
+        sidecar_path.write_text(json.dumps(existing, indent=2, sort_keys=True))
+
     return results
+
+
+def check_freshness(
+    connection_string: str | None,
+    container_name: str,
+    source_dir: Path,
+) -> list[StaleBlob]:
+    """Compare each blob's current ``last_modified`` against the sidecar
+    written by the last ``fetch_state``. Returns the list of stale blobs
+    (empty list = safe to push).
+
+    A file with no sidecar entry is treated as fresh (no recorded fetch
+    means we can't claim drift). A blob that no longer exists in storage
+    is also considered fresh — push_state will recreate it.
+    """
+    sidecar_path = source_dir / FETCH_SIDECAR
+    if not sidecar_path.exists():
+        return []
+
+    try:
+        recorded = json.loads(sidecar_path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return []
+
+    container = _get_container(connection_string, container_name)
+    stale: list[StaleBlob] = []
+
+    for name in DB_FILES:
+        recorded_iso = recorded.get(name)
+        if not recorded_iso:
+            continue
+        try:
+            fetched_dt = datetime.fromisoformat(recorded_iso)
+        except ValueError:
+            continue
+        blob = _probe_blob(container, name)
+        if blob.last_modified is None:
+            continue
+        if blob.last_modified > fetched_dt:
+            stale.append(
+                StaleBlob(
+                    db_file=name,
+                    fetched_last_modified=fetched_dt,
+                    current_last_modified=blob.last_modified,
+                )
+            )
+
+    return stale
 
 
 def push_state(
@@ -181,11 +273,23 @@ def push_state(
     source_dir: Path,
     *,
     dry_run: bool = False,
+    force: bool = False,
 ) -> list[PushResult]:
     """Upload each local DB to the corresponding blob (overwrite).
 
     Files missing locally are skipped (status ``missing_local``).
+
+    Unless ``force=True``, runs :func:`check_freshness` first and raises
+    :class:`BlobChangedSinceFetch` if any blob has been modified since the
+    last fetch. This protects against clobbering writes from a concurrent
+    Azure Function run. ``dry_run`` still performs the freshness check so
+    the caller can preview the same outcome.
     """
+    if not force:
+        stale = check_freshness(connection_string, container_name, source_dir)
+        if stale:
+            raise BlobChangedSinceFetch(stale)
+
     container = _get_container(connection_string, container_name)
     results: list[PushResult] = []
 

--- a/rehoboam/backfill.py
+++ b/rehoboam/backfill.py
@@ -211,13 +211,13 @@ def _backfill_matchday_phase(
     league: League,
     user_id: str,
     learner: BidLearner,
-    last_finished_matchday: int,
+    current_day: int,
     *,
     dry_run: bool,
     stats: BackfillStats,
 ) -> None:
-    """For each matchday in [1..lfmd]: fetch teamcenter + ranking, write rows."""
-    for day in range(1, last_finished_matchday + 1):
+    """For each matchday in [1..current_day]: fetch teamcenter + ranking, write rows."""
+    for day in range(1, current_day + 1):
         tc = client.get_user_teamcenter(league.id, user_id, day_number=day)
         lp = tc.get("lp") or []
         if not lp:
@@ -277,8 +277,12 @@ def run_backfill(
     stats = BackfillStats()
 
     current_ranking = client.get_league_ranking(league.id)
-    last_finished = int(current_ranking.get("lfmd") or 0)
-    logger.info("Backfilling matchdays 1..%d (dry_run=%s)", last_finished, dry_run)
+    # `day` is the current matchday number (matches what the live writer in
+    # trader.py persists). `lfmd` is something else and was a misread during
+    # scoping — confirmed against probe dumps where `day=33` matched the
+    # bot's day_number=33 in league_rank_history.
+    current_day = int(current_ranking.get("day") or 0)
+    logger.info("Backfilling matchdays 1..%d (dry_run=%s)", current_day, dry_run)
 
     _backfill_flip_outcomes(client, league.id, manager_id, learner, dry_run=dry_run, stats=stats)
     logger.info(
@@ -290,9 +294,9 @@ def run_backfill(
         stats.transfers_paginated,
     )
 
-    if last_finished > 0:
+    if current_day > 0:
         _backfill_matchday_phase(
-            client, league, user_id, learner, last_finished, dry_run=dry_run, stats=stats
+            client, league, user_id, learner, current_day, dry_run=dry_run, stats=stats
         )
     logger.info(
         "Phase 2/3: %d matchdays processed (%d skipped), %d lineup rows, %d rank rows",

--- a/rehoboam/backfill.py
+++ b/rehoboam/backfill.py
@@ -1,0 +1,305 @@
+"""REH-39: One-shot backfill of foundation tables from KICKBASE history.
+
+Three phases against the live KICKBASE API:
+
+1. ``/managers/{mid}/transfer`` paginated via ``?start=`` cursor → derive
+   closed flips by FIFO buy/sell pairing per ``player_id`` → ``flip_outcomes``.
+2. ``/users/{uid}/teamcenter?dayNumber=N`` → ``matchday_lineup_results``
+   (with ``total_points`` summed from each player's ``p`` field).
+3. ``/leagues/{lid}/ranking?dayNumber=N`` → ``league_rank_history``
+   (one row per manager per matchday).
+
+``team_value_history`` is intentionally NOT backfilled — its schema requires
+``budget`` and ``squad_size`` which the ranking endpoint doesn't expose for
+historical matchdays. The longitudinal team-value series is preserved via
+``league_rank_history.team_value`` instead.
+
+Idempotent: every writer call uses ``INSERT OR IGNORE`` against a meaningful
+unique constraint (``flip_outcomes`` gets ``idx_flip_unique`` added in the
+same PR; the other tables already had it).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from .bid_learner import BidLearner, FlipOutcome
+from .kickbase_client import KickbaseV4Client, League
+
+logger = logging.getLogger(__name__)
+
+TRANSFER_PAGE_SIZE = 25
+TRANSFER_BUY = 1
+TRANSFER_SELL = 2
+
+
+@dataclass
+class BackfillStats:
+    transfers_paginated: int = 0
+    flip_outcomes_inserted: int = 0
+    flip_outcomes_skipped_duplicate: int = 0
+    flip_outcomes_unpaired_buys: int = 0
+    flip_outcomes_orphaned_sells: int = 0
+    matchdays_processed: int = 0
+    matchdays_skipped_no_lineup: int = 0
+    league_rank_history_inserted: int = 0
+    matchday_lineup_results_inserted: int = 0
+
+
+@dataclass
+class FlipPair:
+    player_id: str
+    player_name: str
+    buy: dict[str, Any]
+    sell: dict[str, Any]
+
+
+def _to_epoch(iso_str: str) -> float:
+    """Convert ISO-8601 with optional 'Z' suffix to a unix epoch float."""
+    if iso_str.endswith("Z"):
+        iso_str = iso_str[:-1] + "+00:00"
+    return datetime.fromisoformat(iso_str).timestamp()
+
+
+def _paginate_transfers(
+    client: KickbaseV4Client, league_id: str, manager_id: str
+) -> tuple[list[dict[str, Any]], int]:
+    """Walk ``/managers/{mid}/transfer?start=N`` until the API stops returning
+    a full page. Returns ``(all_items, page_count)``.
+    """
+    items: list[dict[str, Any]] = []
+    pages = 0
+    start = 0
+    while True:
+        page = client.get_manager_transfer_history(league_id, manager_id, start=start)
+        pages += 1
+        page_items = page.get("it") or []
+        if not page_items:
+            break
+        items.extend(page_items)
+        if len(page_items) < TRANSFER_PAGE_SIZE:
+            break
+        start += TRANSFER_PAGE_SIZE
+    return items, pages
+
+
+def _pair_flips(transfers: list[dict[str, Any]]) -> tuple[list[FlipPair], int, int]:
+    """FIFO buy→sell pairing per player_id.
+
+    For each player_id, sort transfers ascending by ``dt`` and pair successive
+    buys (``tty=1``) with the next sell (``tty=2``). Re-buys after a wash-trade
+    window produce a second flip. Buys with no matching sell (still in squad)
+    and sells with no preceding buy (data gap) are counted but not written.
+
+    Returns ``(flips, unpaired_buy_count, orphaned_sell_count)``.
+    """
+    by_player: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for t in transfers:
+        by_player[t["pi"]].append(t)
+
+    flips: list[FlipPair] = []
+    unpaired = 0
+    orphaned = 0
+
+    for pi, items in by_player.items():
+        items.sort(key=lambda x: x["dt"])
+        buy_queue: list[dict[str, Any]] = []
+        for t in items:
+            tty = t.get("tty")
+            if tty == TRANSFER_BUY:
+                buy_queue.append(t)
+            elif tty == TRANSFER_SELL:
+                if buy_queue:
+                    buy = buy_queue.pop(0)
+                    flips.append(
+                        FlipPair(
+                            player_id=pi,
+                            player_name=t.get("pn") or buy.get("pn") or "",
+                            buy=buy,
+                            sell=t,
+                        )
+                    )
+                else:
+                    orphaned += 1
+                    logger.warning(
+                        "Orphaned sell for player %s (%s) at %s — no preceding buy",
+                        pi,
+                        t.get("pn"),
+                        t.get("dt"),
+                    )
+        unpaired += len(buy_queue)
+
+    return flips, unpaired, orphaned
+
+
+def _flip_to_outcome(pair: FlipPair) -> FlipOutcome:
+    buy_epoch = _to_epoch(pair.buy["dt"])
+    sell_epoch = _to_epoch(pair.sell["dt"])
+    buy_price = int(pair.buy.get("trp", 0))
+    sell_price = int(pair.sell.get("trp", 0))
+    profit = sell_price - buy_price
+    profit_pct = (profit / buy_price * 100.0) if buy_price else 0.0
+    hold_days = max(0, int((sell_epoch - buy_epoch) // 86400))
+    return FlipOutcome(
+        player_id=pair.player_id,
+        player_name=pair.player_name,
+        buy_price=buy_price,
+        sell_price=sell_price,
+        profit=profit,
+        profit_pct=profit_pct,
+        hold_days=hold_days,
+        buy_date=buy_epoch,
+        sell_date=sell_epoch,
+        trend_at_buy=None,
+        average_points=None,
+        position=None,
+        was_injured=False,
+    )
+
+
+def _backfill_flip_outcomes(
+    client: KickbaseV4Client,
+    league_id: str,
+    manager_id: str,
+    learner: BidLearner,
+    *,
+    dry_run: bool,
+    stats: BackfillStats,
+) -> None:
+    transfers, pages = _paginate_transfers(client, league_id, manager_id)
+    stats.transfers_paginated = pages
+    flips, unpaired, orphaned = _pair_flips(transfers)
+    stats.flip_outcomes_unpaired_buys = unpaired
+    stats.flip_outcomes_orphaned_sells = orphaned
+
+    if dry_run:
+        # Upper-bound estimate; we can't tell duplicates without writing.
+        stats.flip_outcomes_inserted = len(flips)
+        return
+
+    for f in flips:
+        if learner.record_flip(_flip_to_outcome(f)):
+            stats.flip_outcomes_inserted += 1
+        else:
+            stats.flip_outcomes_skipped_duplicate += 1
+
+
+def _ranking_row(
+    user: dict[str, Any], league_id: str, day: int, snapshot_at: float, our_user_id: str
+) -> dict[str, Any]:
+    tv_raw = user.get("tv")
+    return {
+        "snapshot_at": snapshot_at,
+        "league_id": league_id,
+        "manager_id": str(user.get("i", "")),
+        "day_number": day,
+        "rank_overall": user.get("spl"),
+        "rank_matchday": user.get("mdpl"),
+        "total_points": user.get("sp"),
+        "matchday_points": user.get("mdp"),
+        "team_value": int(tv_raw) if tv_raw is not None else None,
+        "is_self": 1 if str(user.get("i")) == our_user_id else 0,
+    }
+
+
+def _backfill_matchday_phase(
+    client: KickbaseV4Client,
+    league: League,
+    user_id: str,
+    learner: BidLearner,
+    last_finished_matchday: int,
+    *,
+    dry_run: bool,
+    stats: BackfillStats,
+) -> None:
+    """For each matchday in [1..lfmd]: fetch teamcenter + ranking, write rows."""
+    for day in range(1, last_finished_matchday + 1):
+        tc = client.get_user_teamcenter(league.id, user_id, day_number=day)
+        lp = tc.get("lp") or []
+        if not lp:
+            stats.matchdays_skipped_no_lineup += 1
+            logger.info("Skipping matchday %d — no lineup recorded", day)
+            continue
+
+        matchday_date = lp[0].get("md", "")
+        snapshot_at = _to_epoch(matchday_date) if matchday_date else 0.0
+        total_points = sum(int(p.get("p", 0)) for p in lp)
+        lineup_player_ids = [str(p.get("i", "")) for p in lp]
+
+        if dry_run:
+            stats.matchday_lineup_results_inserted += 1
+        else:
+            inserted = learner.record_matchday_lineup_result(
+                league_id=league.id,
+                day_number=day,
+                matchday_date=matchday_date,
+                total_points=total_points,
+                lineup_player_ids=lineup_player_ids,
+                lineup_count=len(lp),
+                snapshot_at=snapshot_at,
+            )
+            if inserted:
+                stats.matchday_lineup_results_inserted += 1
+
+        ranking = client.get_league_ranking(league.id, day_number=day)
+        users = ranking.get("us") or []
+        rank_rows = [_ranking_row(u, league.id, day, snapshot_at, user_id) for u in users]
+
+        if rank_rows:
+            if dry_run:
+                stats.league_rank_history_inserted += len(rank_rows)
+            else:
+                stats.league_rank_history_inserted += learner.record_league_rank_snapshot(rank_rows)
+
+        stats.matchdays_processed += 1
+
+
+def run_backfill(
+    client: KickbaseV4Client,
+    league: League,
+    user_id: str,
+    manager_id: str,
+    learner: BidLearner,
+    *,
+    dry_run: bool = False,
+) -> BackfillStats:
+    """Backfill all three foundation phases. Idempotent.
+
+    ``user_id`` and ``manager_id`` are the same KICKBASE id today (the
+    ``/teamcenter`` endpoint addresses by user, ``/transfer`` by manager,
+    but both resolve to ``client.user.id``). Kept as separate params so a
+    future API split doesn't need a signature change.
+    """
+    stats = BackfillStats()
+
+    current_ranking = client.get_league_ranking(league.id)
+    last_finished = int(current_ranking.get("lfmd") or 0)
+    logger.info("Backfilling matchdays 1..%d (dry_run=%s)", last_finished, dry_run)
+
+    _backfill_flip_outcomes(client, league.id, manager_id, learner, dry_run=dry_run, stats=stats)
+    logger.info(
+        "Phase 1: %d flips, %d duplicates, %d unpaired buys, %d orphaned sells, %d transfer pages",
+        stats.flip_outcomes_inserted,
+        stats.flip_outcomes_skipped_duplicate,
+        stats.flip_outcomes_unpaired_buys,
+        stats.flip_outcomes_orphaned_sells,
+        stats.transfers_paginated,
+    )
+
+    if last_finished > 0:
+        _backfill_matchday_phase(
+            client, league, user_id, learner, last_finished, dry_run=dry_run, stats=stats
+        )
+    logger.info(
+        "Phase 2/3: %d matchdays processed (%d skipped), %d lineup rows, %d rank rows",
+        stats.matchdays_processed,
+        stats.matchdays_skipped_no_lineup,
+        stats.matchday_lineup_results_inserted,
+        stats.league_rank_history_inserted,
+    )
+
+    return stats

--- a/rehoboam/bid_learner.py
+++ b/rehoboam/bid_learner.py
@@ -137,6 +137,16 @@ class BidLearner:
             """
             )
 
+            # REH-39: idempotency for the backfill-history CLI. Each real-world
+            # flip is uniquely identified by (player_id, buy_date), so this
+            # also catches accidental duplicate live writes as a side benefit.
+            conn.execute(
+                """
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_flip_unique
+                ON flip_outcomes(player_id, buy_date)
+            """
+            )
+
             # Matchday outcomes table for tracking EP accuracy
             conn.execute(
                 """
@@ -484,12 +494,17 @@ class BidLearner:
             )
             conn.commit()
 
-    def record_flip(self, outcome: FlipOutcome):
-        """Record a completed flip for learning"""
+    def record_flip(self, outcome: FlipOutcome) -> bool:
+        """Record a completed flip for learning.
+
+        Uses INSERT OR IGNORE so backfill reruns and accidental double-writes
+        from the live trader collapse deterministically (idx_flip_unique on
+        (player_id, buy_date)). Returns True if a row was actually inserted.
+        """
         with sqlite3.connect(self.db_path) as conn:
-            conn.execute(
+            cur = conn.execute(
                 """
-                INSERT INTO flip_outcomes (
+                INSERT OR IGNORE INTO flip_outcomes (
                     player_id, player_name, buy_price, sell_price, profit, profit_pct,
                     hold_days, buy_date, sell_date, trend_at_buy, average_points, position,
                     was_injured
@@ -513,6 +528,7 @@ class BidLearner:
                 ),
             )
             conn.commit()
+            return cur.rowcount > 0
 
     # ------------------------------------------------------------------
     # Operational state: pending bids + tracked purchases

--- a/rehoboam/cli.py
+++ b/rehoboam/cli.py
@@ -277,11 +277,19 @@ def push_azure_state(
         help="Required to actually upload — without it the command refuses.",
     ),
     dry_run: bool = typer.Option(False, "--dry-run", help="List local files without uploading"),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Bypass the freshness check and clobber even if blob has been "
+        "modified since fetch (DANGEROUS — likely overwrites the bot's writes).",
+    ),
 ):
     """Push local ./logs/ SQLite state to Azure Blob Storage (DANGEROUS).
 
     Overwrites the live bot's persistent state. Refuses to run without
-    --i-know-what-im-doing. Use --dry-run to preview.
+    --i-know-what-im-doing. By default, also refuses if the blob has been
+    modified since the last fetch (Function ran in the meantime); re-fetch
+    or pass --force to override. Use --dry-run to preview.
     """
     if not confirm:
         console.print(
@@ -300,15 +308,119 @@ def push_azure_state(
             container_name=blob_settings.blob_container,
             source_dir=Path("logs"),
             dry_run=dry_run,
+            force=force,
         )
     except azure_blob.MissingAzureCredentials as e:
         console.print(f"[red]✗ {e}[/red]")
+        raise typer.Exit(code=1) from e
+    except azure_blob.BlobChangedSinceFetch as e:
+        console.print("[red]⛔ Refusing to push — blob has been modified since fetch.[/red]")
+        for s in e.stale:
+            console.print(
+                f"  • {s.db_file}: fetched at "
+                f"[cyan]{s.fetched_last_modified.isoformat()}[/cyan]"
+                f", current blob at [yellow]{s.current_last_modified.isoformat()}[/yellow]"
+            )
+        console.print(
+            "\nThe Azure Function probably ran since you fetched. Either:\n"
+            "  1. Re-run [bold]rehoboam fetch-azure-state[/bold] (preserves your local "
+            "work as .local-bak), redo your local mutations, then push again, OR\n"
+            "  2. Pass [bold]--force[/bold] to clobber the bot's writes (NOT recommended)."
+        )
         raise typer.Exit(code=1) from e
 
     console.print(_render_push_table(results, dry_run=dry_run))
 
     if not dry_run and any(r.status == "error" for r in results):
         raise typer.Exit(code=1)
+
+
+@app.command("backfill-history")
+def backfill_history(
+    league_index: int = typer.Option(0, "--league", "-l", help="League index (0 for first league)"),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Run all HTTP calls but skip DB writes; reports row-count estimates.",
+    ),
+):
+    """Backfill foundation tables from KICKBASE history (REH-39).
+
+    One-shot command that derives historical rows from the KICKBASE API:
+      • flip_outcomes           ← per-manager transfer history (FIFO pairing)
+      • matchday_lineup_results ← per-matchday teamcenter (lineup + actual points)
+      • league_rank_history     ← per-matchday ranking (one row per manager)
+
+    Idempotent: rerunning silently skips duplicates.
+
+    Workflow when targeting prod state:
+      1. rehoboam fetch-azure-state
+      2. rehoboam backfill-history
+      3. rehoboam push-azure-state --i-know-what-im-doing
+    """
+    from .backfill import run_backfill
+    from .bid_learner import BidLearner
+
+    api, _settings, league = _login_and_get_league(league_index)
+    user_id = api.user.id
+    learner = BidLearner()
+
+    console.print("\n[bold cyan]🔁 Backfilling foundation tables…[/bold cyan]")
+    if dry_run:
+        console.print("[yellow]DRY RUN — no DB writes; counts are upper-bound estimates[/yellow]")
+
+    stats = run_backfill(
+        client=api.client,
+        league=league,
+        user_id=user_id,
+        manager_id=user_id,
+        learner=learner,
+        dry_run=dry_run,
+    )
+
+    table = Table(title="Backfill summary")
+    table.add_column("Metric", style="bold")
+    table.add_column("Value", justify="right")
+    table.add_row("Transfer pages walked", f"{stats.transfers_paginated}")
+    table.add_row(
+        "flip_outcomes inserted",
+        f"[green]{stats.flip_outcomes_inserted}[/green]",
+    )
+    table.add_row(
+        "flip_outcomes skipped (duplicate)",
+        f"[cyan]{stats.flip_outcomes_skipped_duplicate}[/cyan]",
+    )
+    table.add_row(
+        "Unpaired buys (still in squad)",
+        f"{stats.flip_outcomes_unpaired_buys}",
+    )
+    table.add_row(
+        "Orphaned sells (data gap)",
+        (
+            f"[yellow]{stats.flip_outcomes_orphaned_sells}[/yellow]"
+            if stats.flip_outcomes_orphaned_sells
+            else "0"
+        ),
+    )
+    table.add_row(
+        "Matchdays processed",
+        f"{stats.matchdays_processed} (skipped {stats.matchdays_skipped_no_lineup})",
+    )
+    table.add_row(
+        "matchday_lineup_results inserted",
+        f"[green]{stats.matchday_lineup_results_inserted}[/green]",
+    )
+    table.add_row(
+        "league_rank_history inserted",
+        f"[green]{stats.league_rank_history_inserted}[/green]",
+    )
+    console.print(table)
+
+    if not dry_run:
+        console.print(
+            "\n[dim]Next step: rehoboam push-azure-state --i-know-what-im-doing  "
+            "(during a quiet window — between 08:02 and 19:58 UTC, or after 20:02)[/dim]"
+        )
 
 
 @app.callback()

--- a/tests/test_azure_blob.py
+++ b/tests/test_azure_blob.py
@@ -5,7 +5,8 @@ chain. ``MissingAzureCredentials`` is exercised separately by leaving
 ``connection_string`` empty.
 """
 
-from datetime import datetime, timezone
+import json
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock
 
 import pytest
@@ -13,7 +14,10 @@ import pytest
 from rehoboam import azure_blob
 from rehoboam.azure_blob import (
     DB_FILES,
+    FETCH_SIDECAR,
+    BlobChangedSinceFetch,
     MissingAzureCredentials,
+    check_freshness,
     fetch_state,
     list_blobs,
     push_state,
@@ -270,3 +274,118 @@ def test_push_state_isolates_upload_failures(monkeypatch, tmp_path):
 
     assert statuses[failing] == "error"
     assert all(s == "uploaded" for n, s in statuses.items() if n != failing)
+
+
+# --- sidecar + freshness check (REH-39) -----------------------------------
+
+
+def test_fetch_state_writes_sidecar(monkeypatch, tmp_path):
+    ts = datetime(2026, 5, 9, 8, 0, 8, tzinfo=timezone.utc)
+    container = _make_container({n: {"props": _props(ts, 1024), "data": b"x"} for n in DB_FILES})
+    _patch_container(monkeypatch, container)
+
+    fetch_state("conn", "rehoboam-data", tmp_path)
+
+    sidecar = tmp_path / FETCH_SIDECAR
+    assert sidecar.exists(), "fetch_state should write the .fetch_state.json sidecar"
+    recorded = json.loads(sidecar.read_text())
+    assert set(recorded) == set(DB_FILES)
+    for v in recorded.values():
+        assert v.startswith("2026-05-09T08:00:08")
+
+
+def test_fetch_state_dry_run_does_not_write_sidecar(monkeypatch, tmp_path):
+    ts = datetime(2026, 5, 9, tzinfo=timezone.utc)
+    container = _make_container({n: {"props": _props(ts, 100), "data": b"x"} for n in DB_FILES})
+    _patch_container(monkeypatch, container)
+
+    fetch_state("conn", "rehoboam-data", tmp_path, dry_run=True)
+    assert not (tmp_path / FETCH_SIDECAR).exists()
+
+
+def test_check_freshness_empty_when_no_sidecar(monkeypatch, tmp_path):
+    container = _make_container(
+        {n: {"props": _props(datetime.now(timezone.utc), 100)} for n in DB_FILES}
+    )
+    _patch_container(monkeypatch, container)
+
+    stale = check_freshness("conn", "rehoboam-data", tmp_path)
+    assert stale == []
+
+
+def test_check_freshness_passes_when_blob_unchanged(monkeypatch, tmp_path):
+    ts = datetime(2026, 5, 9, 8, 0, 8, tzinfo=timezone.utc)
+    container = _make_container({n: {"props": _props(ts, 100)} for n in DB_FILES})
+    _patch_container(monkeypatch, container)
+
+    sidecar = {n: ts.isoformat() for n in DB_FILES}
+    (tmp_path / FETCH_SIDECAR).write_text(json.dumps(sidecar))
+
+    assert check_freshness("conn", "rehoboam-data", tmp_path) == []
+
+
+def test_check_freshness_detects_drift(monkeypatch, tmp_path):
+    fetched_at = datetime(2026, 5, 9, 8, 0, 8, tzinfo=timezone.utc)
+    later = fetched_at + timedelta(hours=12)
+    drifting = DB_FILES[0]
+    spec = {n: {"props": _props(fetched_at, 100)} for n in DB_FILES}
+    spec[drifting] = {"props": _props(later, 100)}
+    container = _make_container(spec)
+    _patch_container(monkeypatch, container)
+
+    sidecar = {n: fetched_at.isoformat() for n in DB_FILES}
+    (tmp_path / FETCH_SIDECAR).write_text(json.dumps(sidecar))
+
+    stale = check_freshness("conn", "rehoboam-data", tmp_path)
+    assert len(stale) == 1
+    assert stale[0].db_file == drifting
+    assert stale[0].fetched_last_modified == fetched_at
+    assert stale[0].current_last_modified == later
+
+
+def test_push_state_refuses_on_drift(monkeypatch, tmp_path):
+    for n in DB_FILES:
+        (tmp_path / n).write_bytes(b"x")
+    fetched_at = datetime(2026, 5, 9, 8, 0, 8, tzinfo=timezone.utc)
+    later = fetched_at + timedelta(hours=12)
+    spec = {n: {"props": _props(later, 100)} for n in DB_FILES}
+    container = _make_container(spec)
+    _patch_container(monkeypatch, container)
+
+    sidecar = {n: fetched_at.isoformat() for n in DB_FILES}
+    (tmp_path / FETCH_SIDECAR).write_text(json.dumps(sidecar))
+
+    with pytest.raises(BlobChangedSinceFetch) as exc_info:
+        push_state("conn", "rehoboam-data", tmp_path)
+    assert len(exc_info.value.stale) == len(DB_FILES)
+
+
+def test_push_state_force_bypasses_freshness(monkeypatch, tmp_path):
+    for n in DB_FILES:
+        (tmp_path / n).write_bytes(b"x")
+    fetched_at = datetime(2026, 5, 9, 8, 0, 8, tzinfo=timezone.utc)
+    later = fetched_at + timedelta(hours=12)
+    container = _make_container({n: {"props": _props(later, 100)} for n in DB_FILES})
+    _patch_container(monkeypatch, container)
+
+    sidecar = {n: fetched_at.isoformat() for n in DB_FILES}
+    (tmp_path / FETCH_SIDECAR).write_text(json.dumps(sidecar))
+
+    # force=True: no exception, regular upload path runs
+    results = push_state("conn", "rehoboam-data", tmp_path, force=True)
+    assert all(r.status == "uploaded" for r in results)
+
+
+def test_push_state_dry_run_still_checks_freshness(monkeypatch, tmp_path):
+    """Dry-run should surface drift the same way a real push would so the
+    user can preview the failure mode without committing."""
+    for n in DB_FILES:
+        (tmp_path / n).write_bytes(b"x")
+    fetched_at = datetime(2026, 5, 9, tzinfo=timezone.utc)
+    later = fetched_at + timedelta(hours=12)
+    container = _make_container({n: {"props": _props(later, 100)} for n in DB_FILES})
+    _patch_container(monkeypatch, container)
+    (tmp_path / FETCH_SIDECAR).write_text(json.dumps({n: fetched_at.isoformat() for n in DB_FILES}))
+
+    with pytest.raises(BlobChangedSinceFetch):
+        push_state("conn", "rehoboam-data", tmp_path, dry_run=True)

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -1,0 +1,271 @@
+"""Tests for rehoboam.backfill — REH-39 historical foundation-table backfill.
+
+The KICKBASE client is mocked end-to-end so tests don't hit the network. The
+``BidLearner`` is exercised against a fresh sqlite db in tmp_path, which
+gives us real INSERT OR IGNORE semantics for the idempotency tests.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from rehoboam.backfill import (
+    TRANSFER_BUY,
+    TRANSFER_PAGE_SIZE,
+    TRANSFER_SELL,
+    _paginate_transfers,
+    _pair_flips,
+    run_backfill,
+)
+from rehoboam.bid_learner import BidLearner
+from rehoboam.kickbase_client import League
+
+
+def _t(pi: str, tty: int, dt: str, trp: int = 1_000_000, pn: str = "Player") -> dict[str, Any]:
+    return {"pi": pi, "tty": tty, "dt": dt, "trp": trp, "pn": pn}
+
+
+def _league(lid: str = "lid-1") -> League:
+    return League(id=lid, name="Test League", creator_id="creator")
+
+
+def _learner(tmp_path) -> BidLearner:
+    return BidLearner(db_path=tmp_path / "bid_learning.db")
+
+
+# --- _pair_flips ----------------------------------------------------------
+
+
+def test_pair_flips_simple_one_to_one():
+    transfers = [
+        _t("p1", TRANSFER_BUY, "2026-04-01T10:00:00Z", trp=1_000_000),
+        _t("p1", TRANSFER_SELL, "2026-04-05T10:00:00Z", trp=1_200_000),
+    ]
+    flips, unpaired, orphaned = _pair_flips(transfers)
+    assert len(flips) == 1
+    assert flips[0].player_id == "p1"
+    assert flips[0].buy["trp"] == 1_000_000
+    assert flips[0].sell["trp"] == 1_200_000
+    assert (unpaired, orphaned) == (0, 0)
+
+
+def test_pair_flips_unpaired_buy_still_in_squad():
+    transfers = [_t("p1", TRANSFER_BUY, "2026-04-01T10:00:00Z")]
+    flips, unpaired, orphaned = _pair_flips(transfers)
+    assert flips == []
+    assert unpaired == 1
+    assert orphaned == 0
+
+
+def test_pair_flips_orphaned_sell_logged_but_skipped():
+    transfers = [_t("p1", TRANSFER_SELL, "2026-04-01T10:00:00Z")]
+    flips, unpaired, orphaned = _pair_flips(transfers)
+    assert flips == []
+    assert unpaired == 0
+    assert orphaned == 1
+
+
+def test_pair_flips_rebuy_after_sell_creates_two_flips():
+    transfers = [
+        _t("p1", TRANSFER_BUY, "2026-01-01T10:00:00Z"),
+        _t("p1", TRANSFER_SELL, "2026-01-15T10:00:00Z"),
+        _t("p1", TRANSFER_BUY, "2026-03-01T10:00:00Z"),
+        _t("p1", TRANSFER_SELL, "2026-03-15T10:00:00Z"),
+    ]
+    flips, unpaired, orphaned = _pair_flips(transfers)
+    assert len(flips) == 2
+    assert flips[0].buy["dt"] < flips[1].buy["dt"]
+    assert (unpaired, orphaned) == (0, 0)
+
+
+def test_pair_flips_handles_multiple_players_independently():
+    transfers = [
+        _t("p1", TRANSFER_BUY, "2026-04-01T10:00:00Z"),
+        _t("p2", TRANSFER_BUY, "2026-04-02T10:00:00Z"),
+        _t("p1", TRANSFER_SELL, "2026-04-05T10:00:00Z"),
+        _t("p2", TRANSFER_SELL, "2026-04-06T10:00:00Z"),
+    ]
+    flips, _, _ = _pair_flips(transfers)
+    assert len(flips) == 2
+    assert {f.player_id for f in flips} == {"p1", "p2"}
+
+
+def test_pair_flips_sorts_within_player_even_if_input_unsorted():
+    """Input-order shouldn't matter — only per-player chronological order."""
+    transfers = [
+        _t("p1", TRANSFER_SELL, "2026-04-05T10:00:00Z", trp=1_200_000),
+        _t("p1", TRANSFER_BUY, "2026-04-01T10:00:00Z", trp=1_000_000),
+    ]
+    flips, _, _ = _pair_flips(transfers)
+    assert len(flips) == 1
+    assert flips[0].buy["dt"] < flips[0].sell["dt"]
+
+
+# --- _paginate_transfers --------------------------------------------------
+
+
+def _client_with_pages(pages: list[list[dict[str, Any]]]) -> MagicMock:
+    """Return a fake KickbaseV4Client whose paginated calls walk ``pages``."""
+    c = MagicMock()
+    c.get_manager_transfer_history.side_effect = [{"it": p} for p in pages]
+    return c
+
+
+def test_paginate_transfers_walks_full_pages_until_short():
+    full = [_t(f"p{i}", TRANSFER_BUY, "2026-04-01T10:00:00Z") for i in range(TRANSFER_PAGE_SIZE)]
+    short = [_t("plast", TRANSFER_BUY, "2026-04-01T10:00:00Z")]
+    client = _client_with_pages([full, short])
+
+    items, pages = _paginate_transfers(client, "lid", "mid")
+
+    assert pages == 2
+    assert len(items) == TRANSFER_PAGE_SIZE + 1
+
+
+def test_paginate_transfers_stops_on_empty_page():
+    full = [_t(f"p{i}", TRANSFER_BUY, "2026-04-01T10:00:00Z") for i in range(TRANSFER_PAGE_SIZE)]
+    client = _client_with_pages([full, []])
+
+    items, pages = _paginate_transfers(client, "lid", "mid")
+
+    assert pages == 2
+    assert len(items) == TRANSFER_PAGE_SIZE
+
+
+def test_paginate_transfers_passes_cursor_via_start_param():
+    client = _client_with_pages([[]])
+    _paginate_transfers(client, "lid", "mid")
+    client.get_manager_transfer_history.assert_called_with("lid", "mid", start=0)
+
+
+# --- run_backfill (integration with real BidLearner) ----------------------
+
+
+def _baseline_client(transfers: list[dict[str, Any]], lfmd: int = 0) -> MagicMock:
+    c = MagicMock()
+    # First call: current ranking (provides lfmd). Subsequent calls: per-day rankings.
+    c.get_league_ranking.return_value = {"lfmd": lfmd, "us": []}
+    c.get_manager_transfer_history.side_effect = [{"it": transfers}, {"it": []}]
+    c.get_user_teamcenter.return_value = {"lp": []}
+    return c
+
+
+def test_run_backfill_writes_flip_outcomes(tmp_path):
+    transfers = [
+        _t("p1", TRANSFER_BUY, "2026-04-01T10:00:00Z", trp=1_000_000, pn="P1"),
+        _t("p1", TRANSFER_SELL, "2026-04-05T10:00:00Z", trp=1_200_000, pn="P1"),
+        _t("p2", TRANSFER_BUY, "2026-04-02T10:00:00Z", trp=2_000_000, pn="P2"),
+        _t("p2", TRANSFER_SELL, "2026-04-08T10:00:00Z", trp=1_800_000, pn="P2"),
+    ]
+    learner = _learner(tmp_path)
+    client = _baseline_client(transfers, lfmd=0)
+
+    stats = run_backfill(client, _league(), "uid", "mid", learner, dry_run=False)
+
+    assert stats.flip_outcomes_inserted == 2
+    assert stats.flip_outcomes_skipped_duplicate == 0
+
+
+def test_run_backfill_is_idempotent_on_rerun(tmp_path):
+    transfers = [
+        _t("p1", TRANSFER_BUY, "2026-04-01T10:00:00Z", trp=1_000_000),
+        _t("p1", TRANSFER_SELL, "2026-04-05T10:00:00Z", trp=1_200_000),
+    ]
+    learner = _learner(tmp_path)
+
+    client1 = _baseline_client(transfers, lfmd=0)
+    s1 = run_backfill(client1, _league(), "uid", "mid", learner, dry_run=False)
+    assert s1.flip_outcomes_inserted == 1
+
+    client2 = _baseline_client(transfers, lfmd=0)
+    s2 = run_backfill(client2, _league(), "uid", "mid", learner, dry_run=False)
+    assert s2.flip_outcomes_inserted == 0
+    assert s2.flip_outcomes_skipped_duplicate == 1
+
+
+def test_run_backfill_dry_run_writes_nothing(tmp_path):
+    transfers = [
+        _t("p1", TRANSFER_BUY, "2026-04-01T10:00:00Z", trp=1_000_000),
+        _t("p1", TRANSFER_SELL, "2026-04-05T10:00:00Z", trp=1_200_000),
+    ]
+    learner = _learner(tmp_path)
+    client = _baseline_client(transfers, lfmd=0)
+
+    stats = run_backfill(client, _league(), "uid", "mid", learner, dry_run=True)
+
+    # Stats reflect what WOULD have been written
+    assert stats.flip_outcomes_inserted == 1
+    # But the DB is empty
+    import sqlite3
+
+    with sqlite3.connect(learner.db_path) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM flip_outcomes").fetchone()[0]
+    assert count == 0
+
+
+def test_run_backfill_writes_lineup_and_rank_per_matchday(tmp_path):
+    """Phase 2/3: when lfmd>0 and teamcenter returns a real lineup, we get
+    one matchday_lineup_results row and N league_rank_history rows."""
+    learner = _learner(tmp_path)
+
+    teamcenter_for_md1 = {
+        "lp": [
+            {"i": "10", "p": 80, "md": "2025-08-23T13:30:00Z"},
+            {"i": "20", "p": 65, "md": "2025-08-23T13:30:00Z"},
+            {"i": "30", "p": 90, "md": "2025-08-23T13:30:00Z"},
+        ]
+    }
+    ranking_for_md1 = {
+        "us": [
+            {"i": "uid", "spl": 1, "mdpl": 1, "sp": 235, "mdp": 235, "tv": 100_000_000},
+            {"i": "other", "spl": 2, "mdpl": 2, "sp": 200, "mdp": 200, "tv": 95_000_000},
+        ]
+    }
+
+    c = MagicMock()
+    c.get_league_ranking.side_effect = [
+        {"lfmd": 1, "us": []},  # initial probe
+        ranking_for_md1,  # per-matchday call
+    ]
+    c.get_manager_transfer_history.side_effect = [{"it": []}]
+    c.get_user_teamcenter.return_value = teamcenter_for_md1
+
+    stats = run_backfill(c, _league(), "uid", "mid", learner, dry_run=False)
+
+    assert stats.matchdays_processed == 1
+    assert stats.matchday_lineup_results_inserted == 1
+    assert stats.league_rank_history_inserted == 2
+
+    import sqlite3
+
+    with sqlite3.connect(learner.db_path) as conn:
+        lineup_row = conn.execute(
+            "SELECT total_points, lineup_count, matchday_date FROM matchday_lineup_results"
+        ).fetchone()
+        assert lineup_row[0] == 80 + 65 + 90
+        assert lineup_row[1] == 3
+        assert lineup_row[2] == "2025-08-23T13:30:00Z"
+
+        self_rank = conn.execute(
+            "SELECT rank_overall, total_points, is_self FROM league_rank_history "
+            "WHERE manager_id = 'uid'"
+        ).fetchone()
+        assert self_rank == (1, 235, 1)
+
+
+def test_run_backfill_skips_matchday_with_no_lineup(tmp_path):
+    """Pre-league-join matchdays return empty lp; should be counted but not
+    written, and the ranking call for that matchday should NOT fire."""
+    learner = _learner(tmp_path)
+    c = MagicMock()
+    c.get_league_ranking.side_effect = [{"lfmd": 1, "us": []}]
+    c.get_manager_transfer_history.side_effect = [{"it": []}]
+    c.get_user_teamcenter.return_value = {"lp": []}
+
+    stats = run_backfill(c, _league(), "uid", "mid", learner, dry_run=False)
+
+    assert stats.matchdays_skipped_no_lineup == 1
+    assert stats.matchday_lineup_results_inserted == 0
+    # Only the initial /ranking probe call, no per-day call
+    assert c.get_league_ranking.call_count == 1

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -142,10 +142,10 @@ def test_paginate_transfers_passes_cursor_via_start_param():
 # --- run_backfill (integration with real BidLearner) ----------------------
 
 
-def _baseline_client(transfers: list[dict[str, Any]], lfmd: int = 0) -> MagicMock:
+def _baseline_client(transfers: list[dict[str, Any]], current_day: int = 0) -> MagicMock:
     c = MagicMock()
-    # First call: current ranking (provides lfmd). Subsequent calls: per-day rankings.
-    c.get_league_ranking.return_value = {"lfmd": lfmd, "us": []}
+    # First call: current ranking (provides `day`). Subsequent: per-day rankings.
+    c.get_league_ranking.return_value = {"day": current_day, "us": []}
     c.get_manager_transfer_history.side_effect = [{"it": transfers}, {"it": []}]
     c.get_user_teamcenter.return_value = {"lp": []}
     return c
@@ -159,7 +159,7 @@ def test_run_backfill_writes_flip_outcomes(tmp_path):
         _t("p2", TRANSFER_SELL, "2026-04-08T10:00:00Z", trp=1_800_000, pn="P2"),
     ]
     learner = _learner(tmp_path)
-    client = _baseline_client(transfers, lfmd=0)
+    client = _baseline_client(transfers, current_day=0)
 
     stats = run_backfill(client, _league(), "uid", "mid", learner, dry_run=False)
 
@@ -174,11 +174,11 @@ def test_run_backfill_is_idempotent_on_rerun(tmp_path):
     ]
     learner = _learner(tmp_path)
 
-    client1 = _baseline_client(transfers, lfmd=0)
+    client1 = _baseline_client(transfers, current_day=0)
     s1 = run_backfill(client1, _league(), "uid", "mid", learner, dry_run=False)
     assert s1.flip_outcomes_inserted == 1
 
-    client2 = _baseline_client(transfers, lfmd=0)
+    client2 = _baseline_client(transfers, current_day=0)
     s2 = run_backfill(client2, _league(), "uid", "mid", learner, dry_run=False)
     assert s2.flip_outcomes_inserted == 0
     assert s2.flip_outcomes_skipped_duplicate == 1
@@ -190,7 +190,7 @@ def test_run_backfill_dry_run_writes_nothing(tmp_path):
         _t("p1", TRANSFER_SELL, "2026-04-05T10:00:00Z", trp=1_200_000),
     ]
     learner = _learner(tmp_path)
-    client = _baseline_client(transfers, lfmd=0)
+    client = _baseline_client(transfers, current_day=0)
 
     stats = run_backfill(client, _league(), "uid", "mid", learner, dry_run=True)
 
@@ -205,8 +205,8 @@ def test_run_backfill_dry_run_writes_nothing(tmp_path):
 
 
 def test_run_backfill_writes_lineup_and_rank_per_matchday(tmp_path):
-    """Phase 2/3: when lfmd>0 and teamcenter returns a real lineup, we get
-    one matchday_lineup_results row and N league_rank_history rows."""
+    """Phase 2/3: when current_day>0 and teamcenter returns a real lineup,
+    we get one matchday_lineup_results row and N league_rank_history rows."""
     learner = _learner(tmp_path)
 
     teamcenter_for_md1 = {
@@ -225,7 +225,7 @@ def test_run_backfill_writes_lineup_and_rank_per_matchday(tmp_path):
 
     c = MagicMock()
     c.get_league_ranking.side_effect = [
-        {"lfmd": 1, "us": []},  # initial probe
+        {"day": 1, "us": []},  # initial probe
         ranking_for_md1,  # per-matchday call
     ]
     c.get_manager_transfer_history.side_effect = [{"it": []}]
@@ -259,7 +259,7 @@ def test_run_backfill_skips_matchday_with_no_lineup(tmp_path):
     written, and the ranking call for that matchday should NOT fire."""
     learner = _learner(tmp_path)
     c = MagicMock()
-    c.get_league_ranking.side_effect = [{"lfmd": 1, "us": []}]
+    c.get_league_ranking.side_effect = [{"day": 1, "us": []}]
     c.get_manager_transfer_history.side_effect = [{"it": []}]
     c.get_user_teamcenter.return_value = {"lp": []}
 


### PR DESCRIPTION
## Summary
- New `rehoboam backfill-history` derives historical foundation-table rows from the live KICKBASE API. Three phases: transfer history → `flip_outcomes` (FIFO buy/sell pairing per `player_id`); `/teamcenter?dayNumber` → `matchday_lineup_results`; `/ranking?dayNumber` → `league_rank_history` (one row per manager per matchday).
- Bundles a small REH-15 follow-up: `push-azure-state` now writes a `.fetch_state.json` sidecar at fetch time and refuses to push if the blob has moved since (Function ran in between). New `--force` flag for the rare case where you really do mean to clobber.
- New `UNIQUE INDEX idx_flip_unique ON flip_outcomes(player_id, buy_date)` keeps backfill reruns idempotent; `record_flip` now uses `INSERT OR IGNORE` and returns bool.
- `team_value_history` is intentionally NOT backfilled — its schema requires `budget` and `squad_size` which historical `/ranking` doesn't expose. The `tv` series is preserved via `league_rank_history.team_value`.

Resolves REH-39. Unblocks REH-32, REH-33, REH-35, REH-37.

## Test plan
- [x] `uv run pytest` — 352 passed, 1 skipped (22 new tests in tests/test_backfill.py + tests/test_azure_blob.py covering FIFO pairing, pagination loop, idempotency, dry-run no-op, sidecar write, freshness drift detection, --force bypass)
- [x] `uv run ruff check` clean across modified files
- [x] `uv run black` clean on new files
- [x] `uv run rehoboam --help` lists the new backfill-history command and the new --force flag on push-azure-state
- [ ] Manual smoke against live league: `uv run rehoboam backfill-history --dry-run` should report ~100-150 flips, ~32 lineup rows, ~450 rank rows
- [ ] Manual end-to-end: fetch-azure-state → backfill-history → push-azure-state --i-know-what-im-doing during a quiet window
- [ ] After merge: confirm next 08:00 UTC scheduled Function run still runs cleanly against the enriched blob

🤖 Generated with [Claude Code](https://claude.com/claude-code)