### PR TITLE
Full-fidelity replay: bid competition and profit flipping (REH-68)

### DIFF
--- a/rehoboam/cli.py
+++ b/rehoboam/cli.py
@@ -687,6 +687,15 @@ def replay_season(
             "bot ships with; override only for a labelled sensitivity check."
         ),
     ),
+    with_flips: bool = typer.Option(
+        False,
+        "--with-flips",
+        help=(
+            "Model profit flipping (REH-68): take profit at min_sell_profit_pct "
+            "and cut losses at max_loss_pct. Real flipping LOST EUR 55.3M over "
+            "151 flips, so expect this to lower the result."
+        ),
+    ),
     with_competition: bool = typer.Option(
         False,
         "--with-competition",
@@ -712,6 +721,7 @@ def replay_season(
         learning_db_path=learning_db,
         min_ep_gain=min_ep_gain,
         with_competition=with_competition,
+        with_flips=with_flips,
     )
     console.print(report)
 

--- a/rehoboam/cli.py
+++ b/rehoboam/cli.py
@@ -687,6 +687,15 @@ def replay_season(
             "bot ships with; override only for a labelled sensitivity check."
         ),
     ),
+    with_competition: bool = typer.Option(
+        False,
+        "--with-competition",
+        help=(
+            "Model bid competition (REH-68): bid via SmartBidding and win only by "
+            "exceeding what the real buyer paid. Incomplete until profit flipping "
+            "lands, so treat the output as a diagnostic, not a season result."
+        ),
+    ),
 ) -> None:
     """Replay the full bot across 2025/26 and report the counterfactual finish."""
     from rehoboam.replay.driver import run_replay
@@ -699,7 +708,10 @@ def replay_season(
         raise typer.Exit(1)
 
     _result, report = run_replay(
-        corpus_path=corpus, learning_db_path=learning_db, min_ep_gain=min_ep_gain
+        corpus_path=corpus,
+        learning_db_path=learning_db,
+        min_ep_gain=min_ep_gain,
+        with_competition=with_competition,
     )
     console.print(report)
 

--- a/rehoboam/replay/attribution.py
+++ b/rehoboam/replay/attribution.py
@@ -17,7 +17,7 @@ FIDELITY_NOTES = [
     ("Sell decisions", "medium", "instant sell at MV; profit flips NOT modelled"),
     ("Buy prices", "high", "real transaction prices"),
     ("Buy availability", "medium", "only players who actually traded are visible"),
-    ("Bid competition", "ABSENT - optimistic", "wanted players are always won"),
+    ("Bid competition", "see footer", "absent unless --with-competition"),
 ]
 
 
@@ -65,6 +65,7 @@ def format_report(
     actual_per_matchday: dict[int, int],
     standings: list[LeagueStanding],
     min_ep_gain: float,
+    with_competition: bool = False,
 ) -> str:
     """Human-readable replay report with fidelity caveats attached.
 
@@ -111,8 +112,20 @@ def format_report(
         f"Total sells: {sum(o.sells for o in result.outcomes)}",
         f"Final budget: EUR {result.final_budget:,}",
         "",
-        "This models no bid competition: any listed player the bot wanted, it got.",
-        "Treat the buy-side contribution as an upper bound.",
+    ]
+    if with_competition:
+        lines += [
+            "Bid competition IS modelled: a listing is won only by bidding above",
+            "what the real buyer paid, and the winning bid is what we pay.",
+            "INCOMPLETE - profit flipping is still unmodelled, and it is the",
+            "behaviour that funds bidding. Diagnostic only, not a season result.",
+        ]
+    else:
+        lines += [
+            "This models no bid competition: any listed player the bot wanted, it got.",
+            "Treat the buy-side contribution as an upper bound.",
+        ]
+    lines += [
         "=" * 68,
     ]
     return "\n".join(lines)

--- a/rehoboam/replay/attribution.py
+++ b/rehoboam/replay/attribution.py
@@ -66,6 +66,7 @@ def format_report(
     standings: list[LeagueStanding],
     min_ep_gain: float,
     with_competition: bool = False,
+    with_flips: bool = False,
 ) -> str:
     """Human-readable replay report with fidelity caveats attached.
 
@@ -117,14 +118,25 @@ def format_report(
         lines += [
             "Bid competition IS modelled: a listing is won only by bidding above",
             "what the real buyer paid, and the winning bid is what we pay.",
-            "INCOMPLETE - profit flipping is still unmodelled, and it is the",
-            "behaviour that funds bidding. Diagnostic only, not a season result.",
         ]
     else:
         lines += [
             "This models no bid competition: any listed player the bot wanted, it got.",
             "Treat the buy-side contribution as an upper bound.",
         ]
+    if with_flips:
+        lines += [
+            "Profit flipping IS modelled: take profit / cut loss against the",
+            "cost basis. Real flipping lost EUR 55.3M over 151 flips, so this is",
+            "expected to LOWER the result, not raise it.",
+        ]
+    else:
+        lines += [
+            "Profit flipping is NOT modelled: the bot sells only to make room or",
+            "to restore solvency, while the live bot also trades for gain.",
+        ]
+    if not (with_competition and with_flips):
+        lines += ["INCOMPLETE - diagnostic only, not a season result."]
     lines += [
         "=" * 68,
     ]

--- a/rehoboam/replay/driver.py
+++ b/rehoboam/replay/driver.py
@@ -156,6 +156,17 @@ def _make_score_fn(
     return score
 
 
+def _shipped_default(name: str) -> float:
+    """A Settings field default without instantiating Settings.
+
+    Instantiation requires KICKBASE credentials; the replay must stay runnable
+    offline and deterministic against the DBs alone.
+    """
+    from rehoboam.config import Settings
+
+    return float(Settings.model_fields[name].default)
+
+
 def buy_quota_from(result: SeasonResult) -> dict[int, int]:
     """Per-matchday buy counts, for holding a control's trading tempo fixed.
 
@@ -174,6 +185,7 @@ def run_replay(
     buy_rank_fn: Callable[[str, float], float] | None = None,
     buy_quota: dict[int, int] | None = None,
     with_competition: bool = False,
+    with_flips: bool = False,
 ) -> tuple[SeasonResult, str]:
     """Replay the whole season and return the result plus a formatted report.
 
@@ -224,6 +236,11 @@ def run_replay(
             if with_competition
             else None
         ),
+        # Live trade-side thresholds, read from the shipped Settings defaults
+        # for the same reason shipped_min_ep_gain is (REH-66): a production
+        # re-tune must not leave the harness describing a bot nobody deployed.
+        profit_take_pct=_shipped_default("min_sell_profit_pct") if with_flips else None,
+        loss_cut_pct=_shipped_default("max_loss_pct") if with_flips else None,
     )
 
     with sqlite3.connect(learning_db_path) as conn:
@@ -243,6 +260,7 @@ def run_replay(
         standings=standings,
         min_ep_gain=gain_floor,
         with_competition=with_competition,
+        with_flips=with_flips,
     )
     return result, report
 

--- a/rehoboam/replay/driver.py
+++ b/rehoboam/replay/driver.py
@@ -173,6 +173,7 @@ def run_replay(
     min_ep_gain: float | None = None,
     buy_rank_fn: Callable[[str, float], float] | None = None,
     buy_quota: dict[int, int] | None = None,
+    with_competition: bool = False,
 ) -> tuple[SeasonResult, str]:
     """Replay the whole season and return the result plus a formatted report.
 
@@ -218,6 +219,11 @@ def run_replay(
         min_ep_gain=gain_floor,
         buy_rank_fn=buy_rank_fn,
         buy_quota=buy_quota,
+        bid_fn=(
+            make_ep_bid_fn(mv_fn=corpus.market_value_at, score_fn=score_fn)
+            if with_competition
+            else None
+        ),
     )
 
     with sqlite3.connect(learning_db_path) as conn:
@@ -236,6 +242,7 @@ def run_replay(
         actual_per_matchday=actual_per_matchday,
         standings=standings,
         min_ep_gain=gain_floor,
+        with_competition=with_competition,
     )
     return result, report
 
@@ -298,3 +305,56 @@ def run_buy_control(*, corpus_path: Path, learning_db_path: Path) -> str:
         "=" * 68,
     ]
     return "\n".join(lines)
+
+
+def make_ep_bid_fn(
+    *,
+    mv_fn: Callable[[str, float], int | None],
+    score_fn: Callable[[str, float], float],
+) -> Callable[[str, int, float, float, int], int]:
+    """Bid with the bot's own bidding strategy (REH-68).
+
+    Until now the replay bought at the listed price and never called
+    ``SmartBidding`` at all, so the tier thresholds REH-55 re-tuned (70/53/43)
+    and the entire overbid stack were unexercised by the harness. Wiring
+    ``calculate_ep_bid`` in as the bidder is what makes them matter: a
+    must-have candidate now bids high enough to outbid the manager who really
+    signed him, while a marginal one does not.
+
+    Tiers are read from the shipped ``Settings`` defaults for the same reason
+    ``shipped_min_ep_gain`` is — so a production re-tune cannot leave the
+    harness describing a bot nobody deployed — and without instantiating
+    ``Settings``, which would require KICKBASE credentials.
+
+    Two inputs the live bot has and the replay does not, both pinned to neutral
+    and both making this an UPPER bound on our willingness to pay:
+    ``offer_count=0`` (we cannot know how many rivals bid on a given listing)
+    and ``trend_change_pct=0.0`` (no market-value trend is fed in). Confidence
+    is fixed at 0.8 rather than derived from data quality grading.
+    """
+    from rehoboam.bidding_strategy import SmartBidding
+    from rehoboam.config import Settings
+
+    def _default(name: str) -> float:
+        return float(Settings.model_fields[name].default)
+
+    bidding = SmartBidding(
+        tier_must_have=_default("bid_tier_must_have"),
+        tier_strong_upgrade=_default("bid_tier_strong_upgrade"),
+        tier_solid_upgrade=_default("bid_tier_solid_upgrade"),
+    )
+
+    def bid(player_id: str, price: int, at: float, gain: float, budget: int) -> int:
+        rec = bidding.calculate_ep_bid(
+            asking_price=price,
+            market_value=mv_fn(player_id, at) or price,
+            expected_points=score_fn(player_id, at),
+            marginal_ep_gain=gain,
+            confidence=0.8,
+            current_budget=budget,
+            sell_plan=None,
+            trend_change_pct=0.0,
+        )
+        return int(rec.recommended_bid)
+
+    return bid

--- a/rehoboam/replay/engine.py
+++ b/rehoboam/replay/engine.py
@@ -189,13 +189,18 @@ def run_season(
     # shipped behaviour.
     buy_rank_fn: Callable[[str, float], float] | None = None,
     buy_quota: dict[int, int] | None = None,
-    # REH-68 bid competition. Given (player_id, real_price, at), returns our
-    # maximum bid. We win only if it EXCEEDS what the real buyer actually paid,
+    # REH-68 bid competition. Given (player_id, real_price, at, marginal_gain,
+    # budget), returns our maximum bid. Gain and budget are passed because a
+    # real bid is a function of both — SmartBidding sizes its overbid from the
+    # marginal-gain tier and caps it against what we can afford — and a hook
+    # without them could only express a flat willingness to pay, which is not
+    # what the bot does.
+    # We win only if the bid EXCEEDS what the real buyer actually paid,
     # and we then pay our own bid rather than theirs — outbidding a rival costs
     # more than the rival paid, and charging their price would hand us the
     # upside of competition with none of its cost. None keeps the shipped
     # behaviour, in which every wanted player is won.
-    bid_fn: Callable[[str, int, float], int] | None = None,
+    bid_fn: Callable[[str, int, float, float, int], int] | None = None,
 ) -> SeasonResult:
     """Replay every matchday in order, mutating ``state`` as the bot would."""
     result = SeasonResult()
@@ -226,15 +231,6 @@ def run_season(
                 team_id=team_fn(listing.player_id),
             )
 
-            # What this signing costs us. Without a competition model that is
-            # the price the real buyer paid; with one it is our own winning bid.
-            cost = listing.price
-            if bid_fn is not None:
-                our_bid = bid_fn(listing.player_id, listing.price, decide_at)
-                if our_bid <= listing.price:
-                    continue  # outbid by the manager who really signed him
-                cost = our_bid
-
             # Marginal gain: how much this player improves the best legal
             # eleven. Measuring against the weakest *squad* member instead
             # waves through a twelfth midfielder who outscores the bench but
@@ -249,6 +245,15 @@ def run_season(
                 # Tempo matched to the reference run — the control may not buy
                 # its way to a better season simply by trading more.
                 break
+
+            # What this signing costs us. Without a competition model that is
+            # the price the real buyer paid; with one it is our own winning bid.
+            cost = listing.price
+            if bid_fn is not None:
+                our_bid = bid_fn(listing.player_id, listing.price, decide_at, gain, state.budget)
+                if our_bid <= listing.price:
+                    continue  # outbid by the manager who really signed him
+                cost = our_bid
 
             # Check every constraint that a sale would NOT relieve before
             # selling anyone — otherwise a blocked buy leaves us a player down.

--- a/rehoboam/replay/engine.py
+++ b/rehoboam/replay/engine.py
@@ -86,10 +86,13 @@ def _solvent_after(state: ReplayState, price: int, proceeds: int = 0) -> bool:
 
     Without this gate the engine leveraged to the credit floor (measured:
     EUR -167,048,229 against a EUR 80,000,000 starting budget) and then had to
-    unwind it in the same session at 95% of market value, against a mean buy
-    price of 1.117x market value — destroying ~15% of the squad's equity every
-    matchday until nothing was left. ``can_buy``'s credit-line check stays as
-    the standing legality rule; this is an additional decision-time one.
+    unwind it in the same session, destroying squad equity every matchday until
+    nothing was left. The round-trip cost is the buy-side premium alone — a
+    measured mean transaction price of 1.117x market value against an instant
+    sell that returns the full market value, so ~11.7%, not the ~15% claimed
+    while ``INSTANT_SELL_PCT`` was wrongly 0.95 (see REH-67). ``can_buy``'s
+    credit-line check stays as the standing legality rule; this is an
+    additional decision-time one.
     """
     return state.budget + int(proceeds) - int(price) >= 0
 
@@ -186,6 +189,13 @@ def run_season(
     # shipped behaviour.
     buy_rank_fn: Callable[[str, float], float] | None = None,
     buy_quota: dict[int, int] | None = None,
+    # REH-68 bid competition. Given (player_id, real_price, at), returns our
+    # maximum bid. We win only if it EXCEEDS what the real buyer actually paid,
+    # and we then pay our own bid rather than theirs — outbidding a rival costs
+    # more than the rival paid, and charging their price would hand us the
+    # upside of competition with none of its cost. None keeps the shipped
+    # behaviour, in which every wanted player is won.
+    bid_fn: Callable[[str, int, float], int] | None = None,
 ) -> SeasonResult:
     """Replay every matchday in order, mutating ``state`` as the bot would."""
     result = SeasonResult()
@@ -216,6 +226,15 @@ def run_season(
                 team_id=team_fn(listing.player_id),
             )
 
+            # What this signing costs us. Without a competition model that is
+            # the price the real buyer paid; with one it is our own winning bid.
+            cost = listing.price
+            if bid_fn is not None:
+                our_bid = bid_fn(listing.player_id, listing.price, decide_at)
+                if our_bid <= listing.price:
+                    continue  # outbid by the manager who really signed him
+                cost = our_bid
+
             # Marginal gain: how much this player improves the best legal
             # eleven. Measuring against the weakest *squad* member instead
             # waves through a twelfth midfielder who outscores the bench but
@@ -234,7 +253,7 @@ def run_season(
             # Check every constraint that a sale would NOT relieve before
             # selling anyone — otherwise a blocked buy leaves us a player down.
             allowed, reason = can_buy(
-                state, candidate, listing.price, team_value=_team_value(state, mv_fn, decide_at)
+                state, candidate, cost, team_value=_team_value(state, mv_fn, decide_at)
             )
             if not allowed and "squad full" not in reason:
                 continue
@@ -246,7 +265,7 @@ def run_season(
                 sale_proceeds = _proceeds(sold_id, mv_fn, decide_at)
                 # Solvency is tested *before* the sale so that an unaffordable
                 # candidate never costs us a player we then cannot replace.
-                if not _solvent_after(state, listing.price, sale_proceeds):
+                if not _solvent_after(state, cost, sale_proceeds):
                     continue
                 state.sell(sold_id, sale_proceeds)
                 scores.pop(sold_id, None)
@@ -256,15 +275,15 @@ def run_season(
                 allowed, reason = can_buy(
                     state,
                     candidate,
-                    listing.price,
+                    cost,
                     team_value=_team_value(state, mv_fn, decide_at),
                 )
                 if not allowed:
                     continue
-            elif not _solvent_after(state, listing.price):
+            elif not _solvent_after(state, cost):
                 continue
 
-            state.buy(candidate, listing.price)
+            state.buy(candidate, cost)
             scores[candidate.id] = cand_ep
             buys += 1
 

--- a/rehoboam/replay/engine.py
+++ b/rehoboam/replay/engine.py
@@ -154,6 +154,54 @@ def _restore_budget(
     return sells
 
 
+def _flip_sells(
+    state: ReplayState,
+    scores: dict[str, float],
+    mv_fn: Callable[[str, float], int | None],
+    at: float,
+    *,
+    profit_take_pct: float | None,
+    loss_cut_pct: float | None,
+) -> int:
+    """Take profit and cut losses on squad players; returns sells (REH-68).
+
+    Ports the live trade-side thresholds (``min_sell_profit_pct`` 15.0,
+    ``max_loss_pct`` -15.0). Until now the replay sold only to make room or to
+    restore solvency, so an entire revenue behaviour of the real bot was
+    missing from every result.
+
+    Fieldability is checked before every sale for the same reason it is on the
+    make-room path: an empty slot costs -100, which dwarfs any plausible
+    trading gain. A squad of exactly eleven therefore holds a winner rather
+    than banking it.
+
+    Players with no cost basis are skipped rather than assumed free.
+    """
+    if profit_take_pct is None and loss_cut_pct is None:
+        return 0
+
+    sells = 0
+    for pid in list(state.player_ids):
+        player = state.squad.get(pid)
+        if player is None or not player.buy_price:
+            continue
+        current = mv_fn(pid, at)
+        if not current:
+            continue
+        change_pct = (current - player.buy_price) / player.buy_price * 100.0
+        take = profit_take_pct is not None and change_pct >= profit_take_pct
+        cut = loss_cut_pct is not None and change_pct <= loss_cut_pct
+        if not (take or cut):
+            continue
+        remaining = {k: v for k, v in state.squad.items() if k != pid}
+        if not can_field_eleven(ReplayState(budget=state.budget, squad=remaining)):
+            continue
+        state.sell(pid, _proceeds(pid, mv_fn, at))
+        scores.pop(pid, None)
+        sells += 1
+    return sells
+
+
 def shipped_min_ep_gain() -> float:
     """The marginal-gain floor the live bot actually ships with (REH-66).
 
@@ -201,6 +249,12 @@ def run_season(
     # upside of competition with none of its cost. None keeps the shipped
     # behaviour, in which every wanted player is won.
     bid_fn: Callable[[str, int, float, float, int], int] | None = None,
+    # REH-68 profit flipping. The live trade-side thresholds
+    # (min_sell_profit_pct 15.0 / max_loss_pct -15.0). Both None disables the
+    # pass entirely, preserving the shipped replay behaviour in which the bot
+    # sells only to make room or to restore solvency.
+    profit_take_pct: float | None = None,
+    loss_cut_pct: float | None = None,
 ) -> SeasonResult:
     """Replay every matchday in order, mutating ``state`` as the bot would."""
     result = SeasonResult()
@@ -210,6 +264,15 @@ def run_season(
         scores = {pid: score_fn(pid, decide_at) for pid in state.player_ids}
 
         buys = sells = 0
+        # Trade before shopping: proceeds fund the same matchday's buys.
+        sells += _flip_sells(
+            state,
+            scores,
+            mv_fn,
+            decide_at,
+            profit_take_pct=profit_take_pct,
+            loss_cut_pct=loss_cut_pct,
+        )
         rank_fn = buy_rank_fn or score_fn
         quota = None if buy_quota is None else buy_quota.get(md.day_number, 0)
         listings = sorted(
@@ -288,7 +351,7 @@ def run_season(
             elif not _solvent_after(state, cost):
                 continue
 
-            state.buy(candidate, cost)
+            state.buy(candidate, cost, at=decide_at)
             scores[candidate.id] = cand_ep
             buys += 1
 

--- a/rehoboam/replay/engine.py
+++ b/rehoboam/replay/engine.py
@@ -175,13 +175,23 @@ def _flip_sells(
     trading gain. A squad of exactly eleven therefore holds a winner rather
     than banking it.
 
+    Best-eleven starters are protected, mirroring the live sell logic
+    ("Non-displaced best-11 starters are protected and cannot be sold",
+    decision.py). Without that, the replay banks a 15% gain by selling the very
+    player it needs on Saturday — converting points into cash it then spends
+    worse, since re-entry pays a measured 1.117x market value.
+
     Players with no cost basis are skipped rather than assumed free.
     """
     if profit_take_pct is None and loss_cut_pct is None:
         return 0
 
+    protected = {p.id for p in select_best_eleven(state.players, scores)}
+
     sells = 0
     for pid in list(state.player_ids):
+        if pid in protected:
+            continue
         player = state.squad.get(pid)
         if player is None or not player.buy_price:
             continue

--- a/rehoboam/replay/rules.py
+++ b/rehoboam/replay/rules.py
@@ -8,6 +8,7 @@ A negative balance at kickoff zeroes the entire matchday.
 from __future__ import annotations
 
 from rehoboam.config import POSITION_MINIMUMS
+from rehoboam.formation import select_best_eleven
 from rehoboam.replay.state import ReplayPlayer, ReplayState
 
 MAX_SQUAD_SIZE = 15
@@ -32,13 +33,36 @@ def can_buy(
 
 
 def can_field_eleven(state: ReplayState) -> bool:
-    """Whether the squad can legally fill all 11 starting slots."""
+    """Whether the squad can legally fill all 11 starting slots.
+
+    Needs BOTH checks below, because neither source of truth is complete:
+
+    * ``POSITION_MINIMUMS`` (GK 1, DEF 3, MID 2, FW 1) is the legal floor, but
+      says nothing about the per-position *ceilings* — so a 13-man squad of
+      1 GK / 3 DEF / 2 MID / 7 FW satisfies it while only nine players can
+      actually start, since forwards cap at 3.
+    * ``select_best_eleven`` enforces those ceilings, but does NOT guarantee
+      the floor: given no goalkeeper at all it will happily return eleven
+      outfielders (5 DEF + 5 MID + 3 FW = 13 to choose from), which is not a
+      legal Kickbase lineup.
+
+    Checking only the minimums booked -300 in empty-slot penalties across
+    matchdays 4, 5 and 26 of the full-fidelity run, at squad sizes of 12 and 13
+    — never below eleven. Checking only ``select_best_eleven`` would instead
+    let the make-room sale strand us without a keeper. Profit flipping did not
+    introduce either bug; it skewed squad shapes enough to reach the first.
+
+    Scores are uniform because this is a question about shape, not quality.
+    """
     if state.squad_size < STARTING_ELEVEN:
         return False
     counts: dict[str, int] = {}
     for p in state.players:
         counts[p.position] = counts.get(p.position, 0) + 1
-    return all(counts.get(pos, 0) >= need for pos, need in POSITION_MINIMUMS.items())
+    if not all(counts.get(pos, 0) >= need for pos, need in POSITION_MINIMUMS.items()):
+        return False
+    uniform = {p.id: 1.0 for p in state.players}
+    return len(select_best_eleven(state.players, uniform)) >= STARTING_ELEVEN
 
 
 def empty_slot_penalty(chosen_count: int) -> int:

--- a/rehoboam/replay/state.py
+++ b/rehoboam/replay/state.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import sqlite3
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 
 from rehoboam.enrichment.corpus import TrainingCorpus
 
@@ -17,11 +17,20 @@ ASSIGNMENT_WINDOW_SECONDS = 300.0
 
 @dataclass(frozen=True)
 class ReplayPlayer:
-    """A squad member. ``id`` and ``position`` satisfy ``select_best_eleven``."""
+    """A squad member. ``id`` and ``position`` satisfy ``select_best_eleven``.
+
+    ``buy_price`` / ``bought_at`` are the cost basis, needed to compute profit
+    (REH-68). Both default to ``None`` rather than ``0``: the opening squad was
+    *assigned* rather than bought, and a zero basis would make every
+    opening-squad sale read as a 100% gain — a fortune the replay never earned.
+    Unknown must stay distinguishable from free.
+    """
 
     id: str
     position: str
     team_id: str | None = None
+    buy_price: int | None = None
+    bought_at: float | None = None
 
 
 @dataclass
@@ -43,8 +52,9 @@ class ReplayState:
     def players(self) -> list[ReplayPlayer]:
         return list(self.squad.values())
 
-    def buy(self, player: ReplayPlayer, price: int) -> None:
-        self.squad[player.id] = player
+    def buy(self, player: ReplayPlayer, price: int, at: float | None = None) -> None:
+        """Add ``player`` to the squad, recording the cost basis (REH-68)."""
+        self.squad[player.id] = replace(player, buy_price=int(price), bought_at=at)
         self.budget -= int(price)
 
     def sell(self, player_id: str, proceeds: int) -> None:
@@ -83,8 +93,19 @@ def initial_state(
     pids = [str(r[0]) for r in rows]
     positions = corpus.positions_for(pids)
     teams = corpus.team_ids_for(pids)
+    # Cost basis for an ASSIGNED player is his market value at assignment
+    # (REH-68), mirroring how the live API derives buy_price as
+    # market_value - mvgl. Leaving it None would exclude the entire opening
+    # squad from profit logic; setting it to 0 would make selling any of them
+    # read as pure profit.
     squad = {
-        pid: ReplayPlayer(id=pid, position=positions[pid], team_id=teams.get(pid))
+        pid: ReplayPlayer(
+            id=pid,
+            position=positions[pid],
+            team_id=teams.get(pid),
+            buy_price=corpus.market_value_at(pid, assigned_on),
+            bought_at=assigned_on,
+        )
         for pid in pids
         if pid in positions
     }

--- a/tests/test_replay/test_bid_competition.py
+++ b/tests/test_replay/test_bid_competition.py
@@ -51,13 +51,13 @@ def _run(bid_fn):
 
 def test_a_bid_below_the_real_price_loses_the_auction():
     """The rival paid 10,000,000. Bidding under that must not win."""
-    _result, state = _run(lambda pid, price, at: 9_999_999)
+    _result, state = _run(lambda pid, price, at, gain, budget: 9_999_999)
 
     assert "target" not in state.squad
 
 
 def test_a_bid_above_the_real_price_wins():
-    _result, state = _run(lambda pid, price, at: 11_000_000)
+    _result, state = _run(lambda pid, price, at, gain, budget: 11_000_000)
 
     assert "target" in state.squad
 
@@ -65,7 +65,7 @@ def test_a_bid_above_the_real_price_wins():
 def test_the_winner_pays_its_own_bid_not_the_rivals_price():
     """Outbidding costs more than the rival paid. Charging the rival's price
     would give us the upside of competition with none of its cost."""
-    _result, state = _run(lambda pid, price, at: 11_000_000)
+    _result, state = _run(lambda pid, price, at, gain, budget: 11_000_000)
 
     assert state.budget == 100_000_000 - 11_000_000
 
@@ -76,3 +76,50 @@ def test_without_a_bid_fn_every_wanted_player_is_still_won():
 
     assert "target" in state.squad
     assert state.budget == 100_000_000 - 10_000_000
+
+
+def test_bid_fn_receives_the_marginal_gain_and_the_current_budget():
+    """A bid is a function of how much the player improves the eleven and what
+    we can afford — SmartBidding.calculate_ep_bid needs both. Without them the
+    hook can only express a flat willingness to pay, which is not the bot."""
+    seen: dict = {}
+
+    def bid(pid, price, at, gain, budget):
+        seen.update(pid=pid, price=price, gain=gain, budget=budget)
+        return 0  # lose, so the run is unaffected
+
+    _run(bid)
+
+    assert seen["pid"] == "target"
+    assert seen["price"] == 10_000_000
+    assert seen["gain"] > 0.0, "target scores 200 against a squad of 10s"
+    assert seen["budget"] == 100_000_000
+
+
+def test_the_ep_bid_fn_bids_more_for_a_must_have_than_for_a_marginal_gain():
+    """Wires SmartBidding in as the bidder, which is what finally makes the
+    tier thresholds REH-55 re-tuned (70/53/43) matter to the replay at all —
+    until now the harness bought at the listed price and never called it.
+    """
+    from rehoboam.replay.driver import make_ep_bid_fn
+
+    bid_fn = make_ep_bid_fn(
+        mv_fn=lambda pid, at: 10_000_000,
+        score_fn=lambda pid, at: 100.0,
+    )
+
+    must_have = bid_fn("p", 10_000_000, 0.0, 80.0, 50_000_000)
+    marginal = bid_fn("p", 10_000_000, 0.0, 5.0, 50_000_000)
+
+    assert must_have > marginal
+
+
+def test_the_ep_bid_fn_never_bids_beyond_the_budget():
+    from rehoboam.replay.driver import make_ep_bid_fn
+
+    bid_fn = make_ep_bid_fn(
+        mv_fn=lambda pid, at: 10_000_000,
+        score_fn=lambda pid, at: 100.0,
+    )
+
+    assert bid_fn("p", 10_000_000, 0.0, 80.0, 3_000_000) <= 3_000_000

--- a/tests/test_replay/test_bid_competition.py
+++ b/tests/test_replay/test_bid_competition.py
@@ -1,0 +1,78 @@
+"""REH-68: the replay must be able to LOSE an auction.
+
+Until now every wanted player was won, at the price someone else really paid —
+the single largest fidelity gap in the harness, and the reason every buy-side
+number has been labelled an upper bound.
+
+`player_transfers` has a price on all 6,610 type-2 rows (a counterparty on only
+51%), so the defensible model is price-based: we win a listing only if our bid
+exceeds what the real buyer actually paid, and we pay our own bid, not theirs.
+Paying our bid is the pessimistic and correct choice — outbidding a rival costs
+more than the rival paid, and pretending otherwise would hand us the upside of
+competition without its cost.
+"""
+
+from __future__ import annotations
+
+from rehoboam.replay.engine import Matchday, run_season
+from rehoboam.replay.market import MarketListing
+from rehoboam.replay.state import ReplayPlayer, ReplayState
+
+DAY = 86400.0
+POS = ["Goalkeeper"] + ["Defender"] * 4 + ["Midfielder"] * 4 + ["Forward"] * 2
+
+
+class FakeMarket:
+    def __init__(self, listings):
+        self.listings = listings
+
+    def available_before(self, at):
+        return [x for x in self.listings if x.transfer_at < at]
+
+
+def _squad():
+    return {str(i): ReplayPlayer(id=str(i), position=POS[i], team_id=str(i)) for i in range(11)}
+
+
+def _run(bid_fn):
+    state = ReplayState(budget=100_000_000, squad=_squad())
+    result = run_season(
+        state=state,
+        market=FakeMarket([MarketListing(player_id="target", price=10_000_000, transfer_at=DAY)]),
+        matchdays=[Matchday(day_number=1, kickoff=10 * DAY, points={})],
+        score_fn=lambda pid, at: 200.0 if pid == "target" else 10.0,
+        mv_fn=lambda pid, at: 10_000_000,
+        position_fn=lambda pid: "Forward",
+        team_fn=lambda pid: pid,
+        bid_fn=bid_fn,
+    )
+    return result, state
+
+
+def test_a_bid_below_the_real_price_loses_the_auction():
+    """The rival paid 10,000,000. Bidding under that must not win."""
+    _result, state = _run(lambda pid, price, at: 9_999_999)
+
+    assert "target" not in state.squad
+
+
+def test_a_bid_above_the_real_price_wins():
+    _result, state = _run(lambda pid, price, at: 11_000_000)
+
+    assert "target" in state.squad
+
+
+def test_the_winner_pays_its_own_bid_not_the_rivals_price():
+    """Outbidding costs more than the rival paid. Charging the rival's price
+    would give us the upside of competition with none of its cost."""
+    _result, state = _run(lambda pid, price, at: 11_000_000)
+
+    assert state.budget == 100_000_000 - 11_000_000
+
+
+def test_without_a_bid_fn_every_wanted_player_is_still_won():
+    """The shipped path is unchanged — competition is opt-in."""
+    _result, state = _run(None)
+
+    assert "target" in state.squad
+    assert state.budget == 100_000_000 - 10_000_000

--- a/tests/test_replay/test_cost_basis.py
+++ b/tests/test_replay/test_cost_basis.py
@@ -1,0 +1,37 @@
+"""REH-68: the replay has to remember what it paid.
+
+`state.buy()` debited the budget and discarded the price, so profit was
+uncomputable and no flip logic could exist. Profit is the difference between
+what we paid and what a player is worth now, so a cost basis is the
+prerequisite for modelling the sell side at all.
+"""
+
+from __future__ import annotations
+
+from rehoboam.replay.state import ReplayPlayer, ReplayState
+
+
+def test_buying_records_what_we_paid():
+    state = ReplayState(budget=50_000_000)
+
+    state.buy(ReplayPlayer(id="p", position="Forward"), 7_000_000, at=1000.0)
+
+    assert state.squad["p"].buy_price == 7_000_000
+
+
+def test_buying_records_when_we_bought():
+    """Hold duration gates a flip — the live ProfitTrader caps holds at 7 days."""
+    state = ReplayState(budget=50_000_000)
+
+    state.buy(ReplayPlayer(id="p", position="Forward"), 7_000_000, at=1234.0)
+
+    assert state.squad["p"].bought_at == 1234.0
+
+
+def test_a_player_with_no_basis_is_not_treated_as_pure_profit():
+    """The opening squad was ASSIGNED, not bought. A basis of zero would make
+    every opening-squad sale read as a 100% gain and hand the replay a fortune
+    it never earned."""
+    player = ReplayPlayer(id="p", position="Forward")
+
+    assert player.buy_price is None, "unknown basis must be explicit, not 0"

--- a/tests/test_replay/test_fieldability_guard.py
+++ b/tests/test_replay/test_fieldability_guard.py
@@ -1,0 +1,63 @@
+"""REH-68: the fieldability guard must agree with the thing that fields.
+
+Symptom: the full-fidelity run booked -300 in empty-slot penalties on matchdays
+where the squad held 12-13 players. Minimum squad size all season was 12, so
+this was never "too few players".
+
+Root cause: two different definitions of "can field eleven".
+
+  can_field_eleven  -> checks POSITION_MINIMUMS only (GK 1, DEF 3, MID 2, FW 1)
+  select_best_eleven-> ALSO enforces _POSITION_MAX_STARTERS ceilings
+                       (GK 1, DEF 5, MID 5, FW 3), because a 2nd keeper can
+                       never start in any formation
+
+So a squad can satisfy every minimum, pass the guard, and still not fill the
+eleven. The guard was a weaker re-implementation of a rule that already had an
+authority. Profit flipping did not introduce this bug; it skewed squad shapes
+enough to expose it.
+"""
+
+from __future__ import annotations
+
+from rehoboam.formation import select_best_eleven
+from rehoboam.replay.rules import can_field_eleven
+from rehoboam.replay.state import ReplayPlayer, ReplayState
+
+
+def _skewed_squad():
+    """13 players meeting every minimum, but 7 of them forwards.
+
+    Ceilings cap selection at 1 GK + 3 DEF + 2 MID + 3 FW = 9, so two starting
+    slots cannot be filled however the eleven is chosen.
+    """
+    squad = {}
+    for i, pos in enumerate(
+        ["Goalkeeper"] + ["Defender"] * 3 + ["Midfielder"] * 2 + ["Forward"] * 7
+    ):
+        squad[str(i)] = ReplayPlayer(id=str(i), position=pos, team_id=str(i))
+    return ReplayState(budget=0, squad=squad)
+
+
+def test_the_skewed_squad_really_cannot_fill_eleven():
+    """Establishes the ground truth the guard has to match."""
+    state = _skewed_squad()
+
+    chosen = select_best_eleven(state.players, {p.id: 1.0 for p in state.players})
+
+    assert len(chosen) < 11, "fixture is wrong if the eleven can actually be filled"
+
+
+def test_the_guard_rejects_a_squad_that_cannot_fill_eleven():
+    """The bug: minimums are satisfied, so the old guard said yes and the
+    engine then sold into an unfieldable shape and ate -100 per empty slot."""
+    assert can_field_eleven(_skewed_squad()) is False
+
+
+def test_the_guard_still_accepts_a_normal_squad():
+    squad = {}
+    for i, pos in enumerate(
+        ["Goalkeeper"] + ["Defender"] * 4 + ["Midfielder"] * 4 + ["Forward"] * 2
+    ):
+        squad[str(i)] = ReplayPlayer(id=str(i), position=pos, team_id=str(i))
+
+    assert can_field_eleven(ReplayState(budget=0, squad=squad)) is True

--- a/tests/test_replay/test_profit_flips.py
+++ b/tests/test_replay/test_profit_flips.py
@@ -1,0 +1,100 @@
+"""REH-68: selling for gain (and cutting losses), not only under duress.
+
+The replay's only sell triggers were "make room for a buy" and "restore
+solvency". The live bot also takes profit at `min_sell_profit_pct` (15%) and
+cuts losses at `max_loss_pct` (-15%), which is a whole revenue behaviour the
+harness never exercised.
+
+Measured expectation, pre-registered: real flipping LOST money — 151 flips,
+net -EUR 55,256,064, 27.8% win rate — so modelling it faithfully should push
+the season result DOWN. A result that improves is a red flag, not a win.
+"""
+
+from __future__ import annotations
+
+from rehoboam.replay.engine import Matchday, run_season
+from rehoboam.replay.state import ReplayPlayer, ReplayState
+
+DAY = 86400.0
+POS = ["Goalkeeper"] + ["Defender"] * 4 + ["Midfielder"] * 4 + ["Forward"] * 2 + ["Forward"]
+
+
+class NoMarket:
+    def available_before(self, at):
+        return []
+
+
+def _squad_of_12(basis: int = 10_000_000):
+    """Twelve players, so one sale still leaves a legal eleven."""
+    return {
+        str(i): ReplayPlayer(
+            id=str(i), position=POS[i], team_id=str(i), buy_price=basis, bought_at=0.0
+        )
+        for i in range(12)
+    }
+
+
+def _run(*, current_mv: int, profit_take_pct=None, loss_cut_pct=None, squad=None):
+    state = ReplayState(budget=10_000_000, squad=squad or _squad_of_12())
+    # Player "11" is the flip candidate; everyone else holds their basis.
+    result = run_season(
+        state=state,
+        market=NoMarket(),
+        matchdays=[Matchday(day_number=1, kickoff=10 * DAY, points={})],
+        score_fn=lambda pid, at: 10.0,
+        mv_fn=lambda pid, at: current_mv if pid == "11" else 10_000_000,
+        position_fn=lambda pid: "Forward",
+        team_fn=lambda pid: pid,
+        profit_take_pct=profit_take_pct,
+        loss_cut_pct=loss_cut_pct,
+    )
+    return result, state
+
+
+def test_a_player_up_twenty_percent_is_sold_for_profit():
+    _result, state = _run(current_mv=12_000_000, profit_take_pct=15.0)
+
+    assert "11" not in state.squad
+
+
+def test_a_player_up_five_percent_is_held():
+    """Below the take-profit threshold — churning him would just pay the
+    ~11.7% buy-side premium again on the way back in."""
+    _result, state = _run(current_mv=10_500_000, profit_take_pct=15.0)
+
+    assert "11" in state.squad
+
+
+def test_a_player_down_twenty_percent_is_cut():
+    _result, state = _run(current_mv=8_000_000, loss_cut_pct=-15.0)
+
+    assert "11" not in state.squad
+
+
+def test_the_proceeds_of_a_profit_sale_reach_the_budget():
+    """Instant sell returns full market value (REH-67)."""
+    _result, state = _run(current_mv=12_000_000, profit_take_pct=15.0)
+
+    assert state.budget == 10_000_000 + 12_000_000
+
+
+def test_flips_never_break_the_starting_eleven():
+    """A squad of exactly eleven has no spare player, so a profitable one must
+    be held regardless — an empty slot costs -100, far more than the gain."""
+    eleven = {
+        str(i): ReplayPlayer(
+            id=str(i), position=POS[i], team_id=str(i), buy_price=10_000_000, bought_at=0.0
+        )
+        for i in range(11)
+    }
+
+    _result, state = _run(current_mv=99_000_000, profit_take_pct=15.0, squad=eleven)
+
+    assert len(state.squad) == 11
+
+
+def test_flipping_is_off_by_default():
+    """The shipped replay path must be unchanged until the run that enables it."""
+    _result, state = _run(current_mv=99_000_000)
+
+    assert "11" in state.squad

--- a/tests/test_replay/test_profit_flips.py
+++ b/tests/test_replay/test_profit_flips.py
@@ -98,3 +98,50 @@ def test_flipping_is_off_by_default():
     _result, state = _run(current_mv=99_000_000)
 
     assert "11" in state.squad
+
+
+def test_a_best_eleven_starter_is_never_flipped():
+    """The live sell logic protects non-displaced best-11 starters
+    (decision.py: "Non-displaced best-11 starters are protected and cannot be
+    sold"). Without this the replay banks a 15% gain by selling the very player
+    it needs on Saturday — trading points for cash it then spends worse.
+    """
+    squad = _squad_of_12()
+    state = ReplayState(budget=10_000_000, squad=squad)
+
+    result = run_season(
+        state=state,
+        market=NoMarket(),
+        matchdays=[Matchday(day_number=1, kickoff=10 * DAY, points={})],
+        # "11" is both the most valuable player and deep in profit: exactly the
+        # player a naive take-profit rule sells and a real manager keeps.
+        score_fn=lambda pid, at: 500.0 if pid == "11" else 10.0,
+        mv_fn=lambda pid, at: 12_000_000 if pid == "11" else 10_000_000,
+        position_fn=lambda pid: "Forward",
+        team_fn=lambda pid: pid,
+        profit_take_pct=15.0,
+    )
+
+    assert "11" in state.squad, "sold a best-eleven starter for a 20% gain"
+    assert result.outcomes[0].sells == 0
+
+
+def test_a_benched_player_in_profit_is_still_flipped():
+    """Protection applies to the eleven, not to the whole squad — otherwise
+    profit taking could never fire at all."""
+    squad = _squad_of_12()
+    state = ReplayState(budget=10_000_000, squad=squad)
+
+    run_season(
+        state=state,
+        market=NoMarket(),
+        matchdays=[Matchday(day_number=1, kickoff=10 * DAY, points={})],
+        # "11" is the WORST player, so he is the one left out of the eleven.
+        score_fn=lambda pid, at: 0.0 if pid == "11" else 100.0,
+        mv_fn=lambda pid, at: 12_000_000 if pid == "11" else 10_000_000,
+        position_fn=lambda pid: "Forward",
+        team_fn=lambda pid: pid,
+        profit_take_pct=15.0,
+    )
+
+    assert "11" not in state.squad

--- a/tests/test_replay/test_rules.py
+++ b/tests/test_replay/test_rules.py
@@ -62,13 +62,18 @@ def test_credit_line_boundary_is_inclusive():
     assert can_buy(state, _p("x"), 35_000_000, team_value=50_000_000)[0] is True
 
 
-def test_can_field_eleven_requires_position_minimums():
+def test_can_field_eleven_accepts_a_shape_that_can_actually_start():
+    """REH-68: this fixture used to be 1 GK / 3 DEF / 6 MID / 1 FW and asserted
+    True, but midfielders cap at 5 across every Kickbase formation, so only ten
+    of those eleven could ever start. The old guard checked position *minimums*
+    only and waved it through. Corrected to a shape that genuinely fields
+    eleven: 1 + 4 + 5 + 1.
+    """
     ok = _squad(
         [("g", "Goalkeeper", "1")]
-        + [(f"d{i}", "Defender", str(i)) for i in range(3)]
-        + [(f"m{i}", "Midfielder", str(i + 10)) for i in range(2)]
+        + [(f"d{i}", "Defender", str(i)) for i in range(4)]
+        + [(f"m{i}", "Midfielder", str(i + 10)) for i in range(5)]
         + [("f", "Forward", "20")]
-        + [(f"x{i}", "Midfielder", str(i + 30)) for i in range(4)]
     )
     assert can_field_eleven(ReplayState(budget=0, squad=ok)) is True
 


### PR DESCRIPTION
The season replay tested about two thirds of the bot. Bid competition and profit flipping were both missing, and because they push opposite ways — flips fund the bidding competition consumes — either alone gives a *more* misleading number than having neither. Both now land together.

## The result

```
Simulated total:    26,684 points
Actual total:       26,172 points
Difference:           +512 points

FINISHING POSITION: 9 of 14

  Zero-point matchdays avoided           +757   exact
  Empty-slot penalties incurred            +0   exact
  Better squad and lineup                -245   medium - buy side is optimistic

Total buys: 19   Total sells: 19   Final budget: EUR 648,648
```

## Do not quote +512

One faithfulness decision — protecting best-eleven starters from being flipped — moved the season total by **6,162 points**. A headline that swings that far on a single modelling choice is fragile, and it is not the finding.

**What survives every configuration is the shape, not the number:**

| Configuration | Total | MD14 term (exact) | Squad/lineup term |
| --- | --- | --- | --- |
| No competition, no flips | +788 | +688 | **+100** |
| Competition, no flips | −1,158 | — | — |
| **Competition + flips** | **+512** | **+757** | **−245** |

The matchday-14 bankruptcy term is consistently **+688 to +757 and exact**. The squad-and-lineup term ranges **+100 to −245** — zero within the noise of the modelling choices.

**The v2 scorer's demonstrated edge is that it would not have gone bankrupt on matchday 14. Its player selection is worth approximately nothing.** That should feed REH-56's ship decision directly, and it argues for a conservative trade policy for 2026/27 rather than an aggressive one.

## What shipped, in five increments

**1. The replay can lose an auction** (`dc20b53`). `run_season` takes `bid_fn`; we win only by bidding above what the real buyer paid, and we pay *our* bid, not theirs — outbidding costs more than the rival paid, and charging their price would hand us the upside of competition with none of its cost. The bid flows through every affordability check, not just the final debit.

Price-based rather than rival-identity based, because that is what the data supports: of 6,610 type-2 rows in `player_transfers`, **100% carry a price but only 51% carry a counterparty**.

**2. SmartBidding is the bidder** (`32d0463`). `make_ep_bid_fn` wires `calculate_ep_bid` in. This is the **first time the harness has ever called SmartBidding** — it previously bought at the listed price, so the tiers REH-55 re-tuned (70/53/43) and the whole overbid stack were unexercised by every prior replay result, including REH-51's original +239.

**3. Profit flipping, and a cost basis to compute it** (`44c6b22`). `ReplayPlayer` now carries `buy_price` / `bought_at`; `state.buy()` previously debited the budget and threw the price away, so profit was literally uncomputable. Both default to `None`, not `0` — the opening squad was *assigned*, and a zero basis would make every opening-squad sale read as a 100% gain. Their basis is market value at the assignment timestamp, mirroring how the live API derives `buy_price` as `market_value - mvgl`.

**4. Fieldability guard fixed** (`62fa10c`) — see below.

**5. Best-eleven starters protected from flipping** (`8b70335`), mirroring `decision.py`: *"Non-displaced best-11 starters are protected and cannot be sold."*

## Two bugs found, one of them latent since REH-51

**The fieldability guard disagreed with the thing that fields.** Symptom: −300 in empty-slot penalties at squad sizes of 12–13, never below eleven. Root cause: two definitions of "can field eleven", and **neither source of truth is complete**:

| Source | Enforces | Misses |
| --- | --- | --- |
| `POSITION_MINIMUMS` | the legal floor (GK 1, DEF 3, MID 2, FW 1) | ceilings — 1 GK / 3 DEF / 2 MID / **7 FW** passes, but forwards cap at 3, so only nine can start |
| `select_best_eleven` | those ceilings | the floor — with **no goalkeeper** it returns eleven outfielders, which is not a legal lineup |

`can_field_eleven` checked only the first. My first fix swapped it for only the second, and `test_make_room_sale_never_strands_the_squad_without_a_goalkeeper` caught it immediately by selling the only keeper. The guard now requires both. Profit flipping did not introduce this — it skewed squad shapes enough to reach a defect latent since REH-51 Task 3.

One existing test **asserted the bug**: its fixture was 1 GK / 3 DEF / **6 MID** / 1 FW, and midfielders cap at 5, so only ten could ever start. Corrected the fixture rather than relaxing the guard to match it.

**A latent bug in increment 1**, caught while wiring increment 2: the bid block sat *before* the marginal gain was computed. On the first listing that is a `NameError`, but Python keeps loop bindings, so from the second matchday it would have silently bid using the **previous candidate's** gain.

## Two of my own claims the data overturned

**The ticket's predicted direction for flips was wrong.** It said flips would push results *up* because they fund bidding. Measured first: **151 real flips, net −€55,256,064, 27.8% win rate.** The ticket was corrected to predict DOWN *before* any code was written, and it went down. Pre-registration is why the later swing back up was read as fragility rather than success.

**"The flip port over-trades badly."** Also wrong. Those 151 flips span 2025-08-10 → 2026-05-15 — the entire season — so the real bot traded roughly **2.5× more** than the replay. The hold window I was about to add would have made the model *less* faithful. The real infidelity was *which* players got flipped, which is what increment 5 fixes.

## Reports no longer lie about their own configuration

Twice the footer asserted a caveat contradicted by the run it described — "models no bid competition" with competition on, then "profit flipping is still unmodelled" with flips on. Hardcoded fidelity text is a defect waiting for the first person who changes the configuration. The footer is now **derived** from the actual flags, including whether the run is complete at all.

## Verification

- **645 passed, 1 skipped** (from 631).
- Two consecutive runs **byte-identical**.
- `logs/training_corpus.db` and `logs/bid_learning.db` SHA-256 **unchanged**.
- `git diff --quiet -- rehoboam/scoring/v2/coefficients.json` → clean.
- `ruff` clean. All pre-existing engine tests pass unmodified except the one that asserted the fieldability bug.
- Every new behaviour is opt-in (`bid_fn`, `profit_take_pct`, `loss_cut_pct` all default to `None`); the shipped replay path is unchanged.

## Still open

- Bid competition pins `offer_count=0` and `trend_change_pct=0.0` — the corpus cannot supply either — so our bids remain an **upper bound** on willingness to pay.
- REH-67's own question is unanswered: a valid buy-side control must equalise **spend**, not trade count.
- The fidelity block should record that flips protect starters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
