### PR TITLE
feat: expand player_mv_history coverage (REH-40)

### DIFF
--- a/rehoboam/cli.py
+++ b/rehoboam/cli.py
@@ -335,6 +335,67 @@ def push_azure_state(
         raise typer.Exit(code=1)
 
 
+@app.command("backfill-mv-history")
+def backfill_mv_history(
+    league_index: int = typer.Option(0, "--league", "-l", help="League index (0 for first league)"),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Run all HTTP calls but skip DB writes; reports row-count estimates.",
+    ),
+    timeframe_days: int = typer.Option(
+        365,
+        "--timeframe",
+        help="Days of MV history to fetch per player (default: 365 = full season).",
+    ),
+):
+    """One-shot backfill of player_mv_history for all flipped players (REH-40).
+
+    Walks every distinct player_id in flip_outcomes and fetches the v2 MV
+    history endpoint, writing daily snapshots into player_mv_history. This
+    populates the trajectory data REH-32 / REH-33 calibrations need.
+
+    Idempotent: rerunning silently skips duplicates via the existing
+    UNIQUE(player_id, snapshot_at) constraint.
+
+    Workflow when targeting prod state:
+      1. rehoboam fetch-azure-state
+      2. rehoboam backfill-mv-history
+      3. rehoboam push-azure-state --i-know-what-im-doing
+    """
+    from .bid_learner import BidLearner
+    from .mv_backfill import run_mv_backfill
+
+    api, _settings, _league = _login_and_get_league(league_index)
+    learner = BidLearner()
+
+    console.print("\n[bold cyan]🔁 Backfilling player_mv_history…[/bold cyan]")
+    if dry_run:
+        console.print("[yellow]DRY RUN — no DB writes; counts are upper-bound estimates[/yellow]")
+
+    stats = run_mv_backfill(
+        client=api.client, learner=learner, dry_run=dry_run, timeframe_days=timeframe_days
+    )
+
+    table = Table(title="MV backfill summary")
+    table.add_column("Metric", style="bold")
+    table.add_column("Value", justify="right")
+    table.add_row("Players processed", f"[green]{stats.players_processed}[/green]")
+    table.add_row("Players with no MV data", f"{stats.players_skipped_no_data}")
+    table.add_row(
+        "Players failed (HTTP errors)",
+        f"[red]{stats.players_failed}[/red]" if stats.players_failed else "0",
+    )
+    table.add_row("Rows attempted", f"{stats.rows_attempted}")
+    console.print(table)
+
+    if not dry_run:
+        console.print(
+            "\n[dim]Next step: rehoboam push-azure-state --i-know-what-im-doing  "
+            "(during a quiet window — between 08:02 and 19:58 UTC, or after 20:02)[/dim]"
+        )
+
+
 @app.command("backfill-history")
 def backfill_history(
     league_index: int = typer.Option(0, "--league", "-l", help="League index (0 for first league)"),

--- a/rehoboam/mv_backfill.py
+++ b/rehoboam/mv_backfill.py
@@ -1,0 +1,132 @@
+"""REH-40: One-shot backfill of player_mv_history from KICKBASE history.
+
+Why this exists: ``player_mv_history`` (REH-26) only captures snapshots for
+players currently in the squad. Anything we already flipped left the squad
+before the snapshot was taken, so the table has zero coverage for the 143
+historical flips backfilled by REH-39. This blocks REH-32 / REH-33 which
+need worst-dip / peak-MV computations across each flip's hold period.
+
+This module fixes that by walking every distinct ``player_id`` in
+``flip_outcomes`` and fetching the full season's MV history via the v2
+endpoint (``/v4/competitions/1/players/{pid}/marketValue/{timeframe}``).
+Each daily point becomes a row in ``player_mv_history``; the existing
+``INSERT OR IGNORE`` PK keeps reruns idempotent.
+
+Forward-looking coverage of market players is handled inline in
+``trader.py`` (it's free — the market data is already in memory each
+session). This module is one-shot.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from .bid_learner import BidLearner
+from .kickbase_client import KickbaseV4Client
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEFRAME_DAYS = 365  # full season
+
+
+@dataclass
+class MvBackfillStats:
+    players_processed: int = 0
+    players_skipped_no_data: int = 0
+    players_failed: int = 0
+    rows_attempted: int = 0  # upper bound — actual inserts dedupe via INSERT OR IGNORE
+
+
+def _distinct_flip_player_ids(learner: BidLearner) -> list[str]:
+    import sqlite3
+
+    with sqlite3.connect(learner.db_path) as conn:
+        rows = conn.execute("SELECT DISTINCT player_id FROM flip_outcomes").fetchall()
+    return [r[0] for r in rows]
+
+
+def _history_to_rows(player_id: str, history: dict[str, Any]) -> list[dict[str, Any]]:
+    """Transform v2 history response into ``record_player_mv_snapshot`` rows.
+
+    The v2 response shape is ``{"it": [{"dt": <days_since_epoch>, "mv": <value>}, ...]}``.
+    ``dt * 86400`` gives a unix epoch in seconds. Empty / non-positive ``mv``
+    is dropped (newly-listed players get sentinel rows).
+
+    ``peak_mv_30d`` / ``trough_mv_30d`` are intentionally NULL on backfilled
+    rows — the live writer's 30-day window only makes sense at write time;
+    backfilled trajectories are point-in-time snapshots, not derived metrics.
+    """
+    items = history.get("it") or []
+    rows: list[dict[str, Any]] = []
+    for item in items:
+        dt = item.get("dt")
+        mv = item.get("mv")
+        if dt is None or not mv or mv <= 0:
+            continue
+        rows.append(
+            {
+                "player_id": player_id,
+                "snapshot_at": float(dt) * 86400.0,
+                "market_value": int(mv),
+                "peak_mv_30d": None,
+                "trough_mv_30d": None,
+            }
+        )
+    return rows
+
+
+def run_mv_backfill(
+    client: KickbaseV4Client,
+    learner: BidLearner,
+    *,
+    dry_run: bool = False,
+    timeframe_days: int = DEFAULT_TIMEFRAME_DAYS,
+) -> MvBackfillStats:
+    """Fetch + persist MV trajectories for every player in flip_outcomes.
+
+    Idempotent: ``record_player_mv_snapshot`` is INSERT OR IGNORE on
+    ``(player_id, snapshot_at)``, so reruns silently dedupe.
+
+    ``dry_run`` performs all HTTP calls so the count estimate reflects
+    real coverage, but skips DB writes.
+    """
+    stats = MvBackfillStats()
+    player_ids = _distinct_flip_player_ids(learner)
+    logger.info(
+        "Backfilling MV history for %d distinct players (dry_run=%s, timeframe=%dd)",
+        len(player_ids),
+        dry_run,
+        timeframe_days,
+    )
+
+    for pid in player_ids:
+        try:
+            history = client.get_player_market_value_history_v2(
+                player_id=pid, timeframe=timeframe_days
+            )
+        except Exception as e:
+            stats.players_failed += 1
+            logger.warning("Failed to fetch MV history for player %s: %s", pid, e)
+            continue
+
+        rows = _history_to_rows(pid, history)
+        if not rows:
+            stats.players_skipped_no_data += 1
+            continue
+
+        stats.rows_attempted += len(rows)
+        stats.players_processed += 1
+
+        if not dry_run:
+            learner.record_player_mv_snapshot(rows)
+
+    logger.info(
+        "MV backfill done: %d players, %d rows attempted, %d failed, %d empty",
+        stats.players_processed,
+        stats.rows_attempted,
+        stats.players_failed,
+        stats.players_skipped_no_data,
+    )
+    return stats

--- a/rehoboam/trader.py
+++ b/rehoboam/trader.py
@@ -347,6 +347,15 @@ class Trader:
         def _calibration_for(player) -> float:
             return position_calibrations.get(player.position, 1.0)
 
+        # REH-26 + REH-40: collect daily MV rows for both squad AND market
+        # players in a single mv_rows list, persisted after both loops via
+        # one bulk INSERT. trend_service.get_history uses the 24h-cached
+        # data already fetched for trend analysis — no extra HTTP traffic.
+        # Market coverage (REH-40) gives REH-32 / REH-33 calibrations a
+        # populated trajectory for any future flip without further backfill.
+        mv_rows: list[dict] = []
+        snapshot_at = datetime.now(tz=timezone.utc).timestamp()
+
         market_scores: list = []
         market_player_map: dict = {}
         for player in kickbase_market:
@@ -362,6 +371,23 @@ class Trader:
                     score_player(data, calibration_multiplier=_calibration_for(player))
                 )
                 market_player_map[player.id] = player
+
+                try:
+                    mvh = self.trend_service.get_history(player.id, league.id)
+                    recent = mvh.points[-30:] if mvh.points else []
+                    peak_30d = max((p.value for p in recent), default=None)
+                    trough_30d = min((p.value for p in recent), default=None)
+                    mv_rows.append(
+                        {
+                            "player_id": player.id,
+                            "snapshot_at": snapshot_at,
+                            "market_value": player.market_value,
+                            "peak_mv_30d": peak_30d,
+                            "trough_mv_30d": trough_30d,
+                        }
+                    )
+                except Exception:
+                    pass
             except Exception as e:
                 if self.verbose:
                     console.print(f"[dim]EP: scoring failed for {player.last_name}: {e}[/dim]")
@@ -369,12 +395,6 @@ class Trader:
         squad_scores: list = []
         squad_player_map: dict = {}
         squad_performance: dict[str, dict] = {}
-        # REH-26: collect daily MV rows for each held player. Persist after
-        # the squad loop (single bulk INSERT). The trend_service.get_history
-        # call uses the same 24h-cached data already fetched for trend
-        # analysis — no extra HTTP traffic.
-        mv_rows: list[dict] = []
-        snapshot_at = datetime.now(tz=timezone.utc).timestamp()
         for player in squad:
             try:
                 perf, details = _fetch_player_data(player)

--- a/tests/test_mv_backfill.py
+++ b/tests/test_mv_backfill.py
@@ -1,0 +1,184 @@
+"""Tests for rehoboam.mv_backfill — REH-40 player_mv_history backfill."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+from unittest.mock import MagicMock
+
+from rehoboam.bid_learner import BidLearner, FlipOutcome
+from rehoboam.mv_backfill import (
+    MvBackfillStats,
+    _history_to_rows,
+    run_mv_backfill,
+)
+
+
+def _learner_with_flips(tmp_path, player_ids: list[str]) -> BidLearner:
+    """BidLearner pre-seeded with one minimal flip per player_id so the
+    backfill has a non-empty distinct-id list to walk."""
+    learner = BidLearner(db_path=tmp_path / "bid_learning.db")
+    for i, pid in enumerate(player_ids):
+        # buy_date varies so the UNIQUE(player_id, buy_date) constraint
+        # never collides on rerun.
+        learner.record_flip(
+            FlipOutcome(
+                player_id=pid,
+                player_name=f"Player{pid}",
+                buy_price=1_000_000,
+                sell_price=1_100_000,
+                profit=100_000,
+                profit_pct=10.0,
+                hold_days=5,
+                buy_date=1_700_000_000.0 + i,
+                sell_date=1_700_500_000.0 + i,
+            )
+        )
+    return learner
+
+
+def _mv_history(points: list[tuple[int, int]]) -> dict[str, Any]:
+    """Build a fake v2 MV history response. Each tuple is (days_since_epoch, mv)."""
+    return {"it": [{"dt": dt, "mv": mv} for dt, mv in points]}
+
+
+def _client_with_history(per_player: dict[str, dict[str, Any]]) -> MagicMock:
+    c = MagicMock()
+
+    def get_history(player_id: str, timeframe: int = 365):
+        if isinstance(per_player.get(player_id), Exception):
+            raise per_player[player_id]
+        return per_player.get(player_id, {"it": []})
+
+    c.get_player_market_value_history_v2.side_effect = get_history
+    return c
+
+
+# --- _history_to_rows -----------------------------------------------------
+
+
+def test_history_to_rows_converts_dt_to_unix_epoch():
+    rows = _history_to_rows("p1", _mv_history([(20000, 5_000_000)]))
+    assert len(rows) == 1
+    assert rows[0]["snapshot_at"] == 20000 * 86400.0
+    assert rows[0]["market_value"] == 5_000_000
+    assert rows[0]["player_id"] == "p1"
+    assert rows[0]["peak_mv_30d"] is None
+    assert rows[0]["trough_mv_30d"] is None
+
+
+def test_history_to_rows_filters_zero_and_missing_mv():
+    rows = _history_to_rows(
+        "p1",
+        {
+            "it": [
+                {"dt": 20000, "mv": 5_000_000},
+                {"dt": 20001, "mv": 0},
+                {"dt": 20002, "mv": None},
+                {"dt": 20003, "mv": 4_900_000},
+            ]
+        },
+    )
+    assert len(rows) == 2
+    assert {r["snapshot_at"] for r in rows} == {20000 * 86400.0, 20003 * 86400.0}
+
+
+def test_history_to_rows_handles_empty_response():
+    assert _history_to_rows("p1", {}) == []
+    assert _history_to_rows("p1", {"it": []}) == []
+
+
+# --- run_mv_backfill ------------------------------------------------------
+
+
+def test_backfill_writes_one_row_per_dt(tmp_path):
+    learner = _learner_with_flips(tmp_path, ["p1", "p2", "p3"])
+    client = _client_with_history(
+        {
+            "p1": _mv_history([(20000, 1_000_000), (20001, 1_100_000)]),
+            "p2": _mv_history([(20000, 2_000_000)]),
+            "p3": _mv_history([(20000, 3_000_000), (20001, 3_100_000), (20002, 3_200_000)]),
+        }
+    )
+
+    stats = run_mv_backfill(client, learner, dry_run=False)
+
+    assert stats.players_processed == 3
+    assert stats.rows_attempted == 6  # 2 + 1 + 3
+    assert stats.players_failed == 0
+
+    with sqlite3.connect(learner.db_path) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM player_mv_history").fetchone()[0]
+    assert count == 6
+
+
+def test_backfill_is_idempotent(tmp_path):
+    learner = _learner_with_flips(tmp_path, ["p1"])
+    client = _client_with_history({"p1": _mv_history([(20000, 1_000_000), (20001, 1_100_000)])})
+
+    run_mv_backfill(client, learner, dry_run=False)
+    run_mv_backfill(client, learner, dry_run=False)
+
+    with sqlite3.connect(learner.db_path) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM player_mv_history").fetchone()[0]
+    # Two runs against the same data still yield 2 rows (UNIQUE on (pid, snapshot_at))
+    assert count == 2
+
+
+def test_backfill_dry_run_writes_no_rows(tmp_path):
+    learner = _learner_with_flips(tmp_path, ["p1"])
+    client = _client_with_history({"p1": _mv_history([(20000, 1_000_000), (20001, 1_100_000)])})
+
+    stats = run_mv_backfill(client, learner, dry_run=True)
+
+    assert stats.rows_attempted == 2
+    with sqlite3.connect(learner.db_path) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM player_mv_history").fetchone()[0]
+    assert count == 0
+
+
+def test_backfill_isolates_per_player_failures(tmp_path):
+    learner = _learner_with_flips(tmp_path, ["p1", "pfail", "p3"])
+    client = _client_with_history(
+        {
+            "p1": _mv_history([(20000, 1_000_000)]),
+            "pfail": RuntimeError("API timeout"),
+            "p3": _mv_history([(20000, 3_000_000)]),
+        }
+    )
+
+    stats = run_mv_backfill(client, learner, dry_run=False)
+
+    assert stats.players_failed == 1
+    assert stats.players_processed == 2
+    with sqlite3.connect(learner.db_path) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM player_mv_history").fetchone()[0]
+    assert count == 2
+
+
+def test_backfill_counts_empty_mv_data_separately(tmp_path):
+    """Newly-listed players may legitimately return no history. Don't
+    confuse them with HTTP failures."""
+    learner = _learner_with_flips(tmp_path, ["p1", "pempty"])
+    client = _client_with_history(
+        {
+            "p1": _mv_history([(20000, 1_000_000)]),
+            "pempty": {"it": []},
+        }
+    )
+
+    stats = run_mv_backfill(client, learner, dry_run=False)
+
+    assert stats.players_processed == 1
+    assert stats.players_skipped_no_data == 1
+    assert stats.players_failed == 0
+
+
+def test_backfill_no_flips_is_noop(tmp_path):
+    learner = BidLearner(db_path=tmp_path / "bid_learning.db")
+    client = MagicMock()
+
+    stats = run_mv_backfill(client, learner)
+
+    assert stats == MvBackfillStats()
+    client.get_player_market_value_history_v2.assert_not_called()


### PR DESCRIPTION
## Summary
- **One-shot backfill CLI**: `rehoboam backfill-mv-history` walks every distinct `player_id` in `flip_outcomes` (~150 today), fetches the v2 MV history endpoint, converts each daily point into a `player_mv_history` row. Idempotent via existing UNIQUE PK + INSERT OR IGNORE. ~30s wall clock.
- **Forward-looking writer expansion**: the MV-snapshot block in `trader.py` was previously squad-only. It now runs in both squad AND market loops, sharing a single `mv_rows` list bulk-inserted post-loop. Adds no HTTP traffic — `trend_service.get_history` is already 24h-cached for trend analysis on market players.
- Together these unblock REH-32 (loss-cut threshold calibration needs worst-dip during hold) and REH-33 (sell-timing peak-MV regret).

Resolves REH-40. Unblocks REH-32, REH-33.

## Test plan
- [x] uv run pytest — 361 passed, 1 skipped (9 new tests in tests/test_mv_backfill.py)
- [x] uv run ruff check clean
- [x] uv run rehoboam --help lists the new backfill-mv-history command
- [ ] Manual smoke: uv run rehoboam backfill-mv-history --dry-run should report ~150 players processed, ~40k rows attempted (148 unique flipped players × ~270 daily snapshots)
- [ ] Manual end-to-end: fetch-azure-state → backfill-mv-history → push-azure-state during a quiet window
- [ ] After merge: confirm next 20:00 UTC scheduled run also writes market-player MVs (covers mv_rows list growing post-deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)