### PR TITLE
Restore the bid-sizing gradient on the real-points scale (REH-69)

### DIFF
--- a/rehoboam/bidding_strategy.py
+++ b/rehoboam/bidding_strategy.py
@@ -38,6 +38,46 @@ TIER_MUST_HAVE = 70.0
 TIER_STRONG_UPGRADE = 53.0
 TIER_SOLID_UPGRADE = 43.0
 
+# How much of the budget a signing may consume, as a function of marginal gain.
+#
+# REH-69: the previous rule was inline arithmetic,
+# ``min(0.8, 0.2 + marginal_ep_gain / 50)``, calibrated for the 0-100 index
+# where it ramped 0.30 -> 0.70 across the gains the bot actually saw. On real
+# points EVERY gain clearing the shipped floor of 40 saturates at 0.80, so a
+# +43 signing and a +195 superstar were sized identically — the bot would
+# commit 80% of budget to the first qualifying candidate and be unable to
+# afford the one that mattered next week.
+#
+# The ramp now spans the measured operating range: it starts at the
+# solid-upgrade tier (p50 = 43.1, the weakest candidate worth recommending)
+# and reaches full commitment at p95. Anchoring the top at p95 rather than the
+# observed maximum (176.2) keeps the gradient discriminating across the bulk of
+# real candidates instead of being stretched flat by one outlier.
+BID_FRACTION_MIN = 0.2
+BID_FRACTION_MAX = 0.8
+BID_FULL_COMMIT_GAIN = 82.0
+
+
+def max_bid_fraction(
+    marginal_ep_gain: float,
+    *,
+    ramp_start: float = TIER_SOLID_UPGRADE,
+    full_commit_gain: float = BID_FULL_COMMIT_GAIN,
+) -> float:
+    """Fraction of the budget ceiling this gain justifies committing.
+
+    Linear between ``ramp_start`` and ``full_commit_gain``, clamped to
+    ``[BID_FRACTION_MIN, BID_FRACTION_MAX]`` outside that range. Committing
+    0.8 is the whole war chest, so it should take a gain near the top of the
+    measured distribution, not merely clearing the median.
+    """
+    span = full_commit_gain - ramp_start
+    if span <= 0:  # misconfigured — fail toward caution, not toward spending
+        return BID_FRACTION_MIN
+    progress = (marginal_ep_gain - ramp_start) / span
+    progress = max(0.0, min(1.0, progress))
+    return BID_FRACTION_MIN + progress * (BID_FRACTION_MAX - BID_FRACTION_MIN)
+
 
 # ---------------------------------------------------------------------------
 # Competitor-aware bidding helpers
@@ -136,6 +176,7 @@ class SmartBidding:
         tier_must_have: float = TIER_MUST_HAVE,  # Marginal EP gain bands, real points
         tier_strong_upgrade: float = TIER_STRONG_UPGRADE,
         tier_solid_upgrade: float = TIER_SOLID_UPGRADE,
+        full_commit_gain: float = BID_FULL_COMMIT_GAIN,  # gain earning max budget share
     ):
         self.default_overbid_pct = default_overbid_pct
         self.max_overbid_pct = max_overbid_pct
@@ -150,6 +191,7 @@ class SmartBidding:
         self.tier_must_have = tier_must_have
         self.tier_strong_upgrade = tier_strong_upgrade
         self.tier_solid_upgrade = tier_solid_upgrade
+        self.full_commit_gain = full_commit_gain
 
     def calculate_ep_bid(
         self,
@@ -261,9 +303,14 @@ class SmartBidding:
         # Budget ceiling = current budget + any sell plan recovery
         budget_ceiling = current_budget + (sell_plan.total_recovery if sell_plan else 0)
 
-        # EP-proportional max bid: larger EP gain justifies spending more of the budget
-        max_bid_fraction = min(0.8, 0.2 + marginal_ep_gain / 50)
-        ep_max_bid = int(budget_ceiling * max_bid_fraction)
+        # EP-proportional max bid: larger EP gain justifies spending more of the
+        # budget. See max_bid_fraction for why this is no longer inline (REH-69).
+        bid_fraction = max_bid_fraction(
+            marginal_ep_gain,
+            ramp_start=self.tier_solid_upgrade,
+            full_commit_gain=self.full_commit_gain,
+        )
+        ep_max_bid = int(budget_ceiling * bid_fraction)
 
         # League competitive intelligence
         demand_adjustment = 0.0

--- a/rehoboam/config.py
+++ b/rehoboam/config.py
@@ -163,6 +163,17 @@ class Settings(BaseSettings):
             "Pre-season estimate awaiting live-market validation."
         ),
     )
+    bid_full_commit_gain: float = Field(
+        default=82.0,
+        description=(
+            "Marginal EP gain (real points) at which the bot will commit its "
+            "maximum share of budget to a single signing. Set to p95 = 82.0 of "
+            "the distribution measured 2026-07-31; anchoring here rather than at "
+            "the observed maximum (176.2) keeps bid sizing discriminating across "
+            "the bulk of real candidates instead of being stretched flat by one "
+            "outlier. Pre-season estimate awaiting live-market validation."
+        ),
+    )
     bid_tier_solid_upgrade: float = Field(
         default=43.0,
         description=(

--- a/rehoboam/replay/driver.py
+++ b/rehoboam/replay/driver.py
@@ -360,6 +360,7 @@ def make_ep_bid_fn(
         tier_must_have=_default("bid_tier_must_have"),
         tier_strong_upgrade=_default("bid_tier_strong_upgrade"),
         tier_solid_upgrade=_default("bid_tier_solid_upgrade"),
+        full_commit_gain=_default("bid_full_commit_gain"),
     )
 
     def bid(player_id: str, price: int, at: float, gain: float, budget: int) -> int:

--- a/rehoboam/trader.py
+++ b/rehoboam/trader.py
@@ -21,6 +21,7 @@ from rich.console import Console
 
 from .api import KickbaseAPI
 from .bidding_strategy import (
+    BID_FULL_COMMIT_GAIN,
     TIER_MUST_HAVE,
     TIER_SOLID_UPGRADE,
     TIER_STRONG_UPGRADE,
@@ -95,6 +96,7 @@ class Trader:
             tier_must_have=getattr(settings, "bid_tier_must_have", TIER_MUST_HAVE),
             tier_strong_upgrade=getattr(settings, "bid_tier_strong_upgrade", TIER_STRONG_UPGRADE),
             tier_solid_upgrade=getattr(settings, "bid_tier_solid_upgrade", TIER_SOLID_UPGRADE),
+            full_commit_gain=getattr(settings, "bid_full_commit_gain", BID_FULL_COMMIT_GAIN),
         )
 
     # ------------------------------------------------------------------

--- a/tests/test_bid_gradient.py
+++ b/tests/test_bid_gradient.py
@@ -1,0 +1,62 @@
+"""REH-69: bid sizing must still discriminate on the real-points scale.
+
+`max_bid_fraction = min(0.8, 0.2 + marginal_ep_gain / 50)` was calibrated for
+the 0-100 index, where it ramped 0.30 -> 0.70 across the gains the bot saw.
+On real points every gain that clears the shipped floor of 40 saturates at
+0.80, so a +43 signing and a +195 superstar are sized identically. The bot
+commits 80% of budget to the first qualifying candidate and cannot afford the
+one that matters next week.
+
+REH-55 migrated every NAMED threshold and missed this one because it is
+arithmetic buried mid-function, and because no test asserted the gradient's
+SHAPE — only its endpoints. That missing test class is the point of this file.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rehoboam.bidding_strategy import (
+    BID_FRACTION_MAX,
+    BID_FRACTION_MIN,
+    max_bid_fraction,
+)
+
+
+def test_the_fraction_rises_across_the_real_operating_range():
+    """The regression proper. Every one of these clears the shipped floor of
+    40, so under the old formula they were all identical at 0.80."""
+    solid = max_bid_fraction(43.0)
+    strong = max_bid_fraction(53.0)
+    must_have = max_bid_fraction(70.0)
+    exceptional = max_bid_fraction(82.0)
+
+    assert solid < strong < must_have <= exceptional
+
+
+def test_a_superstar_is_sized_above_a_merely_qualifying_candidate():
+    """The behaviour the saturation destroyed: p50 and the maximum observed
+    gain (176.2) must not be treated as the same commitment."""
+    assert max_bid_fraction(176.2) > max_bid_fraction(43.0)
+
+
+def test_the_fraction_is_clamped_at_both_ends():
+    assert max_bid_fraction(1000.0) == BID_FRACTION_MAX
+    assert max_bid_fraction(0.0) == BID_FRACTION_MIN
+    assert max_bid_fraction(-50.0) == BID_FRACTION_MIN
+
+
+def test_full_commitment_needs_an_exceptional_gain():
+    """0.80 of budget is the whole war chest. It should require a gain near the
+    top of the measured distribution (p95 = 82.0), not merely clearing p50."""
+    assert max_bid_fraction(82.0) == pytest.approx(BID_FRACTION_MAX)
+    assert max_bid_fraction(43.0) < 0.4
+
+
+def test_the_gradient_is_tunable_without_a_deploy():
+    """Like the tiers (REH-55): the first real evidence arrives mid-season."""
+    from rehoboam.config import Settings
+
+    field = Settings.model_fields["bid_full_commit_gain"]
+    assert field.default == pytest.approx(82.0)
+    assert "real points" in (field.description or "").lower()

--- a/tests/test_ep_bidding.py
+++ b/tests/test_ep_bidding.py
@@ -341,13 +341,19 @@ class TestDGWBidding:
     def test_dgw_floors_confidence(self):
         """DGW player bid should reflect higher confidence even when the
         caller passes a low confidence (e.g. from small games_played sample).
+
+        REH-69: the gain here was 25.0, an old-index must-have. On real points
+        that is BELOW the shipped buy floor of 40, so the bot would never
+        consider the player at all -- and once bid sizing discriminated again,
+        it clamped to the minimum budget share and pinned both bids to the
+        asking price, erasing the difference this test exists to check.
         """
         bidding = SmartBidding()
         non_dgw = bidding.calculate_ep_bid(
             asking_price=10_000_000,
             market_value=10_000_000,
             expected_points=80.0,
-            marginal_ep_gain=25.0,
+            marginal_ep_gain=75.0,
             confidence=0.5,
             current_budget=30_000_000,
             trend_change_pct=0.0,
@@ -359,7 +365,7 @@ class TestDGWBidding:
             asking_price=10_000_000,
             market_value=10_000_000,
             expected_points=80.0,
-            marginal_ep_gain=25.0,
+            marginal_ep_gain=75.0,
             confidence=0.5,
             current_budget=30_000_000,
             trend_change_pct=0.0,


### PR DESCRIPTION
Bid sizing lost its gradient in the v2 migration. `bidding_strategy.py` sized the maximum bid as inline arithmetic:

```python
max_bid_fraction = min(0.8, 0.2 + marginal_ep_gain / 50)
```

That divisor was calibrated for the **0–100 index**, where it ramped 0.30 → 0.70 across the gains the bot actually saw. On real points, every gain clearing the shipped floor of 40 saturates:

| marginal gain | max bid fraction |
| --- | --- |
| 5 (old scale) | 0.30 |
| 25 (old must-have) | 0.70 |
| **43 (new solid_upgrade)** | **0.80** |
| **70 (new must_have)** | **0.80** |
| **195 (a superstar)** | **0.80** |

A merely-qualifying signing and a superstar were sized identically. The bot would commit 80% of budget to the first candidate over the floor and then be unable to afford the one that mattered next week — a concrete mechanism for failing to own premium scorers, which is what the gap to the top of the league is made of.

REH-55 migrated every *named* threshold and missed this one, because it is arithmetic buried mid-function and because **no test asserted the gradient's shape, only its endpoints**.

## The fix

`max_bid_fraction()` is now a named, testable function. The ramp spans the measured operating range: it starts at the solid-upgrade tier (p50 = 43.1, the weakest candidate worth recommending) and reaches full commitment at **p95 = 82.0**, exposed as `Settings.bid_full_commit_gain` so it is `.env`-tunable like the tiers.

Anchoring the top at p95 rather than the observed maximum (176.2) keeps the gradient discriminating across the bulk of real candidates instead of being stretched flat by a single outlier. A misconfigured ramp (`span <= 0`) fails toward caution rather than toward spending.

## Effect, measured end-to-end

Since REH-68 the replay actually calls `SmartBidding`, so this is verifiable rather than argued. Full-fidelity run (competition + flips), before → after:

| | Before | After |
| --- | --- | --- |
| Simulated total | 26,684 | **27,714** |
| Difference vs human | +512 | **+1,542** |
| Finishing position | 9 of 14 | **7 of 14** |
| **Better squad and lineup** | **−245** | **+653** |

**That last row partially revises REH-68's conclusion.** Across every previous configuration the squad-and-lineup term sat between +100 and −245 — zero within noise — which is why the standing finding was that the scorer's player selection was worth approximately nothing. It is now clearly positive.

With bid sizing saturated, the bot could not express its ranking in its bids: every qualifying candidate drew the same 80% commitment, so a better ranking bought nothing. Given a working gradient, the ranking starts paying. This should be carried into REH-56's ship decision.

**Do not over-read it.** +653 is ~19 points per matchday on ~800, from one run; the buy side remains an upper bound because `offer_count` is pinned at 0; and one faithfulness decision moved the season total by 6,162 points in REH-68. 7th of 14 is not winning — the top two remain ~10,000 points clear.

## Test fixtures

`test_dgw_floors_confidence` used `marginal_ep_gain=25.0`, an old-index must-have. On real points that is **below the shipped buy floor of 40**, so the bot would never consider the player — and once bid sizing discriminated again, the gain clamped to the minimum budget share and pinned both bids to the asking price, erasing the difference the test exists to check. Re-pointed to 75.0 rather than relaxing the assertion.

That is the **fourth** bug of this class (tier thresholds, the 0.95 sell rate, this gradient, this fixture), which is why REH-73 exists.

## Verification

- **650 passed, 1 skipped** (from 645). `tests/test_bid_gradient.py` adds the missing shape-assertion class.
- Two consecutive replay runs **byte-identical**.
- Both DBs SHA-256 **unchanged**; `coefficients.json` unchanged.
- `ruff` clean.
- Wired at both construction sites — `trader.py` for the live bot and `replay/driver.py` for the harness — each reading the shipped `Settings` default so a production re-tune cannot leave either behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
