### PR TITLE
Run the season replay against the shipped gain floor (REH-66)

### DIFF
--- a/rehoboam/cli.py
+++ b/rehoboam/cli.py
@@ -680,6 +680,13 @@ def replay_season(
     learning_db: Path = typer.Option(  # noqa: B008
         Path("logs/bid_learning.db"), help="Path to the learning DB with real standings"
     ),
+    min_ep_gain: float | None = typer.Option(
+        None,
+        help=(
+            "Marginal EP gain floor in real points. Defaults to the value the live "
+            "bot ships with; override only for a labelled sensitivity check."
+        ),
+    ),
 ) -> None:
     """Replay the full bot across 2025/26 and report the counterfactual finish."""
     from rehoboam.replay.driver import run_replay
@@ -691,7 +698,9 @@ def replay_season(
         console.print(f"[red]Learning DB not found: {learning_db}[/red]")
         raise typer.Exit(1)
 
-    _result, report = run_replay(corpus_path=corpus, learning_db_path=learning_db)
+    _result, report = run_replay(
+        corpus_path=corpus, learning_db_path=learning_db, min_ep_gain=min_ep_gain
+    )
     console.print(report)
 
 

--- a/rehoboam/replay/attribution.py
+++ b/rehoboam/replay/attribution.py
@@ -64,8 +64,14 @@ def format_report(
     actual_total: int,
     actual_per_matchday: dict[int, int],
     standings: list[LeagueStanding],
+    min_ep_gain: float,
 ) -> str:
-    """Human-readable replay report with fidelity caveats attached."""
+    """Human-readable replay report with fidelity caveats attached.
+
+    ``min_ep_gain`` is required rather than defaulted: the headline number is a
+    function of it, and REH-51 published a result without recording which floor
+    produced it. A report that cannot be interpreted later is not a report.
+    """
     place = place_in_league(result.total_points, standings)
     total_managers = len(standings) + 1
     lines = [
@@ -86,6 +92,12 @@ def format_report(
         result, actual_total=actual_total, actual_per_matchday=actual_per_matchday
     ):
         lines.append(f"  {label:<34}{points:>+9,}   {fidelity}")
+
+    lines += ["", "Configuration", "-" * 68]
+    lines.append(
+        f"  {'Marginal EP gain floor':<34}{min_ep_gain:>9,.1f}   real points, "
+        "buys below this are skipped"
+    )
 
     lines += ["", "Fidelity", "-" * 68]
     for component, level, basis in FIDELITY_NOTES:

--- a/rehoboam/replay/driver.py
+++ b/rehoboam/replay/driver.py
@@ -15,7 +15,12 @@ from pathlib import Path
 from rehoboam.backtest.snapshot import matches_before
 from rehoboam.enrichment.corpus import TrainingCorpus
 from rehoboam.replay.attribution import LeagueStanding, format_report
-from rehoboam.replay.engine import Matchday, SeasonResult, run_season
+from rehoboam.replay.engine import (
+    Matchday,
+    SeasonResult,
+    run_season,
+    shipped_min_ep_gain,
+)
 from rehoboam.replay.market import ReplayMarket
 from rehoboam.replay.state import initial_state
 from rehoboam.scoring.v2.coefficients import load_coefficients
@@ -151,8 +156,19 @@ def _make_score_fn(
     return score
 
 
-def run_replay(*, corpus_path: Path, learning_db_path: Path) -> tuple[SeasonResult, str]:
-    """Replay the whole season and return the result plus a formatted report."""
+def run_replay(
+    *,
+    corpus_path: Path,
+    learning_db_path: Path,
+    min_ep_gain: float | None = None,
+) -> tuple[SeasonResult, str]:
+    """Replay the whole season and return the result plus a formatted report.
+
+    ``min_ep_gain`` defaults to whatever the live bot ships with, so the replay
+    describes the bot on main rather than an agent nobody deployed. Pass it
+    explicitly only to answer a "what if the floor were X" question — and label
+    any such run as a sensitivity check, not a counterfactual result.
+    """
     corpus = TrainingCorpus(corpus_path)
     kickoffs = load_calendar(learning_db_path, league_id=LEAGUE_ID)
     matchdays = build_matchdays(corpus, season=SEASON, kickoffs=kickoffs)
@@ -177,6 +193,8 @@ def run_replay(*, corpus_path: Path, learning_db_path: Path) -> tuple[SeasonResu
             teams_cache.update(corpus.team_ids_for([pid]))
         return teams_cache.get(pid)
 
+    gain_floor = shipped_min_ep_gain() if min_ep_gain is None else min_ep_gain
+
     result = run_season(
         state=state,
         market=market,
@@ -185,6 +203,7 @@ def run_replay(*, corpus_path: Path, learning_db_path: Path) -> tuple[SeasonResu
         mv_fn=corpus.market_value_at,
         position_fn=position_fn,
         team_fn=team_fn,
+        min_ep_gain=gain_floor,
     )
 
     with sqlite3.connect(learning_db_path) as conn:
@@ -202,5 +221,6 @@ def run_replay(*, corpus_path: Path, learning_db_path: Path) -> tuple[SeasonResu
         actual_total=actual_total,
         actual_per_matchday=actual_per_matchday,
         standings=standings,
+        min_ep_gain=gain_floor,
     )
     return result, report

--- a/rehoboam/replay/engine.py
+++ b/rehoboam/replay/engine.py
@@ -139,6 +139,19 @@ def _restore_budget(
     return sells
 
 
+def shipped_min_ep_gain() -> float:
+    """The marginal-gain floor the live bot actually ships with (REH-66).
+
+    Read from the field default rather than by instantiating ``Settings``,
+    which requires KICKBASE credentials — the replay has to stay runnable
+    offline and deterministic against the DBs alone. Reading it dynamically
+    means a re-tune in production cannot silently leave the harness behind.
+    """
+    from rehoboam.config import Settings
+
+    return float(Settings.model_fields["min_ep_upgrade_threshold"].default)
+
+
 def run_season(
     *,
     state: ReplayState,
@@ -148,6 +161,10 @@ def run_season(
     mv_fn: Callable[[str, float], int | None],
     position_fn: Callable[[str], str | None],
     team_fn: Callable[[str], str | None],
+    # NOTE: this default is the *engine's* neutral value, not the bot's. Any
+    # caller reporting a headline number must pass shipped_min_ep_gain() —
+    # REH-51's result was produced by silently accepting 5.0 while production
+    # gated at 40.0. `driver.run_replay` does this; see REH-66.
     min_ep_gain: float = 5.0,
 ) -> SeasonResult:
     """Replay every matchday in order, mutating ``state`` as the bot would."""

--- a/tests/test_replay/test_attribution.py
+++ b/tests/test_replay/test_attribution.py
@@ -63,7 +63,11 @@ def test_attribution_total_matches_simulated_minus_actual():
 def test_format_report_states_finishing_position_and_fidelity():
     result = SeasonResult(outcomes=[_outcome(1, 800)], total_points=800)
     text = format_report(
-        result, actual_total=700, actual_per_matchday={1: 700}, standings=STANDINGS
+        result,
+        actual_total=700,
+        actual_per_matchday={1: 700},
+        standings=STANDINGS,
+        min_ep_gain=40.0,
     )
     assert "FINISHING POSITION" in text
     assert "Bid competition" in text  # fidelity caveat must be printed

--- a/tests/test_replay/test_shipped_config.py
+++ b/tests/test_replay/test_shipped_config.py
@@ -1,0 +1,60 @@
+"""REH-66: the replay must run the bot that was actually shipped.
+
+REH-51's result was produced with the engine's own ``min_ep_gain=5.0`` default
+because ``run_replay`` never passed the argument. REH-55 shipped a marginal-gain
+floor of 40.0. A replay gated at 5.0 describes a strictly more trigger-happy
+agent than the one on main, so its headline number answers a question nobody
+asked.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from rehoboam.config import Settings
+from rehoboam.replay import driver
+from rehoboam.replay.attribution import format_report
+from rehoboam.replay.engine import SeasonResult
+
+
+def test_replay_gain_floor_is_read_from_the_shipped_settings():
+    """Not hard-coded. If production re-tunes the threshold and the replay does
+    not follow, the harness silently drifts back out of sync — which is the
+    exact defect REH-66 exists to close.
+    """
+    shipped = Settings.model_fields["min_ep_upgrade_threshold"].default
+
+    assert driver.shipped_min_ep_gain() == shipped
+
+
+def test_replay_gain_floor_is_not_the_engine_default():
+    """The regression guard proper: 5.0 is the engine's own parameter default,
+    and it is what REH-51 unknowingly ran with."""
+    assert driver.shipped_min_ep_gain() != 5.0
+
+
+def test_run_replay_passes_the_gain_floor_to_the_engine():
+    """A resolved floor that never reaches run_season changes nothing."""
+    source = inspect.getsource(driver.run_replay)
+
+    assert "min_ep_gain=" in source
+
+
+def test_run_replay_accepts_an_explicit_gain_floor():
+    """So a run is reproducible and can be pinned from the CLI."""
+    assert "min_ep_gain" in inspect.signature(driver.run_replay).parameters
+
+
+def test_report_states_the_gain_floor_it_used():
+    """A headline that depends on a threshold has to print that threshold,
+    or the number cannot be interpreted six months from now."""
+    report = format_report(
+        SeasonResult(),
+        actual_total=0,
+        actual_per_matchday={},
+        standings=[],
+        min_ep_gain=40.0,
+    )
+
+    assert "40" in report
+    assert "gain" in report.lower()


### PR DESCRIPTION
REH-51's headline number described a bot nobody deployed. `driver.run_replay` never passed `min_ep_gain`, so the engine's own neutral default of `5.0` applied — while REH-55 ships a marginal-gain floor of **40.0**. On the real-points scale 5.0 sits far below the median gain (p50 = 43.1), so the replayed agent bought on improvements the shipped bot rejects outright.

## The fix

`shipped_min_ep_gain()` reads `Settings.model_fields["min_ep_upgrade_threshold"].default` rather than instantiating `Settings` — instantiation requires `KICKBASE_EMAIL` / `KICKBASE_PASSWORD`, and the replay must stay runnable offline and deterministic against the DBs alone. Reading it dynamically means a production re-tune cannot silently leave the harness behind again.

The report now prints the floor it used, and `format_report` takes it as a **required** keyword rather than a defaulted one: the headline is a function of that number, and REH-51 published a result without recording which floor produced it.

`rehoboam replay-season --min-ep-gain` allows an explicit override, documented as "for a labelled sensitivity check" only.

The engine's `min_ep_gain=5.0` default is left in place as the harness's neutral value, with a comment naming REH-66 so the next caller doesn't repeat the mistake.

## The re-run — reported as-is, single run

```
Simulated total:    27,099 points
Actual total:       26,172 points
Difference:           +927 points

FINISHING POSITION: 9 of 14

  Zero-point matchdays avoided           +688   exact
  Empty-slot penalties incurred            +0   exact
  Better squad and lineup                +239   medium - buy side is optimistic

  Marginal EP gain floor                 40.0   real points

Total buys: 24   Total sells: 21   Final budget: EUR 110,421
```

## Do not read this as "the rebuild is worth ~900 points"

The ticket pre-registered the expected direction: a stricter filter should have moved the result *closer* to the human's season, and a sharp move up was flagged in advance as a red flag to investigate rather than celebrate. It moved up.

Against REH-51's already-published run at floor 5.0:

| | floor 5.0 | floor 40.0 |
| --- | --- | --- |
| Difference vs human | +239 | **+927** |
| Better squad and lineup | −666 | **+239** |
| Zero-point matchdays avoided *(exact)* | +905 | **+688** |
| Buys / sells | 36 / 33 | 24 / 21 |

**The two exact terms move in opposite directions.** "Zero-point matchdays avoided" is deterministic, and it *dropped* by 217 — the matchday-14 squad got **worse** under the stricter floor. If the filter genuinely selected better players, that term should not have degraded. "The bot picks better now" does not survive contact with its own attribution table.

The likelier mechanism is **transaction cost**: twelve fewer round trips, at the measured 1.117× buy / 0.95× sell spread, preserves roughly 15% of the value involved in each avoided churn — squad equity retained regardless of whether the ranking improved at all.

That hypothesis is deliberately **not** tested here. The v2 spec's rule is that credibility decays with every tuning iteration; this ticket runs once at the shipped value and reports what comes out. Confirming the mechanism needs a labelled sensitivity study, which belongs in its own ticket and must not be folded into a published counterfactual.

Bid competition remains absent, so the buy-side term is still an upper bound — and it is now positive, which makes +239 an optimistic estimate of a number whose sign is not established.

## Verification

- Two consecutive runs **byte-identical**.
- `logs/training_corpus.db` and `logs/bid_learning.db` SHA-256 **unchanged** before and after — the replay is read-only in practice.
- `git diff --quiet -- rehoboam/scoring/v2/coefficients.json` → clean.
- **619 passed, 1 skipped** (614 + 5 new).
- `ruff` clean.

The five new tests pin the wiring: that the floor is read from `Settings` rather than hard-coded, that it is not the engine's 5.0, that `run_replay` actually forwards it to `run_season`, that it is overridable, and that the report states it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
