### PR TITLE
Buy-side controls, and instant sell is full market value not 95% (REH-67)

### DIFF
--- a/rehoboam/cli.py
+++ b/rehoboam/cli.py
@@ -704,6 +704,28 @@ def replay_season(
     console.print(report)
 
 
+@app.command("replay-buy-control")
+def replay_buy_control(
+    corpus: Path = typer.Option(  # noqa: B008
+        Path("logs/training_corpus.db"), help="Path to the training corpus DB"
+    ),
+    learning_db: Path = typer.Option(  # noqa: B008
+        Path("logs/bid_learning.db"), help="Path to the learning DB with real standings"
+    ),
+) -> None:
+    """Control run (REH-67): does EP ranking beat ranking by market value?"""
+    from rehoboam.replay.driver import run_buy_control
+
+    if not corpus.exists():
+        console.print(f"[red]Corpus not found: {corpus}[/red]")
+        raise typer.Exit(1)
+    if not learning_db.exists():
+        console.print(f"[red]Learning DB not found: {learning_db}[/red]")
+        raise typer.Exit(1)
+
+    console.print(run_buy_control(corpus_path=corpus, learning_db_path=learning_db))
+
+
 @app.command("fit-scorer")
 def fit_scorer(
     availability_k: float = typer.Option(

--- a/rehoboam/replay/attribution.py
+++ b/rehoboam/replay/attribution.py
@@ -14,7 +14,7 @@ FIDELITY_NOTES = [
     ("Points scoring", "exact", "real per-match points from the corpus"),
     ("Penalty avoidance", "exact", "deterministic"),
     ("Lineup selection", "high", "real squad, real formation rules"),
-    ("Sell decisions", "high", "instant sell = 95% of market value"),
+    ("Sell decisions", "medium", "instant sell at MV; profit flips NOT modelled"),
     ("Buy prices", "high", "real transaction prices"),
     ("Buy availability", "medium", "only players who actually traded are visible"),
     ("Bid competition", "ABSENT - optimistic", "wanted players are always won"),

--- a/rehoboam/replay/driver.py
+++ b/rehoboam/replay/driver.py
@@ -156,11 +156,23 @@ def _make_score_fn(
     return score
 
 
+def buy_quota_from(result: SeasonResult) -> dict[int, int]:
+    """Per-matchday buy counts, for holding a control's trading tempo fixed.
+
+    Matched matchday by matchday rather than season-wide: a season-wide budget
+    would let the control front-load its buys into whichever weeks happened to
+    be cheap, which is a different policy, not a different chooser.
+    """
+    return {o.day_number: o.buys for o in result.outcomes}
+
+
 def run_replay(
     *,
     corpus_path: Path,
     learning_db_path: Path,
     min_ep_gain: float | None = None,
+    buy_rank_fn: Callable[[str, float], float] | None = None,
+    buy_quota: dict[int, int] | None = None,
 ) -> tuple[SeasonResult, str]:
     """Replay the whole season and return the result plus a formatted report.
 
@@ -204,6 +216,8 @@ def run_replay(
         position_fn=position_fn,
         team_fn=team_fn,
         min_ep_gain=gain_floor,
+        buy_rank_fn=buy_rank_fn,
+        buy_quota=buy_quota,
     )
 
     with sqlite3.connect(learning_db_path) as conn:
@@ -224,3 +238,63 @@ def run_replay(
         min_ep_gain=gain_floor,
     )
     return result, report
+
+
+def run_buy_control(*, corpus_path: Path, learning_db_path: Path) -> str:
+    """REH-67: does the v2 scorer pick better than the market prices?
+
+    Runs the shipped bot, then re-runs it with one thing changed — candidates
+    ranked by market value instead of expected points, at the same per-matchday
+    trading tempo. Lineup and sell decisions keep using EP in both, so the
+    difference isolates the buy side.
+
+    Market value is the sharpest available control because it already embeds
+    every manager's opinion of a player. Beating chance is necessary; beating
+    the crowd's own pricing is what would justify the scorer.
+
+    Returns a comparison, not a verdict. This is a labelled control run and must
+    never be reported as the counterfactual season result.
+    """
+    reference, _ = run_replay(corpus_path=corpus_path, learning_db_path=learning_db_path)
+    quota = buy_quota_from(reference)
+
+    corpus = TrainingCorpus(corpus_path)
+
+    def mv_rank(player_id: str, at: float) -> float:
+        return float(corpus.market_value_at(player_id, at) or 0)
+
+    control, _ = run_replay(
+        corpus_path=corpus_path,
+        learning_db_path=learning_db_path,
+        buy_rank_fn=mv_rank,
+        buy_quota=quota,
+    )
+
+    delta = reference.total_points - control.total_points
+    ref_buys = sum(o.buys for o in reference.outcomes)
+    ctl_buys = sum(o.buys for o in control.outcomes)
+    lines = [
+        "=" * 68,
+        "BUY-SIDE CONTROL - EP ranking vs market-value ranking",
+        "=" * 68,
+        "",
+        f"EP-ranked (shipped):      {reference.total_points:>8,} points   " f"{ref_buys} buys",
+        f"Market-value-ranked:      {control.total_points:>8,} points   {ctl_buys} buys",
+        f"EP advantage:             {delta:>+8,} points",
+        "",
+        "Only the buy chooser differs. Trading tempo is matched per matchday;",
+        "lineup and sell decisions use EP in both runs.",
+        "",
+    ]
+    if ctl_buys != ref_buys:
+        lines.append(
+            f"NOTE: tempo not fully matched ({ref_buys} vs {ctl_buys} buys) - the "
+            "control could not always afford its preferred candidate."
+        )
+        lines.append("")
+    lines += [
+        "A labelled control, not a season result. Bid competition is still",
+        "absent from both runs, so both buy sides remain upper bounds.",
+        "=" * 68,
+    ]
+    return "\n".join(lines)

--- a/rehoboam/replay/engine.py
+++ b/rehoboam/replay/engine.py
@@ -166,6 +166,14 @@ def run_season(
     # REH-51's result was produced by silently accepting 5.0 while production
     # gated at 40.0. `driver.run_replay` does this; see REH-66.
     min_ep_gain: float = 5.0,
+    # REH-67 buy-side control. When buy_rank_fn is given, candidates are ranked
+    # by it instead of by EP and the marginal-gain gate is bypassed, with
+    # buy_quota[day_number] holding the trading tempo fixed to a reference run.
+    # Lineup and sell decisions keep using score_fn, so a difference in the
+    # result is attributable to the buy side alone. Leave both None for the
+    # shipped behaviour.
+    buy_rank_fn: Callable[[str, float], float] | None = None,
+    buy_quota: dict[int, int] | None = None,
 ) -> SeasonResult:
     """Replay every matchday in order, mutating ``state`` as the bot would."""
     result = SeasonResult()
@@ -175,9 +183,11 @@ def run_season(
         scores = {pid: score_fn(pid, decide_at) for pid in state.player_ids}
 
         buys = sells = 0
+        rank_fn = buy_rank_fn or score_fn
+        quota = None if buy_quota is None else buy_quota.get(md.day_number, 0)
         listings = sorted(
             market.available_before(decide_at),
-            key=lambda x: score_fn(x.player_id, decide_at),
+            key=lambda x: rank_fn(x.player_id, decide_at),
             reverse=True,
         )
         for listing in listings:
@@ -201,8 +211,13 @@ def run_season(
             gain = _eleven_total(
                 [*state.players, candidate], {**scores, candidate.id: cand_ep}
             ) - _eleven_total(state.players, scores)
-            if gain < min_ep_gain and state.squad_size >= 11:
-                continue
+            if buy_rank_fn is None:
+                if gain < min_ep_gain and state.squad_size >= 11:
+                    continue
+            elif quota is not None and buys >= quota:
+                # Tempo matched to the reference run — the control may not buy
+                # its way to a better season simply by trading more.
+                break
 
             # Check every constraint that a sale would NOT relieve before
             # selling anyone — otherwise a blocked buy leaves us a player down.

--- a/rehoboam/replay/engine.py
+++ b/rehoboam/replay/engine.py
@@ -19,8 +19,20 @@ from rehoboam.replay.rules import (
 )
 from rehoboam.replay.state import ReplayPlayer, ReplayState
 
-# Selling instantly to Kickbase returns 95% of market value.
-INSTANT_SELL_PCT = 0.95
+# Selling instantly to Kickbase returns the FULL market value.
+#
+# REH-51 asserted 0.95 in its plan and nothing ever checked it. Measured across
+# all 151 real flips in `flip_outcomes`, joined to `player_mv_history` within a
+# day of the sale: the sell/MV ratio has a hard mode of 41 rows at exactly 1.00
+# and ZERO rows at 0.95 (2 anywhere in 0.94-0.96). A 5% haircut would leave a
+# cluster at 0.95; there is none. Ratios above 1.00 are sales to other managers
+# at a premium, a channel this replay deliberately does not model.
+# `api.sell_player_instant` documents the same: "sell instantly to Kickbase at
+# market value".
+#
+# This is not cosmetic: proceeds feed `_solvent_after`, so a 5% understatement
+# suppressed buys the bot could actually afford.
+INSTANT_SELL_PCT = 1.0
 # Decisions are made this long before kickoff, mirroring the live bot's
 # pre-matchday session rather than pretending to trade at the whistle.
 DECISION_LEAD_SECONDS = 3600.0

--- a/tests/test_replay/test_buy_control.py
+++ b/tests/test_replay/test_buy_control.py
@@ -111,3 +111,19 @@ def test_quota_is_taken_from_the_reference_run_matchday_by_matchday():
     result = SeasonResult(outcomes=[_outcome(1, 3), _outcome(2, 0), _outcome(3, 1)])
 
     assert buy_quota_from(result) == {1: 3, 2: 0, 3: 1}
+
+
+def test_instant_sell_returns_full_market_value():
+    """Measured, not assumed. Across 151 real flips in flip_outcomes joined to
+    player_mv_history within a day of the sale, the sell/MV ratio has a hard
+    mode of 41 rows at exactly 1.00 and ZERO at 0.95. A 5% haircut would have
+    produced a cluster at 0.95; there is none. api.py's own wrapper agrees:
+    "Sell a player instantly to Kickbase at market value."
+
+    REH-51 asserted 0.95 in the plan and it was never checked, understating
+    proceeds on every sale in every replay run and tightening the solvency gate
+    that decides how many buys are affordable.
+    """
+    from rehoboam.replay.engine import INSTANT_SELL_PCT
+
+    assert INSTANT_SELL_PCT == 1.0

--- a/tests/test_replay/test_buy_control.py
+++ b/tests/test_replay/test_buy_control.py
@@ -1,0 +1,113 @@
+"""REH-67: a buy-side control that changes only *who* gets bought.
+
+The hold baseline (no buys at all) scored 15,100 against the shipped bot's
+27,099, which rules out "the gain is only avoided churn" — but it cannot show
+the scorer picks *well*, because it differs on two axes at once: whether to
+trade and whom to pick.
+
+This control fixes the trading tempo and varies only the chooser. Lineup and
+sell decisions deliberately keep using EP, so any difference is attributable to
+the buy side alone.
+"""
+
+from __future__ import annotations
+
+from rehoboam.replay.engine import Matchday, run_season
+from rehoboam.replay.market import MarketListing
+from rehoboam.replay.state import ReplayPlayer, ReplayState
+
+DAY = 86400.0
+POS = ["Goalkeeper"] + ["Defender"] * 4 + ["Midfielder"] * 4 + ["Forward"] * 2
+
+
+class FakeMarket:
+    def __init__(self, listings):
+        self.listings = listings
+
+    def available_before(self, at):
+        return [x for x in self.listings if x.transfer_at < at]
+
+
+def _full_squad():
+    return {str(i): ReplayPlayer(id=str(i), position=POS[i], team_id=str(i)) for i in range(11)}
+
+
+def _run(*, buy_rank_fn=None, buy_quota=None):
+    """Two candidates in direct conflict: 'cheap-star' is the better player,
+    'pricey-dud' is the more valuable asset. EP prefers one, market value the
+    other, so whichever is bought identifies the chooser that was used.
+    """
+    state = ReplayState(budget=100_000_000, squad=_full_squad())
+    eps = {"cheap-star": 200.0, "pricey-dud": 12.0}
+    mvs = {"cheap-star": 1_000_000, "pricey-dud": 40_000_000}
+
+    return (
+        run_season(
+            state=state,
+            market=FakeMarket(
+                [
+                    MarketListing(player_id="cheap-star", price=1_000_000, transfer_at=DAY),
+                    MarketListing(player_id="pricey-dud", price=40_000_000, transfer_at=DAY),
+                ]
+            ),
+            matchdays=[Matchday(day_number=1, kickoff=10 * DAY, points={})],
+            score_fn=lambda pid, at: eps.get(pid, 10.0),
+            mv_fn=lambda pid, at: mvs.get(pid, 1_000_000),
+            position_fn=lambda pid: "Forward",
+            team_fn=lambda pid: pid,
+            buy_rank_fn=buy_rank_fn,
+            buy_quota=buy_quota,
+        ),
+        state,
+    )
+
+
+def test_market_value_control_buys_the_expensive_player_ep_would_reject():
+    """The whole point of the control: rank by market value, not by EP."""
+    mvs = {"cheap-star": 1_000_000, "pricey-dud": 40_000_000}
+
+    _result, state = _run(buy_rank_fn=lambda pid, at: float(mvs.get(pid, 0)), buy_quota={1: 1})
+
+    assert "pricey-dud" in state.squad
+    assert "cheap-star" not in state.squad
+
+
+def test_the_quota_caps_how_many_buys_a_matchday_may_make():
+    """Trading tempo is held fixed so only the chooser varies."""
+    mvs = {"cheap-star": 1_000_000, "pricey-dud": 40_000_000}
+
+    _result, state = _run(buy_rank_fn=lambda pid, at: float(mvs.get(pid, 0)), buy_quota={1: 0})
+
+    assert "pricey-dud" not in state.squad
+    assert "cheap-star" not in state.squad
+
+
+def test_without_a_control_the_ep_ranking_still_decides():
+    """The control must be opt-in — the shipped path is unchanged."""
+    _result, state = _run()
+
+    assert "cheap-star" in state.squad
+
+
+def test_quota_is_taken_from_the_reference_run_matchday_by_matchday():
+    """Season-wide matching would let the control front-load its buys into the
+    weeks that happened to be cheap. Tempo is matched per matchday."""
+    from rehoboam.replay.driver import buy_quota_from
+    from rehoboam.replay.engine import MatchdayOutcome, SeasonResult
+
+    def _outcome(day, buys):
+        return MatchdayOutcome(
+            day_number=day,
+            points_scored=0,
+            lineup_ids=[],
+            penalty=0,
+            budget_at_kickoff=0,
+            zeroed=False,
+            squad_size=15,
+            buys=buys,
+            sells=0,
+        )
+
+    result = SeasonResult(outcomes=[_outcome(1, 3), _outcome(2, 0), _outcome(3, 1)])
+
+    assert buy_quota_from(result) == {1: 3, 2: 0, 3: 1}


### PR DESCRIPTION
REH-67 asked whether the replay's gain comes from the v2 scorer picking better players or merely from trading less. It produced one solid answer, one dead end, and one bug that invalidates the economics of every replay run so far.

## 1. The churn hypothesis is dead

A **hold baseline** — no buys at all, which needs no code (`replay-season --min-ep-gain 999999`) — scores:

```
Simulated total:    15,100 points     vs the shipped bot's 26,960
Total buys: 0   Total sells: 0   Final budget: EUR 80,000,000
```

Trading is worth roughly **+11,900 points**. "The gain is only avoided churn" is refuted.

It does **not** establish selection skill, though: it varies two things at once (whether to trade, and whom to pick), and a squad held for 34 matchdays decays badly while sitting on the entire €80,000,000 budget. Almost any refresh policy would beat it.

## 2. The market-value control is invalid — its number is not reported

Ranking candidates by market value instead of EP, at matched per-matchday tempo, gave 26,960 vs 22,809. **That +4,151 is not evidence and is not reported as such**, because the control made **2 buys against the reference's 24**. The arms differ in trading volume as well as in chooser — the same confound as the hold baseline. The command prints an explicit tempo-mismatch warning instead of a verdict.

Diagnosed enough to rule out the obvious cause: with `buy_quota=None`, no cap at all, market-value ranking *still* makes only 2 buys, so the quota logic is not the limiter. Because the buy loop is first-fit over a sorted list, MV-desc ordering already selects the highest-MV **affordable** candidate — the agent is not merely reaching for players it cannot afford. It exhausts its budget on a couple of expensive players and then stops trading.

The lesson generalises: in a budget-constrained agent, *what you rank by* silently determines *how often you can act*. "Change only the chooser" is not achievable by swapping the sort key, because chooser and tempo are coupled through the budget.

## 3. Instant sell returns full market value, not 95% — measured

REH-51's plan asserted a 5% haircut on instant sells. Nothing ever checked it. Measured across all **151 real flips** in `flip_outcomes`, joined to `player_mv_history` within a day of the sale:

| sell / MV bucket | rows |
| --- | --- |
| exactly **1.00** | **41** |
| exactly 0.95 | **0** |
| anywhere in 0.94–0.96 | 2 |
| total | 151 |

A 5% haircut would leave a cluster at 0.95. There is none — the mode is a hard spike at exactly 1.00. `api.sell_player_instant` documents the same: *"sell instantly to Kickbase at market value."* Ratios above 1.00 are sales to other managers, a channel this replay deliberately does not model.

**This is not cosmetic.** Proceeds feed `_solvent_after`, so every replay run so far had 5% less cash on every sale than the real bot would have, suppressing buys it could actually afford.

It also corrects a figure quoted in REH-66's PR and in both tickets: a round trip costs **~11.7%** (the buy-side premium alone), not the ~15% claimed from the fictional 0.95 sell.

## The corrected season result

```
Simulated total:    26,960 points
Actual total:       26,172 points
Difference:           +788 points        (was +927 with the bad constant)

  Zero-point matchdays avoided           +688   exact
  Empty-slot penalties incurred            +0   exact
  Better squad and lineup                +100   medium - buy side is optimistic
```

**+688 of the +788 is matchday 14 alone** — the bankruptcy. Across the other 33 matchdays the squad and lineup are worth **+100 total, about +3 points per matchday on ~800**. Indistinguishable from noise.

The measurable edge remains "would not have gone bankrupt", not "picks better players". Fixing the sell rate made the honest answer *worse*, which is the point of fixing it.

## What shipped

- `run_season` gains `buy_rank_fn` / `buy_quota` so a control can vary the chooser while holding tempo; both default to `None` and the shipped path is untouched. All thirteen pre-existing engine tests pass unmodified.
- `buy_quota_from()` and a `replay-buy-control` command.
- `INSTANT_SELL_PCT` corrected to `1.0`, with the measurement recorded at the constant so it is not re-asserted from a plan document again.
- Fidelity block: sell decisions downgraded from "high" to **"medium"**, and now states plainly that **profit flips are not modelled at all** — the replay sells only to make room or restore solvency, while the live bot has an entire `find_profit_opportunities` path.

## Still open

REH-67's original question is **not answered**. A valid control has to equalise *spend*, not trade count. Beyond that, two behaviours of the real bot remain unmodelled and push in opposite directions — bid competition would make results worse, profit flipping would make them better — so they need to land together rather than one at a time.

## Verification

- **624 passed, 1 skipped.**
- Both DBs SHA-256 unchanged before and after every run.
- `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
