### PR TITLE
REH-71: decide the flip policy — auto mode stops trading for profit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,12 @@ MIN_SELL_PROFIT_PCT=5.0
 # Maximum loss percentage before auto-selling (e.g., -3 means sell at 3% loss)
 MAX_LOSS_PCT=-3.0
 
+# REH-71: buy players for expected appreciation rather than expected points (default off — flipping lost EUR 55.3M in 2025/26)
+ENABLE_FLIP_BUYS=false
+
+# REH-71: take profit / cut losses on squad players against their cost basis (default off — flipping lost EUR 55.3M in 2025/26)
+ENABLE_PROFIT_SELLS=false
+
 ## Minimum market value increase to consider buying (e.g., 10 means player value went up 10%)
 MIN_BUY_VALUE_INCREASE_PCT=10.0
 

--- a/docs/superpowers/plans/2026-08-05-reh-71-flip-policy.md
+++ b/docs/superpowers/plans/2026-08-05-reh-71-flip-policy.md
@@ -1,0 +1,1898 @@
+# REH-71 Flip Policy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Model the live bot's profit-flip *buys* in the season replay, then run a 2×2 factorial over flip buys × profit sells and encode the verdict in two `Settings` switches.
+
+**Architecture:** A new `rehoboam/replay/flip_buys.py` builds corpus-derived inputs (truncated market-value history, average points) and feeds them to the *real shipped* `TrendService.analyze` and `ProfitTrader.find_profit_opportunities` — the same "call the real object" seam `driver.make_ep_bid_fn` uses for `SmartBidding`. The engine gains a `flip_buy_fn` hook that runs after the EP buy loop with whatever squad slots remain. Flip P&L is tracked in a cash ledger reported separately from the points attribution table, because euros cannot be subtracted from points.
+
+**Tech Stack:** Python 3.12, `uv`, pytest, SQLite (`logs/training_corpus.db`, `logs/bid_learning.db`), Typer CLI, Pydantic `Settings`.
+
+**Spec:** `docs/superpowers/specs/2026-08-05-reh-71-flip-policy-design.md`
+
+## Global Constraints
+
+- **Read-only against real data.** Both DB SHA-256s unchanged; `rehoboam/scoring/v2/coefficients.json` byte-identical. Verify before and after Task 12.
+- **Deterministic.** Two consecutive runs of the same arm must be byte-identical. No `Date.now()`-style nondeterminism, no dict-iteration-order dependence.
+- **Shipped path unchanged by default.** New behaviour arrives as explicit parameters defaulting to off, exactly as `profit_take_pct` / `loss_cut_pct` did in REH-68.
+- **No heuristic reimplementation.** `TrendService.analyze` and `ProfitTrader.find_profit_opportunities` are called, never copied.
+- **Leak boundary.** Every input to a matchday-N decision is truncated strictly before N's kickoff, using `decide_at = kickoff - DECISION_LEAD_SECONDS`.
+- **Run once per arm** in Task 12. Credibility decays with every tuning iteration.
+- **Positions** are the strings `"Goalkeeper"`, `"Defender"`, `"Midfielder"`, `"Forward"`.
+- **Style:** `uv run black rehoboam/ tests/` and `uv run ruff check rehoboam/ tests/ --fix` before each commit. Do NOT run `black` on unrelated files — the repo is not black-clean and whole-file formatting causes massive collateral churn.
+- **Branch:** `feat/reh-71-flip-policy`, already created. Never commit to `main`.
+
+______________________________________________________________________
+
+### Task 1: The `CorpusMarketPlayer` adapter
+
+`ProfitTrader` reads a handful of attributes off each market player. The corpus cannot build a real `kickbase_client.MarketPlayer` (dozens of live-API fields), so we supply a stand-in — and a contract test that fails loudly if `ProfitTrader` ever starts reading something new.
+
+**Files:**
+
+- Create: `rehoboam/replay/flip_buys.py`
+- Test: `tests/test_replay/test_flip_buys.py`
+
+**Interfaces:**
+
+- Consumes: nothing.
+
+- Produces: `CorpusMarketPlayer(id: str, price: int, market_value: int, average_points: float, position: str, status: int = 0, first_name: str = "", last_name: str = "")` — a frozen dataclass.
+
+- [ ] **Step 1: Write the failing contract test**
+
+```python
+"""REH-71: model the live bot's profit-flip BUYS inside the replay.
+
+The replay already models profit-taking sells (`engine._flip_sells`). The live
+bot also buys purely for expected appreciation (`auto_trader.py:342-392` ->
+`Trader.find_profit_opportunities` -> `ProfitTrader`), and the real
+-EUR 55.3M came from both halves. Deciding the flip policy from the sell half
+alone answers a question nobody asked.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+
+from rehoboam.replay.flip_buys import CorpusMarketPlayer
+
+
+def _attributes_read_off(name: str, *functions) -> set[str]:
+    """Every `<name>.<attr>` read anywhere in the given functions."""
+    found: set[str] = set()
+    for fn in functions:
+        tree = ast.parse(textwrap.dedent(inspect.getsource(fn)))
+        found |= {
+            node.attr
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Name)
+            and node.value.id == name
+        }
+    return found
+
+
+def test_the_adapter_satisfies_every_attribute_profit_trader_reads():
+    """A contract test, not a formality. ProfitTrader is shipped code this
+    module does not own. If it grows a new attribute read, the replay would
+    raise AttributeError deep inside a season run, most likely on one matchday
+    of thirty-four. Fail here instead.
+    """
+    from rehoboam.profit_trader import ProfitTrader
+
+    read = _attributes_read_off(
+        "player",
+        ProfitTrader.find_profit_opportunities,
+        ProfitTrader._calculate_risk,
+    )
+
+    missing = read - set(CorpusMarketPlayer.__dataclass_fields__)
+    assert not missing, f"ProfitTrader reads attributes the adapter lacks: {missing}"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_replay/test_flip_buys.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'rehoboam.replay.flip_buys'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+"""Model the live bot's profit-flip BUYS inside the replay (REH-71).
+
+Nothing here reimplements a heuristic. `TrendService.analyze` and
+`ProfitTrader.find_profit_opportunities` are called for real, exactly as
+`driver.make_ep_bid_fn` calls the real `SmartBidding` -- so a change to either
+shipped rule shows up in the replay instead of silently drifting from it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CorpusMarketPlayer:
+    """The attribute surface `ProfitTrader.find_profit_opportunities` reads.
+
+    Deliberately a stand-in for `kickbase_client.MarketPlayer` rather than the
+    real thing: the real one is built from a live API payload carrying dozens of
+    fields the corpus cannot supply, and constructing it would mean inventing
+    values that then look authoritative.
+
+    `price == market_value` at every construction site is not an oversight --
+    see `make_flip_buy_fn` for why feeding a real transaction price here
+    silently disables the entire pass.
+    """
+
+    id: str
+    price: int
+    market_value: int
+    average_points: float
+    position: str
+    status: int = 0
+    first_name: str = ""
+    last_name: str = ""
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_replay/test_flip_buys.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+uv run black rehoboam/replay/flip_buys.py tests/test_replay/test_flip_buys.py
+uv run ruff check rehoboam/replay/flip_buys.py tests/test_replay/test_flip_buys.py --fix
+git add rehoboam/replay/flip_buys.py tests/test_replay/test_flip_buys.py
+git commit -m "feat(replay): adapter for the attribute surface ProfitTrader reads (REH-71)"
+```
+
+______________________________________________________________________
+
+### Task 2: Leak-free truncated market-value history
+
+`TrendService.analyze` wants the raw API history shape. We rebuild it from `mv_series`, truncated at the decision timestamp.
+
+The subtle part: `analyze` computes `peak_value = max(api_peak, data_peak, current)`. Passing `hmv` at all risks leaking the season-wide peak into `ProfitTrader`'s mean-reversion branch, which gates on `current_vs_peak_pct < -25`. Omitting `hmv`/`lmv` makes the peak fall out of the truncated series alone — leak-free by construction rather than by care.
+
+**Files:**
+
+- Modify: `rehoboam/replay/flip_buys.py`
+- Test: `tests/test_replay/test_flip_buys.py`
+
+**Interfaces:**
+
+- Consumes: `TrainingCorpus` (`rehoboam/enrichment/corpus.py`), whose `mv_series.snapshot_at` is exactly `dt × 86400`.
+
+- Produces: `history_at(corpus: TrainingCorpus, player_id: str, at: float) -> dict` returning `{"it": [{"dt": int, "mv": int}, ...]}`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_replay/test_flip_buys.py`:
+
+```python
+import sqlite3
+
+from rehoboam.enrichment.corpus import TrainingCorpus
+from rehoboam.replay.flip_buys import history_at
+
+DAY = 86400.0
+
+
+def _corpus_with_mv(tmp_path, series: list[tuple[float, int]]) -> TrainingCorpus:
+    corpus = TrainingCorpus(tmp_path / "corpus.db")
+    with sqlite3.connect(corpus.db_path) as conn:
+        conn.executemany(
+            "INSERT OR REPLACE INTO mv_series (player_id, snapshot_at, market_value) "
+            "VALUES ('p1', ?, ?)",
+            series,
+        )
+        conn.commit()
+    return corpus
+
+
+def test_history_stops_strictly_before_the_decision_time(tmp_path):
+    corpus = _corpus_with_mv(tmp_path, [(1 * DAY, 100), (2 * DAY, 200), (3 * DAY, 300)])
+
+    history = history_at(corpus, "p1", 3 * DAY)
+
+    assert [item["mv"] for item in history["it"]] == [100, 200]
+
+
+def test_a_future_spike_cannot_reach_the_peak(tmp_path):
+    """The leak that matters. ProfitTrader's mean-reversion branch gates on
+    `current_vs_peak_pct < -25` (profit_trader.py:172-175). A season-wide peak
+    would let the bot know in August what a player is worth in March.
+    """
+    from rehoboam.services.trend_service import TrendService
+
+    corpus = _corpus_with_mv(
+        tmp_path, [(1 * DAY, 100), (2 * DAY, 110), (9 * DAY, 10_000)]
+    )
+
+    analysis = TrendService.analyze(history_at(corpus, "p1", 3 * DAY), 110)
+
+    assert analysis.peak_value == 110
+
+
+def test_days_since_epoch_round_trips_exactly(tmp_path):
+    """`record_mv_series` stores `dt * 86400`; `analyze` sorts on `dt`. A lossy
+    round trip would silently reorder the series."""
+    corpus = _corpus_with_mv(tmp_path, [(7 * DAY, 500)])
+
+    assert history_at(corpus, "p1", 8 * DAY)["it"] == [{"dt": 7, "mv": 500}]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_replay/test_flip_buys.py -v -k history or spike or round_trips`
+Expected: FAIL with `ImportError: cannot import name 'history_at'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `rehoboam/replay/flip_buys.py` (add `import sqlite3` and the `TrainingCorpus` import at the top):
+
+```python
+SECONDS_PER_DAY = 86400.0
+
+
+def history_at(corpus: TrainingCorpus, player_id: str, at: float) -> dict:
+    """A `TrendService.analyze`-shaped history, truncated strictly before ``at``.
+
+    ``hmv``/``lmv`` are deliberately omitted rather than computed. ``analyze``
+    derives ``peak_value = max(api_peak, data_peak, current)`` and
+    ``low_value = min(v for v in [api_low, data_low, current] if v > 0)``, so an
+    absent key drops out of both and the extremes come from the truncated series
+    alone. Supplying the season-wide peak would leak the future into
+    ``ProfitTrader``'s mean-reversion branch.
+
+    ``snapshot_at`` is exactly ``dt * 86400`` (``corpus.record_mv_series``), so
+    the round trip back to ``dt`` is lossless.
+    """
+    with sqlite3.connect(corpus.db_path) as conn:
+        rows = conn.execute(
+            "SELECT snapshot_at, market_value FROM mv_series "
+            "WHERE player_id = ? AND snapshot_at < ? ORDER BY snapshot_at",
+            (str(player_id), float(at)),
+        ).fetchall()
+    return {
+        "it": [
+            {"dt": int(snapshot / SECONDS_PER_DAY), "mv": int(mv)}
+            for snapshot, mv in rows
+        ]
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_replay/test_flip_buys.py -v`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+uv run black rehoboam/replay/flip_buys.py tests/test_replay/test_flip_buys.py
+uv run ruff check rehoboam/replay/flip_buys.py tests/test_replay/test_flip_buys.py --fix
+git add rehoboam/replay/flip_buys.py tests/test_replay/test_flip_buys.py
+git commit -m "feat(replay): leak-free truncated MV history for the trend model (REH-71)"
+```
+
+______________________________________________________________________
+
+### Task 3: Leak-free average points
+
+`ProfitTrader` gates hard on `average_points` — `MIN_AVG_POINTS = 20.0` at `profit_trader.py:129`, plus thresholds of 30/40/50 across its appreciation branches. We derive it from `player_match_history` using the same `matches_before` boundary the v2 scorer uses, so the flip path and the EP path cannot disagree about what was knowable.
+
+**Files:**
+
+- Modify: `rehoboam/replay/flip_buys.py`
+- Test: `tests/test_replay/test_flip_buys.py`
+
+**Interfaces:**
+
+- Consumes: `matches_before(matches, *, season, day_number)` from `rehoboam/backtest/snapshot.py`; `corpus.matches_for_player(player_id)` returning dicts with `season`, `day_number`, `points`, `status`.
+
+- Produces: `average_points_at(corpus, player_id, *, season: str, day_number: int) -> float`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_replay/test_flip_buys.py`:
+
+```python
+from rehoboam.replay.flip_buys import average_points_at
+
+SEASON = "2025/2026"
+
+
+def _corpus_with_matches(tmp_path, rows: list[tuple[int, int, int]]) -> TrainingCorpus:
+    """rows: (day_number, points, status)."""
+    corpus = TrainingCorpus(tmp_path / "corpus.db")
+    with sqlite3.connect(corpus.db_path) as conn:
+        conn.executemany(
+            "INSERT OR REPLACE INTO player_match_history "
+            "(player_id, season, day_number, points, minutes, is_home, status) "
+            "VALUES ('p1', ?, ?, ?, 90, 1, ?)",
+            [(SEASON, day, points, status) for day, points, status in rows],
+        )
+        conn.commit()
+    return corpus
+
+
+def test_average_points_ignores_matchdays_at_or_after_the_cutoff(tmp_path):
+    corpus = _corpus_with_matches(tmp_path, [(1, 100, 5), (2, 200, 5), (3, 900, 5)])
+
+    assert average_points_at(corpus, "p1", season=SEASON, day_number=3) == 150.0
+
+
+def test_only_appearances_count_towards_the_average(tmp_path):
+    """Kickbase's own average is per appearance. Averaging in matchdays the
+    player was not in the squad (status 1) or sat unused (status 4) drags a fit
+    player under ProfitTrader's MIN_AVG_POINTS gate of 20 and silently removes
+    him from every flip branch.
+    """
+    corpus = _corpus_with_matches(tmp_path, [(1, 60, 5), (2, 0, 1), (3, 0, 4)])
+
+    assert average_points_at(corpus, "p1", season=SEASON, day_number=4) == 60.0
+
+
+def test_a_player_with_no_appearances_averages_zero(tmp_path):
+    corpus = _corpus_with_matches(tmp_path, [(1, 0, 1)])
+
+    assert average_points_at(corpus, "p1", season=SEASON, day_number=2) == 0.0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_replay/test_flip_buys.py -v -k average`
+Expected: FAIL with `ImportError: cannot import name 'average_points_at'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `rehoboam/replay/flip_buys.py`:
+
+```python
+# Statuses in which the player actually took the pitch: 3 = came on as a sub,
+# 5 = started. Deliberately NARROWER than `driver.PLAYED_STATUSES`, which is
+# (1, 3, 4, 5) because the availability model needs a fitted rate for every
+# state including "not in squad". Kickbase's own average points is per
+# APPEARANCE, so counting non-appearances here would understate every player.
+APPEARANCE_STATUSES = (3, 5)
+
+
+def average_points_at(
+    corpus: TrainingCorpus, player_id: str, *, season: str, day_number: int
+) -> float:
+    """Mean points per appearance over matches strictly before ``day_number``.
+
+    Reuses the v2 scorer's ``matches_before`` boundary rather than introducing a
+    second truncation rule, so the flip path and the EP path cannot disagree
+    about what was knowable at the decision instant.
+    """
+    from rehoboam.backtest.snapshot import matches_before
+
+    history = matches_before(
+        corpus.matches_for_player(player_id), season=season, day_number=day_number
+    )
+    played = [m for m in history if m.get("status") in APPEARANCE_STATUSES]
+    if not played:
+        return 0.0
+    return sum(float(m["points"] or 0) for m in played) / len(played)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_replay/test_flip_buys.py -v`
+Expected: PASS (7 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+uv run black rehoboam/replay/flip_buys.py tests/test_replay/test_flip_buys.py
+uv run ruff check rehoboam/replay/flip_buys.py tests/test_replay/test_flip_buys.py --fix
+git add rehoboam/replay/flip_buys.py tests/test_replay/test_flip_buys.py
+git commit -m "feat(replay): leak-free average points per appearance (REH-71)"
+```
+
+______________________________________________________________________
+
+### Task 4: The economic bid ceiling for a flip
+
+Rivals can target the same flip candidate, so flips face the competition model too. But `make_ep_bid_fn` is the wrong bidder: it sizes from `marginal_ep_gain`, which is ~0 for a flip by construction, so every flip bid would land in the bottom tier and lose — collapsing arms C and D into A and B as a pure artifact.
+
+A flip bids on its own economics: pay at most what still leaves the margin `ProfitTrader` demands, given the exit returns `MV × 1.00`.
+
+**Files:**
+
+- Modify: `rehoboam/replay/flip_buys.py`
+- Test: `tests/test_replay/test_flip_buys.py`
+
+**Interfaces:**
+
+- Consumes: `INSTANT_SELL_PCT` from `rehoboam/replay/engine.py` (currently `1.0`).
+
+- Produces: `flip_bid_ceiling(market_value: int, expected_appreciation: float, *, min_profit_pct: float) -> int`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_replay/test_flip_buys.py`:
+
+```python
+from rehoboam.replay.flip_buys import flip_bid_ceiling
+
+
+def test_the_ceiling_leaves_the_required_margin_intact():
+    """Buy at the ceiling, sell at the appreciated value, and the round trip
+    still returns exactly min_profit_pct."""
+    ceiling = flip_bid_ceiling(10_000_000, 20.0, min_profit_pct=8.0)
+
+    exit_value = 10_000_000 * 1.20
+    realised_pct = (exit_value - ceiling) / ceiling * 100
+
+    assert abs(realised_pct - 8.0) < 0.01
+
+
+def test_a_bigger_expected_move_justifies_a_bigger_bid():
+    """The gradient must discriminate across the operating range -- the missing
+    test class that let REH-69 ship a saturated bid function."""
+    low = flip_bid_ceiling(10_000_000, 10.0, min_profit_pct=8.0)
+    mid = flip_bid_ceiling(10_000_000, 20.0, min_profit_pct=8.0)
+    high = flip_bid_ceiling(10_000_000, 40.0, min_profit_pct=8.0)
+
+    assert low < mid < high
+
+
+def test_a_flip_with_no_expected_upside_bids_below_market_value():
+    """Otherwise the bot pays full price for a player it expects to stagnate."""
+    assert flip_bid_ceiling(10_000_000, 0.0, min_profit_pct=8.0) < 10_000_000
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_replay/test_flip_buys.py -v -k ceiling or bigger or upside`
+Expected: FAIL with `ImportError: cannot import name 'flip_bid_ceiling'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `rehoboam/replay/flip_buys.py`:
+
+```python
+def flip_bid_ceiling(
+    market_value: int, expected_appreciation: float, *, min_profit_pct: float
+) -> int:
+    """The most a flip can rationally cost and still clear its own margin.
+
+    A flip bought at ``P`` exits at ``MV x (1 + a/100) x INSTANT_SELL_PCT``,
+    where ``INSTANT_SELL_PCT`` is 1.00 as measured in REH-67. Requiring the
+    round trip to still return ``min_profit_pct`` gives::
+
+        P <= MV x (1 + a/100) / (1 + m/100)
+
+    Bidding above this guarantees a loss even when the expected appreciation
+    fully materialises, so losing a listing to a rival who paid more is the
+    correct outcome, not a modelling failure.
+
+    Deliberately NOT `SmartBidding.calculate_ep_bid`: that sizes an overbid from
+    the marginal-gain tier, and a flip's marginal EP gain is ~0 by construction,
+    so every flip would bid into the bottom tier and lose every contested
+    listing -- reporting "flip buys do nothing" as an artifact of the bidder
+    rather than a fact about flipping.
+    """
+    from rehoboam.replay.engine import INSTANT_SELL_PCT
+
+    exit_value = market_value * (1.0 + expected_appreciation / 100.0) * INSTANT_SELL_PCT
+    return int(exit_value / (1.0 + min_profit_pct / 100.0))
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_replay/test_flip_buys.py -v`
+Expected: PASS (10 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+uv run black rehoboam/replay/flip_buys.py tests/test_replay/test_flip_buys.py
+uv run ruff check rehoboam/replay/flip_buys.py tests/test_replay/test_flip_buys.py --fix
+git add rehoboam/replay/flip_buys.py tests/test_replay/test_flip_buys.py
+git commit -m "feat(replay): bid flips on their own economics, not on EP gain (REH-71)"
+```
+
+______________________________________________________________________
+
+### Task 5: Wire the real `ProfitTrader` into a candidate function
+
+Composes Tasks 1-4 into the callable the engine will invoke once per matchday.
+
+**Files:**
+
+- Modify: `rehoboam/replay/flip_buys.py`
+- Test: `tests/test_replay/test_flip_buys.py`
+
+**Interfaces:**
+
+- Consumes: `CorpusMarketPlayer`, `history_at`, `average_points_at`, `flip_bid_ceiling`; `TrendService.analyze`; `ProfitTrader.find_profit_opportunities`.
+
+- Produces:
+
+  - `FlipCandidate(player_id: str, market_value: int, expected_appreciation: float, max_bid: int)` — frozen dataclass.
+  - `make_flip_buy_fn(corpus, *, season: str, day_fn: Callable[[float], int], position_fn: Callable[[str], str | None]) -> Callable[[list, float, int, int], list[FlipCandidate]]`. The returned callable takes `(listings, at, budget, team_value)` and returns candidates in `ProfitTrader`'s own preference order.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_replay/test_flip_buys.py`:
+
+```python
+from rehoboam.replay.flip_buys import FlipCandidate, make_flip_buy_fn
+from rehoboam.replay.market import MarketListing
+
+
+def _rising_corpus(tmp_path) -> TrainingCorpus:
+    """A player on a steady climb who also scores well -- the shape
+    ProfitTrader's `rising` branch is looking for."""
+    corpus = TrainingCorpus(tmp_path / "corpus.db")
+    with sqlite3.connect(corpus.db_path) as conn:
+        conn.executemany(
+            "INSERT OR REPLACE INTO mv_series (player_id, snapshot_at, market_value) "
+            "VALUES ('p1', ?, ?)",
+            [(day * DAY, 10_000_000 + day * 400_000) for day in range(1, 31)],
+        )
+        conn.executemany(
+            "INSERT OR REPLACE INTO player_match_history "
+            "(player_id, season, day_number, points, minutes, is_home, status) "
+            "VALUES ('p1', ?, ?, ?, 90, 1, 5)",
+            [(SEASON, day, 80) for day in range(1, 5)],
+        )
+        conn.commit()
+    return corpus
+
+
+def _candidates(corpus, at: float):
+    fn = make_flip_buy_fn(
+        corpus,
+        season=SEASON,
+        day_fn=lambda _at: 10,
+        position_fn=lambda _pid: "Forward",
+    )
+    listings = [MarketListing(player_id="p1", price=11_000_000, transfer_at=at - DAY)]
+    return fn(listings, at, 50_000_000, 100_000_000)
+
+
+def test_a_rising_high_scorer_is_offered_as_a_flip_candidate(tmp_path):
+    """The regression test that matters most. If the adapter fed ProfitTrader a
+    real transaction price instead of market value, EVERY candidate would take
+    the non-Kickbase branch, `value_gap` would be negative, and the whole pass
+    would return an empty list on every matchday while appearing to work.
+    """
+    found = _candidates(_rising_corpus(tmp_path), 31 * DAY)
+
+    assert [c.player_id for c in found] == ["p1"]
+
+
+def test_the_candidate_carries_an_economically_sized_max_bid(tmp_path):
+    found = _candidates(_rising_corpus(tmp_path), 31 * DAY)
+
+    assert found[0].max_bid == flip_bid_ceiling(
+        found[0].market_value, found[0].expected_appreciation, min_profit_pct=8.0
+    )
+
+
+def test_a_player_with_no_market_value_is_skipped(tmp_path):
+    """`market_value_at` returns None outside the recorded series; a zero-value
+    adapter would divide by zero inside the trend model."""
+    corpus = TrainingCorpus(tmp_path / "corpus.db")
+
+    assert _candidates(corpus, 31 * DAY) == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_replay/test_flip_buys.py -v -k candidate or max_bid or no_market_value`
+Expected: FAIL with `ImportError: cannot import name 'FlipCandidate'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `rehoboam/replay/flip_buys.py` (add `from collections.abc import Callable` at the top):
+
+```python
+# Thresholds read from `Trader.find_profit_opportunities`'s call site
+# (trader.py:715-721), NOT from `ProfitTrader.__init__`'s defaults, which no
+# caller in the codebase actually uses.
+FLIP_MIN_PROFIT_PCT = 8.0
+FLIP_MAX_HOLD_DAYS = 7
+FLIP_MAX_RISK_SCORE = 60.0
+# The live path scores only the first 50 market entries (trader.py:711).
+FLIP_MARKET_SCAN_LIMIT = 50
+
+
+@dataclass(frozen=True)
+class FlipCandidate:
+    """A player worth buying for appreciation, with what he is worth paying."""
+
+    player_id: str
+    market_value: int
+    expected_appreciation: float
+    max_bid: int
+
+
+def make_flip_buy_fn(
+    corpus: TrainingCorpus,
+    *,
+    season: str,
+    day_fn: Callable[[float], int],
+    position_fn: Callable[[str], str | None],
+) -> Callable[[list, float, int, int], list[FlipCandidate]]:
+    """Rank flip candidates with the bot's own profit-trading logic (REH-71).
+
+    DECISION PRICE vs EXECUTION PRICE. The adapter reports
+    ``price == market_value`` while the engine pays a bid derived from
+    ``flip_bid_ceiling``. This is not a fudge. The live bot only ever flips
+    ``is_kickbase_seller()`` listings (trader.py:685), where the two are equal by
+    construction, and ``ProfitTrader`` *branches* on that equality
+    (profit_trader.py:121). Feeding it a real transaction price -- which averages
+    1.117x market value -- sends every candidate down the non-Kickbase branch,
+    where ``value_gap`` is negative and the candidate is dropped at
+    profit_trader.py:194. The pass would look modelled and never fire once.
+
+    ``status`` is pinned to 0 (available) because the corpus's per-match status
+    is participation, not injury. Nothing is therefore skipped as injured, so
+    this buys MORE flips than the live bot would -- an upper bound on flip
+    activity, and hence on flip harm.
+    """
+    from rehoboam.profit_trader import ProfitTrader
+    from rehoboam.services.trend_service import TrendService
+
+    trader = ProfitTrader(
+        min_profit_pct=FLIP_MIN_PROFIT_PCT,
+        max_hold_days=FLIP_MAX_HOLD_DAYS,
+        max_risk_score=FLIP_MAX_RISK_SCORE,
+    )
+
+    def candidates(
+        listings: list, at: float, budget: int, team_value: int
+    ) -> list[FlipCandidate]:
+        day = day_fn(at)
+        players: list[CorpusMarketPlayer] = []
+        trends: dict[str, dict] = {}
+
+        for listing in listings[:FLIP_MARKET_SCAN_LIMIT]:
+            pid = listing.player_id
+            market_value = corpus.market_value_at(pid, at)
+            position = position_fn(pid)
+            if not market_value or not position:
+                continue
+            players.append(
+                CorpusMarketPlayer(
+                    id=pid,
+                    price=market_value,
+                    market_value=market_value,
+                    average_points=average_points_at(
+                        corpus, pid, season=season, day_number=day
+                    ),
+                    position=position,
+                )
+            )
+            trends[pid] = TrendService.analyze(
+                history_at(corpus, pid, at), market_value
+            ).to_dict()
+
+        opportunities = trader.find_profit_opportunities(
+            market_players=players,
+            current_budget=budget,
+            player_trends=trends,
+            team_value=team_value,
+        )
+        return [
+            FlipCandidate(
+                player_id=o.player.id,
+                market_value=o.market_value,
+                expected_appreciation=o.expected_appreciation,
+                max_bid=flip_bid_ceiling(
+                    o.market_value,
+                    o.expected_appreciation,
+                    min_profit_pct=FLIP_MIN_PROFIT_PCT,
+                ),
+            )
+            for o in opportunities
+        ]
+
+    return candidates
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_replay/test_flip_buys.py -v`
+Expected: PASS (13 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+uv run black rehoboam/replay/flip_buys.py tests/test_replay/test_flip_buys.py
+uv run ruff check rehoboam/replay/flip_buys.py tests/test_replay/test_flip_buys.py --fix
+git add rehoboam/replay/flip_buys.py tests/test_replay/test_flip_buys.py
+git commit -m "feat(replay): call the real ProfitTrader to rank flip buys (REH-71)"
+```
+
+______________________________________________________________________
+
+### Task 6: Engine integration — the flip-buy pass
+
+Runs after the EP buy loop with whatever slots remain, mirroring `auto_trader.py:533`.
+
+**Files:**
+
+- Modify: `rehoboam/replay/engine.py`
+- Test: `tests/test_replay/test_flip_buy_pass.py`
+
+**Interfaces:**
+
+- Consumes: objects with `.player_id`, `.market_value`, `.expected_appreciation`, `.max_bid` (duck-typed, so the engine need not import `flip_buys` and risk a cycle).
+
+- Produces: `run_season(..., flip_buy_fn: Callable[[list, float, int, int], list] | None = None)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_replay/test_flip_buy_pass.py`:
+
+```python
+"""REH-71: the replay buys for appreciation, not only for points.
+
+The live bot buys flip candidates with whatever squad slots the EP pass leaves
+(auto_trader.py:533). A flip never displaces a squad member -- the live bot does
+not sell to make room for one -- so the pass simply stops at MAX_SQUAD_SIZE.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from rehoboam.replay.engine import Matchday, run_season
+from rehoboam.replay.market import MarketListing
+from rehoboam.replay.state import ReplayPlayer, ReplayState
+
+DAY = 86400.0
+# Fifteen slots, ordered so that _squad(12) is a legal eleven-fieldable squad
+# (1 GK / 5 DEF / 4 MID / 2 FW) with midfield still below the formation ceiling
+# of 5 -- otherwise `_would_create_dead_weight` refuses the candidate and every
+# assertion below fails for a reason unrelated to what it is testing.
+POS = (
+    ["Goalkeeper"]
+    + ["Defender"] * 5
+    + ["Midfielder"] * 4
+    + ["Forward"] * 3
+    + ["Goalkeeper"]
+    + ["Midfielder"]
+)
+
+
+@dataclass(frozen=True)
+class FakeCandidate:
+    player_id: str
+    market_value: int
+    expected_appreciation: float
+    max_bid: int
+
+
+class OneListing:
+    def __init__(self, price: int) -> None:
+        self.price = price
+
+    def available_before(self, at):
+        return [MarketListing(player_id="new", price=self.price, transfer_at=at - DAY)]
+
+
+def _squad(n: int, basis: int = 10_000_000):
+    return {
+        str(i): ReplayPlayer(
+            id=str(i), position=POS[i], team_id=str(i), buy_price=basis, bought_at=0.0
+        )
+        for i in range(n)
+    }
+
+
+def _run(
+    *, squad_size: int, listing_price: int, max_bid: int, budget: int = 50_000_000
+):
+    state = ReplayState(budget=budget, squad=_squad(squad_size))
+    result = run_season(
+        state=state,
+        market=OneListing(listing_price),
+        matchdays=[Matchday(day_number=1, kickoff=10 * DAY, points={})],
+        # High floor so the EP pass never buys; the flip pass is what we measure.
+        min_ep_gain=1_000_000.0,
+        score_fn=lambda pid, at: 10.0,
+        mv_fn=lambda pid, at: 10_000_000,
+        # Midfield sits at 4 of a maximum 5, so the candidate is a real upgrade
+        # slot rather than permanent dead weight.
+        position_fn=lambda pid: "Midfielder",
+        team_fn=lambda pid: pid,
+        flip_buy_fn=lambda listings, at, budget, tv: [
+            FakeCandidate(
+                player_id="new",
+                market_value=10_000_000,
+                expected_appreciation=20.0,
+                max_bid=max_bid,
+            )
+        ],
+    )
+    return result, state
+
+
+def test_a_flip_candidate_within_the_ceiling_is_bought():
+    _result, state = _run(squad_size=12, listing_price=9_000_000, max_bid=11_000_000)
+
+    assert "new" in state.squad
+
+
+def test_a_flip_is_not_bought_above_its_economic_ceiling():
+    """Paying more than the flip can ever return is a guaranteed loss, so losing
+    the listing to a rival is the correct outcome."""
+    _result, state = _run(squad_size=12, listing_price=12_000_000, max_bid=11_000_000)
+
+    assert "new" not in state.squad
+
+
+def test_a_flip_never_displaces_a_squad_member():
+    """At 15/15 the live bot does not sell to make room for a flip."""
+    _result, state = _run(squad_size=15, listing_price=9_000_000, max_bid=11_000_000)
+
+    assert "new" not in state.squad
+    assert len(state.squad) == 15
+
+
+def test_a_flip_is_skipped_when_it_would_leave_the_budget_negative():
+    _result, state = _run(
+        squad_size=12, listing_price=9_000_000, max_bid=11_000_000, budget=1_000
+    )
+
+    assert "new" not in state.squad
+
+
+def test_flip_buying_is_off_by_default():
+    """The shipped replay path must be unchanged until the run that enables it."""
+    state = ReplayState(budget=50_000_000, squad=_squad(12))
+    run_season(
+        state=state,
+        market=OneListing(9_000_000),
+        matchdays=[Matchday(day_number=1, kickoff=10 * DAY, points={})],
+        min_ep_gain=1_000_000.0,
+        score_fn=lambda pid, at: 10.0,
+        mv_fn=lambda pid, at: 10_000_000,
+        position_fn=lambda pid: "Midfielder",
+        team_fn=lambda pid: pid,
+    )
+
+    assert "new" not in state.squad
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_replay/test_flip_buy_pass.py -v`
+Expected: FAIL with `TypeError: run_season() got an unexpected keyword argument 'flip_buy_fn'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `rehoboam/replay/engine.py`, after `_flip_sells`:
+
+```python
+def _flip_buys(
+    state: ReplayState,
+    scores: dict[str, float],
+    listings: list,
+    at: float,
+    *,
+    flip_buy_fn: Callable[[list, float, int, int], list],
+    score_fn: Callable[[str, float], float],
+    mv_fn: Callable[[str, float], int | None],
+    position_fn: Callable[[str], str | None],
+    team_fn: Callable[[str], str | None],
+    with_competition: bool,
+) -> int:
+    """Buy for expected appreciation with the slots the EP pass left (REH-71).
+
+    Mirrors the live ordering: EP candidates execute first and flips take
+    "remaining slots" (auto_trader.py:533). A flip never displaces a squad
+    member, so this stops at MAX_SQUAD_SIZE rather than calling
+    ``_fieldable_sale_victim``.
+
+    Candidates carry their own ``max_bid`` from ``flip_buys.flip_bid_ceiling``
+    rather than going through ``bid_fn``: a flip's marginal EP gain is ~0 by
+    construction, so the EP bidder would put every flip in its bottom tier and
+    lose every contested listing, reporting a bidder artifact as a fact about
+    flipping.
+    """
+    from rehoboam.scoring.decision import _would_create_dead_weight
+
+    by_id = {listing.player_id: listing for listing in listings}
+    team_value = _team_value(state, mv_fn, at)
+    buys = 0
+
+    for candidate in flip_buy_fn(listings, at, state.budget, team_value):
+        if state.squad_size >= MAX_SQUAD_SIZE:
+            break
+        pid = candidate.player_id
+        listing = by_id.get(pid)
+        position = position_fn(pid)
+        if listing is None or not position or pid in state.squad:
+            continue
+
+        # Under competition we must outbid what the real buyer paid, and we then
+        # pay our own bid. Without it the listing is ours at its asking price --
+        # but never above the ceiling, which is an economic limit either way.
+        if with_competition:
+            if candidate.max_bid <= listing.price:
+                continue
+            cost = int(candidate.max_bid)
+        else:
+            if listing.price > candidate.max_bid:
+                continue
+            cost = int(listing.price)
+
+        player = ReplayPlayer(id=pid, position=position, team_id=team_fn(pid))
+        if _would_create_dead_weight(player, state.players):
+            continue
+        allowed, _reason = can_buy(state, player, cost, team_value=team_value)
+        if not allowed or not _solvent_after(state, cost):
+            continue
+
+        state.buy(player, cost, at=at)
+        scores[pid] = score_fn(pid, at)
+        team_value = _team_value(state, mv_fn, at)
+        buys += 1
+
+    return buys
+```
+
+Add the parameter to `run_season`'s signature, immediately after `loss_cut_pct`:
+
+```
+    # REH-71 flip buys. Given (listings, at, budget, team_value), returns
+    # candidates carrying their own economic max_bid. None keeps the shipped
+    # behaviour, in which every buy is justified by marginal expected points.
+    flip_buy_fn: Callable[[list, float, int, int], list] | None = None,
+```
+
+And call it inside the matchday loop, immediately after the EP `for listing in listings:` loop ends and *before* `sells += _restore_budget(...)`:
+
+```python
+if flip_buy_fn is not None:
+    buys += _flip_buys(
+        state,
+        scores,
+        listings,
+        decide_at,
+        flip_buy_fn=flip_buy_fn,
+        score_fn=score_fn,
+        mv_fn=mv_fn,
+        position_fn=position_fn,
+        team_fn=team_fn,
+        with_competition=bid_fn is not None,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_replay/ -v`
+Expected: PASS — the 5 new tests plus every pre-existing replay test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+uv run black rehoboam/replay/engine.py tests/test_replay/test_flip_buy_pass.py
+uv run ruff check rehoboam/replay/engine.py tests/test_replay/test_flip_buy_pass.py --fix
+git add rehoboam/replay/engine.py tests/test_replay/test_flip_buy_pass.py
+git commit -m "feat(replay): buy for appreciation with the slots the EP pass left (REH-71)"
+```
+
+______________________________________________________________________
+
+### Task 7: The flip ledger
+
+Round trips must be countable in euros and comparable to the real 151 / −€55.3M. The opening squad carries a cost basis (market value at assignment), so without an explicit marker its disposals would inflate the count and destroy the comparison.
+
+**Files:**
+
+- Modify: `rehoboam/replay/state.py`, `rehoboam/replay/engine.py`
+- Test: `tests/test_replay/test_flip_ledger.py`
+
+**Interfaces:**
+
+- Consumes: `ReplayPlayer`, `ReplayState.sell`.
+
+- Produces:
+
+  - `ReplayPlayer.acquired: str = "assigned"` — `"assigned"` or `"bought"`.
+  - `FlipRecord(player_id: str, buy_price: int, proceeds: int, bought_at: float | None, sold_at: float)` in `engine.py`.
+  - `SeasonResult.flips: list[FlipRecord]`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_replay/test_flip_ledger.py`:
+
+```python
+"""REH-71: flip P&L is cash, and cash is counted separately from points.
+
+The attribution table decomposes a POINTS delta. Flip income is EUROS and
+reaches the scoreboard only indirectly, through buys it funds. Mixing the two
+would be a category error, so the ledger stands apart.
+"""
+
+from __future__ import annotations
+
+from rehoboam.replay.engine import Matchday, run_season
+from rehoboam.replay.state import ReplayPlayer, ReplayState
+
+DAY = 86400.0
+POS = ["Goalkeeper"] + ["Defender"] * 4 + ["Midfielder"] * 4 + ["Forward"] * 3
+
+
+class NoMarket:
+    def available_before(self, at):
+        return []
+
+
+def _squad_of_12(acquired: str = "bought"):
+    return {
+        str(i): ReplayPlayer(
+            id=str(i),
+            position=POS[i],
+            team_id=str(i),
+            buy_price=10_000_000,
+            bought_at=0.0,
+            acquired=acquired,
+        )
+        for i in range(12)
+    }
+
+
+def _run(*, current_mv: int, squad):
+    state = ReplayState(budget=10_000_000, squad=squad)
+    return run_season(
+        state=state,
+        market=NoMarket(),
+        matchdays=[Matchday(day_number=1, kickoff=10 * DAY, points={})],
+        score_fn=lambda pid, at: 0.0 if pid == "11" else 100.0,
+        mv_fn=lambda pid, at: current_mv if pid == "11" else 10_000_000,
+        position_fn=lambda pid: "Forward",
+        team_fn=lambda pid: pid,
+        profit_take_pct=15.0,
+    )
+
+
+def test_a_profitable_round_trip_is_recorded_with_its_pnl():
+    result = _run(current_mv=12_000_000, squad=_squad_of_12())
+
+    assert len(result.flips) == 1
+    assert result.flips[0].proceeds - result.flips[0].buy_price == 2_000_000
+
+
+def test_an_assigned_player_sold_is_not_a_round_trip():
+    """The opening squad was assigned, not bought (state.py:96-100). Counting
+    its disposals would inflate the count and make it incomparable to the real
+    151 flips."""
+    result = _run(current_mv=12_000_000, squad=_squad_of_12(acquired="assigned"))
+
+    assert result.flips == []
+
+
+def test_players_bought_during_the_season_are_marked_as_bought():
+    state = ReplayState(budget=10_000_000, squad={})
+    state.buy(ReplayPlayer(id="x", position="Forward"), 5_000_000, at=1.0)
+
+    assert state.squad["x"].acquired == "bought"
+
+
+def test_a_flip_bought_then_sold_closes_as_exactly_one_round_trip():
+    """The end-to-end shape the ledger exists to count: the flip pass opens a
+    position on matchday 1, the market moves, and the sell pass banks it on
+    matchday 2. Anything other than a single record means the two halves
+    disagree about what a round trip is.
+    """
+    from dataclasses import dataclass
+
+    from rehoboam.replay.market import MarketListing
+
+    @dataclass(frozen=True)
+    class FakeCandidate:
+        player_id: str
+        market_value: int
+        expected_appreciation: float
+        max_bid: int
+
+    class OneListing:
+        def available_before(self, at):
+            return [
+                MarketListing(player_id="new", price=8_000_000, transfer_at=at - DAY)
+            ]
+
+    # "new" is worth 8M when bought and 12M by matchday 2 -- a 50% gain, well
+    # clear of the 15% take-profit threshold. He scores nothing, so he is never
+    # a best-eleven starter and starter protection does not hold him.
+    def mv_fn(pid, at):
+        if pid != "new":
+            return 10_000_000
+        return 8_000_000 if at < 15 * DAY else 12_000_000
+
+    state = ReplayState(budget=50_000_000, squad=_squad_of_12(acquired="assigned"))
+    result = run_season(
+        state=state,
+        market=OneListing(),
+        matchdays=[
+            Matchday(day_number=1, kickoff=10 * DAY, points={}),
+            Matchday(day_number=2, kickoff=20 * DAY, points={}),
+        ],
+        min_ep_gain=1_000_000.0,
+        score_fn=lambda pid, at: 0.0 if pid == "new" else 100.0,
+        mv_fn=mv_fn,
+        # The squad already holds 3 forwards, the formation ceiling, so a
+        # forward candidate would be refused as dead weight. Midfield has 4 of 5.
+        position_fn=lambda pid: "Midfielder" if pid == "new" else "Forward",
+        team_fn=lambda pid: pid,
+        profit_take_pct=15.0,
+        flip_buy_fn=lambda listings, at, budget, tv: [
+            FakeCandidate(
+                player_id="new",
+                market_value=8_000_000,
+                expected_appreciation=20.0,
+                max_bid=9_000_000,
+            )
+        ],
+    )
+
+    assert "new" not in state.squad
+    assert len(result.flips) == 1
+    assert result.flips[0].proceeds - result.flips[0].buy_price == 4_000_000
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_replay/test_flip_ledger.py -v`
+Expected: FAIL with `TypeError: ReplayPlayer.__init__() got an unexpected keyword argument 'acquired'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `rehoboam/replay/state.py`, add the field to `ReplayPlayer` (after `bought_at`):
+
+```
+    # "assigned" for the randomly-allocated opening squad, "bought" for anything
+    # the replay actually purchased. Both carry a cost basis, so the basis alone
+    # cannot distinguish them -- and counting assigned disposals as round trips
+    # would make the ledger incomparable to the real 151 flips (REH-71).
+    acquired: str = "assigned"
+```
+
+And mark purchases in `ReplayState.buy`:
+
+```python
+def buy(self, player: ReplayPlayer, price: int, at: float | None = None) -> None:
+    """Add ``player`` to the squad, recording the cost basis (REH-68)."""
+    self.squad[player.id] = replace(
+        player, buy_price=int(price), bought_at=at, acquired="bought"
+    )
+    self.budget -= int(price)
+```
+
+In `rehoboam/replay/engine.py`, add the record type next to `MatchdayOutcome`:
+
+```python
+@dataclass(frozen=True)
+class FlipRecord:
+    """One completed round trip: a player the replay bought and later sold."""
+
+    player_id: str
+    buy_price: int
+    proceeds: int
+    bought_at: float | None
+    sold_at: float
+```
+
+Add to `SeasonResult`:
+
+```python
+flips: list[FlipRecord] = field(default_factory=list)
+```
+
+Give `_flip_sells` a `ledger: list[FlipRecord]` keyword argument and append before each sale:
+
+```python
+if player.acquired == "bought":
+    ledger.append(
+        FlipRecord(
+            player_id=pid,
+            buy_price=int(player.buy_price),
+            proceeds=_proceeds(pid, mv_fn, at),
+            bought_at=player.bought_at,
+            sold_at=at,
+        )
+    )
+state.sell(pid, _proceeds(pid, mv_fn, at))
+```
+
+Pass `ledger=result.flips` at the `_flip_sells` call site in `run_season`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_replay/ -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+uv run black rehoboam/replay/state.py rehoboam/replay/engine.py tests/test_replay/test_flip_ledger.py
+uv run ruff check rehoboam/replay/state.py rehoboam/replay/engine.py tests/test_replay/test_flip_ledger.py --fix
+git add rehoboam/replay/state.py rehoboam/replay/engine.py tests/test_replay/test_flip_ledger.py
+git commit -m "feat(replay): a cash ledger for completed round trips (REH-71)"
+```
+
+______________________________________________________________________
+
+### Task 8: The Trading report block
+
+**Files:**
+
+- Modify: `rehoboam/replay/attribution.py`
+- Test: `tests/test_replay/test_attribution.py`
+
+**Interfaces:**
+
+- Consumes: `SeasonResult.flips`.
+
+- Produces: `trading_summary(result: SeasonResult) -> tuple[int, int, int]` returning `(realised_pnl, round_trips, wins)`; `format_report(..., with_flip_buys: bool = False)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_replay/test_attribution.py`:
+
+```python
+from rehoboam.replay.engine import FlipRecord, SeasonResult
+from rehoboam.replay.attribution import format_report, trading_summary
+
+
+def _result_with_flips() -> SeasonResult:
+    return SeasonResult(
+        flips=[
+            FlipRecord("a", 10_000_000, 12_000_000, 0.0, 1.0),
+            FlipRecord("b", 10_000_000, 7_000_000, 0.0, 1.0),
+        ]
+    )
+
+
+def test_trading_summary_nets_wins_against_losses():
+    assert trading_summary(_result_with_flips()) == (-1_000_000, 2, 1)
+
+
+def test_the_report_keeps_cash_out_of_the_points_attribution():
+    """Euros minus points is a category error. The Trading block must say so on
+    its face, so no reader ever adds it to the attribution table."""
+    report = format_report(
+        _result_with_flips(),
+        actual_total=0,
+        actual_per_matchday={},
+        standings=[],
+        min_ep_gain=40.0,
+        with_flips=True,
+    )
+
+    assert "does not enter the points attribution" in report
+
+
+def test_the_report_prints_the_real_season_for_comparison():
+    """A replay P&L with nothing to compare it against is uninterpretable."""
+    report = format_report(
+        _result_with_flips(),
+        actual_total=0,
+        actual_per_matchday={},
+        standings=[],
+        min_ep_gain=40.0,
+        with_flips=True,
+    )
+
+    assert "55,256,064" in report
+    assert "151" in report
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_replay/test_attribution.py -v -k trading or cash or comparison`
+Expected: FAIL with `ImportError: cannot import name 'trading_summary'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `rehoboam/replay/attribution.py`:
+
+```python
+# The real 2025/26 season, for comparison. Without a reference the replay's own
+# P&L is uninterpretable.
+REAL_FLIP_PNL = -55_256_064
+REAL_FLIP_TRIPS = 151
+REAL_FLIP_WIN_RATE = 27.8
+
+
+def trading_summary(result: SeasonResult) -> tuple[int, int, int]:
+    """``(realised_pnl, round_trips, wins)`` over completed round trips."""
+    pnl = sum(f.proceeds - f.buy_price for f in result.flips)
+    wins = sum(1 for f in result.flips if f.proceeds > f.buy_price)
+    return pnl, len(result.flips), wins
+```
+
+Add `with_flip_buys: bool = False` to `format_report`'s signature, and insert this block after the `Configuration` section:
+
+```python
+if with_flips or with_flip_buys:
+    pnl, trips, wins = trading_summary(result)
+    rate = (100.0 * wins / trips) if trips else 0.0
+    lines += [
+        "",
+        "Trading (cash - does not enter the points attribution above)",
+        "-" * 68,
+        f"  {'Realised flip P&L':<34}{'EUR ' + format(pnl, '+,'):>21}",
+        f"  {'Round trips completed':<34}{trips:>21,}",
+        f"  {'Win rate':<34}{rate:>20.1f}%   ({wins} of {trips})",
+        f"  {'Real 2025/26, for comparison':<34}"
+        f"{'EUR ' + format(REAL_FLIP_PNL, '+,'):>21}",
+        f"  {'':<34}{REAL_FLIP_TRIPS:>21,} trips, {REAL_FLIP_WIN_RATE}%",
+    ]
+```
+
+Update `FIDELITY_NOTES`'s sell entry so it no longer asserts flips are absent:
+
+```python
+("Sell decisions", "medium", "instant sell at MV; profit flips per --with-flips"),
+```
+
+Add a footer paragraph mirroring the existing `with_flips` one:
+
+```python
+if with_flip_buys:
+    lines += [
+        "Flip BUYING is modelled: candidates come from the real ProfitTrader,",
+        "bid at an economic ceiling rather than by marginal EP gain.",
+    ]
+else:
+    lines += [
+        "Flip BUYING is NOT modelled: every buy here is justified by expected",
+        "points, while the live bot also buys purely for appreciation.",
+    ]
+```
+
+Finally, extend the INCOMPLETE guard so a run missing any of the three behaviours is still labelled diagnostic:
+
+```python
+if not (with_competition and with_flips and with_flip_buys):
+    lines += ["INCOMPLETE - diagnostic only, not a season result."]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_replay/ -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+uv run black rehoboam/replay/attribution.py tests/test_replay/test_attribution.py
+uv run ruff check rehoboam/replay/attribution.py tests/test_replay/test_attribution.py --fix
+git add rehoboam/replay/attribution.py tests/test_replay/test_attribution.py
+git commit -m "feat(replay): report trading P&L as cash, beside the points table (REH-71)"
+```
+
+______________________________________________________________________
+
+### Task 9: Driver and CLI plumbing
+
+**Files:**
+
+- Modify: `rehoboam/replay/driver.py`, `rehoboam/cli.py`
+- Test: `tests/test_replay/test_driver.py`
+
+**Interfaces:**
+
+- Consumes: `make_flip_buy_fn`, `day_for_kickoff`, `position_fn`.
+
+- Produces: `run_replay(..., with_flip_buys: bool = False)`; CLI flag `--with-flip-buys` on `replay-season`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_replay/test_driver.py`:
+
+```python
+import inspect
+
+from rehoboam.replay import driver
+
+
+def test_run_replay_accepts_a_flip_buy_switch():
+    assert "with_flip_buys" in inspect.signature(driver.run_replay).parameters
+
+
+def test_run_replay_passes_the_flip_buy_fn_to_the_engine():
+    """A switch that never reaches run_season changes nothing -- the exact
+    defect REH-66 caught on the gain floor."""
+    source = inspect.getsource(driver.run_replay)
+
+    assert "flip_buy_fn=" in source
+
+
+def test_the_flip_buy_fn_uses_the_same_matchday_resolver_as_the_scorer():
+    """Two different cutoff rules in one run would let the flip path see a
+    matchday the EP path cannot."""
+    source = inspect.getsource(driver.run_replay)
+
+    assert "day_fn=" in source
+    assert "day_for_kickoff" in source
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_replay/test_driver.py -v -k flip`
+Expected: FAIL — `with_flip_buys` not in signature.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `rehoboam/replay/driver.py`, add `with_flip_buys: bool = False` to `run_replay`'s keyword arguments, then before the `run_season` call:
+
+```
+    flip_buy_fn = None
+    if with_flip_buys:
+        from rehoboam.replay.flip_buys import make_flip_buy_fn
+
+        flip_buy_fn = make_flip_buy_fn(
+            corpus,
+            season=SEASON,
+            # The SAME resolver the scorer uses, so the flip path and the EP
+            # path cannot disagree about which matchday is being predicted.
+            day_fn=lambda at: day_for_kickoff(kickoffs, at),
+            position_fn=position_fn,
+        )
+```
+
+Pass `flip_buy_fn=flip_buy_fn` into `run_season`, and `with_flip_buys=with_flip_buys` into `format_report`.
+
+In `rehoboam/cli.py`, add to `replay_season` after the `with_flips` option:
+
+```python
+with_flip_buys: bool = (
+    typer.Option(
+        False,
+        "--with-flip-buys",
+        help=(
+            "Model profit-flip BUYING (REH-71): candidates from the real "
+            "ProfitTrader, bid at an economic ceiling. The live bot does this; "
+            "--with-flips alone only models the selling half."
+        ),
+    ),
+)
+```
+
+and thread `with_flip_buys=with_flip_buys` into the `run_replay` call.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_replay/ -v && uv run rehoboam replay-season --help`
+Expected: PASS, and the help text lists `--with-flip-buys`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+uv run black rehoboam/replay/driver.py rehoboam/cli.py tests/test_replay/test_driver.py
+uv run ruff check rehoboam/replay/driver.py rehoboam/cli.py tests/test_replay/test_driver.py --fix
+git add rehoboam/replay/driver.py rehoboam/cli.py tests/test_replay/test_driver.py
+git commit -m "feat(replay): --with-flip-buys, wired through the driver (REH-71)"
+```
+
+______________________________________________________________________
+
+### Task 10: The 2×2 factorial command
+
+**Files:**
+
+- Modify: `rehoboam/replay/driver.py`, `rehoboam/cli.py`
+- Test: `tests/test_replay/test_flip_policy_report.py`
+
+**Interfaces:**
+
+- Consumes: `run_replay`, `trading_summary`.
+- Produces: `format_flip_policy(arms: dict[str, SeasonResult], *, actual_total: int) -> str`; `run_flip_policy(*, corpus_path, learning_db_path) -> str`; CLI command `replay-flip-policy`.
+
+Arm keys are exactly `"A"`, `"B"`, `"C"`, `"D"` per the spec table.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_replay/test_flip_policy_report.py`:
+
+```python
+"""REH-71: the 2x2 report, and the decision rule fixed in advance.
+
+REH-68 measured a 6,162-point faithfulness swing. Against a ~27,000-point
+season that will plausibly swallow every flip delta, so the inconclusive branch
+is the LIKELY one and has to be stated before the numbers arrive.
+"""
+
+from __future__ import annotations
+
+from rehoboam.replay.attribution import NOISE_FLOOR_POINTS, format_flip_policy
+from rehoboam.replay.engine import SeasonResult
+
+
+def _arms(a: int, b: int, c: int, d: int) -> dict[str, SeasonResult]:
+    return {
+        key: SeasonResult(total_points=points)
+        for key, points in (("A", a), ("B", b), ("C", c), ("D", d))
+    }
+
+
+def test_the_report_names_all_four_arms():
+    report = format_flip_policy(
+        _arms(27_000, 27_100, 27_050, 27_150), actual_total=26_172
+    )
+
+    for label in ("A", "B", "C", "D"):
+        assert label in report
+
+
+def test_small_deltas_are_declared_inconclusive():
+    """Every arm within the noise floor of every other."""
+    report = format_flip_policy(
+        _arms(27_000, 27_100, 27_050, 27_150), actual_total=26_172
+    )
+
+    assert "INCONCLUSIVE" in report
+
+
+def test_a_delta_clearing_the_noise_floor_is_not_inconclusive():
+    report = format_flip_policy(
+        _arms(27_000, 27_000, 20_000, 20_000), actual_total=26_172
+    )
+
+    assert "INCONCLUSIVE" not in report
+
+
+def test_the_noise_floor_is_the_one_reh_68_measured():
+    assert NOISE_FLOOR_POINTS == 6_162
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_replay/test_flip_policy_report.py -v`
+Expected: FAIL with `ImportError: cannot import name 'NOISE_FLOOR_POINTS'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `rehoboam/replay/attribution.py`:
+
+```python
+# REH-68 measured a single faithfulness decision moving the season total by this
+# much. Any flip delta smaller than it is modelling noise, not a finding. Fixed
+# BEFORE the runs so the result cannot be rationalised after it is seen.
+NOISE_FLOOR_POINTS = 6_162
+
+ARM_LABELS = {
+    "A": "flip buys off, profit sells off",
+    "B": "flip buys off, profit sells ON",
+    "C": "flip buys ON,  profit sells off",
+    "D": "flip buys ON,  profit sells ON",
+}
+
+
+def format_flip_policy(arms: dict, *, actual_total: int) -> str:
+    """The 2x2, its main effects, and the pre-committed decision rule."""
+    points = {key: arms[key].total_points for key in ("A", "B", "C", "D")}
+    buy_effect = (points["C"] + points["D"]) / 2 - (points["A"] + points["B"]) / 2
+    sell_effect = (points["B"] + points["D"]) / 2 - (points["A"] + points["C"]) / 2
+    interaction = (points["D"] - points["C"]) - (points["B"] - points["A"])
+
+    lines = [
+        "=" * 68,
+        "FLIP POLICY 2x2 - REH-71",
+        "=" * 68,
+        "",
+        f"Human actual: {actual_total:>8,}",
+        "",
+    ]
+    for key in ("A", "B", "C", "D"):
+        delta = points[key] - actual_total
+        lines.append(f"  {key}  {ARM_LABELS[key]:<34}{points[key]:>9,}  ({delta:+,})")
+
+    lines += [
+        "",
+        "Main effects (points)",
+        "-" * 68,
+        f"  {'Flip buying':<34}{buy_effect:>+9,.0f}",
+        f"  {'Profit selling':<34}{sell_effect:>+9,.0f}",
+        f"  {'Interaction':<34}{interaction:>+9,.0f}",
+        "",
+        f"Noise floor (REH-68): {NOISE_FLOOR_POINTS:,} points",
+        "",
+    ]
+
+    effects = (abs(buy_effect), abs(sell_effect), abs(interaction))
+    if max(effects) < NOISE_FLOOR_POINTS:
+        lines += [
+            "INCONCLUSIVE on points - every effect is inside the noise floor.",
+            "Per the pre-committed rule, the decision falls to the cash evidence:",
+            f"real flipping lost EUR {abs(REAL_FLIP_PNL):,} at a "
+            f"{REAL_FLIP_WIN_RATE}% win rate over {REAL_FLIP_TRIPS} round trips,",
+            "and every round trip pays a measured 11.7% toll. Both switches",
+            "default OFF, decided on cash rather than on points.",
+        ]
+    else:
+        lines += [
+            "An effect clears the noise floor. Adopt that arm's verdict for its",
+            "own switch; the other switch follows the same rule independently.",
+        ]
+    lines += ["", "A labelled control, not the counterfactual season result.", "=" * 68]
+    return "\n".join(lines)
+```
+
+In `rehoboam/replay/driver.py`:
+
+```python
+def run_flip_policy(*, corpus_path: Path, learning_db_path: Path) -> str:
+    """REH-71: the 2x2 over flip buys x profit sells.
+
+    Every arm runs with bid competition on, because the whole question is what
+    flipping is worth when rivals contest the same listings. Nothing else varies
+    between arms.
+    """
+    from rehoboam.replay.attribution import format_flip_policy
+
+    arms = {}
+    for key, flip_buys, profit_sells in (
+        ("A", False, False),
+        ("B", False, True),
+        ("C", True, False),
+        ("D", True, True),
+    ):
+        arms[key], _report = run_replay(
+            corpus_path=corpus_path,
+            learning_db_path=learning_db_path,
+            with_competition=True,
+            with_flips=profit_sells,
+            with_flip_buys=flip_buys,
+        )
+
+    with sqlite3.connect(learning_db_path) as conn:
+        actual_total = conn.execute(
+            "SELECT MAX(total_points) FROM league_rank_history WHERE is_self = 1"
+        ).fetchone()[0]
+
+    return format_flip_policy(arms, actual_total=int(actual_total or 0))
+```
+
+In `rehoboam/cli.py`, add a command modelled exactly on `replay_buy_control`:
+
+```python
+@app.command("replay-flip-policy")
+def replay_flip_policy(
+    corpus: Path = typer.Option(  # noqa: B008
+        Path("logs/training_corpus.db"), help="Path to the training corpus DB"
+    ),
+    learning_db: Path = typer.Option(  # noqa: B008
+        Path("logs/bid_learning.db"), help="Path to the learning DB with real standings"
+    ),
+) -> None:
+    """REH-71: 2x2 over flip buys x profit sells, with competition on."""
+    from rehoboam.replay.driver import run_flip_policy
+
+    if not corpus.exists():
+        console.print(f"[red]Corpus not found: {corpus}[/red]")
+        raise typer.Exit(1)
+    if not learning_db.exists():
+        console.print(f"[red]Learning DB not found: {learning_db}[/red]")
+        raise typer.Exit(1)
+
+    console.print(run_flip_policy(corpus_path=corpus, learning_db_path=learning_db))
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_replay/ -v && uv run rehoboam replay-flip-policy --help`
+Expected: PASS, and the command exists.
+
+- [ ] **Step 5: Commit**
+
+```bash
+uv run black rehoboam/replay/attribution.py rehoboam/replay/driver.py rehoboam/cli.py tests/test_replay/test_flip_policy_report.py
+uv run ruff check rehoboam/replay/attribution.py rehoboam/replay/driver.py rehoboam/cli.py tests/test_replay/test_flip_policy_report.py --fix
+git add rehoboam/replay/attribution.py rehoboam/replay/driver.py rehoboam/cli.py tests/test_replay/test_flip_policy_report.py
+git commit -m "feat(replay): replay-flip-policy runs the 2x2 and applies the rule (REH-71)"
+```
+
+______________________________________________________________________
+
+### Task 11: The `Settings` switches
+
+**Files:**
+
+- Modify: `rehoboam/config.py`, `rehoboam/auto_trader.py`, `.env.example`
+- Test: `tests/test_replay/test_shipped_config.py`, `tests/test_auto_trader_flip_switches.py`
+
+**Interfaces:**
+
+- Produces: `Settings.enable_flip_buys: bool`, `Settings.enable_profit_sells: bool`.
+
+Defaults are `False` per §1's inconclusive branch, revised in Task 12 only if an effect clears the noise floor.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_auto_trader_flip_switches.py`:
+
+```python
+"""REH-71: the flip verdict must be honoured from .env, without a deploy."""
+
+from __future__ import annotations
+
+import inspect
+
+from rehoboam.auto_trader import AutoTrader
+from rehoboam.config import Settings
+
+
+def test_both_switches_exist():
+    assert "enable_flip_buys" in Settings.model_fields
+    assert "enable_profit_sells" in Settings.model_fields
+
+
+def test_the_flip_buy_block_is_gated_on_its_switch():
+    source = inspect.getsource(AutoTrader.run_unified_trade_phase)
+
+    assert "enable_flip_buys" in source
+
+
+def test_the_profit_sell_phase_is_gated_on_its_switch():
+    source = inspect.getsource(AutoTrader.run_profit_sell_phase)
+
+    assert "enable_profit_sells" in source
+```
+
+Both method names are verified: `run_unified_trade_phase` (`auto_trader.py:250`) encloses the flip-candidate block at line 344, and `run_profit_sell_phase` begins at line 751.
+
+Append to `tests/test_replay/test_shipped_config.py`:
+
+```python
+def test_the_flip_switches_default_off():
+    """REH-71's pre-committed rule: absent a points effect clearing the 6,162
+    noise floor, the decision falls to cash evidence and both switches are off.
+    """
+    assert Settings.model_fields["enable_flip_buys"].default is False
+    assert Settings.model_fields["enable_profit_sells"].default is False
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_auto_trader_flip_switches.py -v`
+Expected: FAIL — fields absent.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `rehoboam/config.py`, after `max_loss_pct`:
+
+```
+    # REH-71. Real flipping lost EUR 55,256,064 over 151 round trips at a 27.8%
+    # win rate, and every round trip pays a measured 11.7% toll. Split in two
+    # because buying for appreciation and taking profit on the squad are
+    # distinct behaviours that need not share a verdict.
+    enable_flip_buys: bool = Field(
+        default=False,
+        description="Buy players for expected appreciation rather than expected points",
+    )
+    enable_profit_sells: bool = Field(
+        default=False,
+        description="Take profit / cut losses on squad players against their cost basis",
+    )
+```
+
+In `rehoboam/auto_trader.py`, gate the flip-candidate block (`auto_trader.py:344`):
+
+```
+        if (
+            self.settings.enable_flip_buys
+            and ctx.matchday_phase.allow_flips
+            and available_slots > 0
+        ):
+```
+
+and return early from `run_profit_sell_phase`:
+
+```
+if not self.settings.enable_profit_sells:
+    console.print("[dim]Profit selling disabled (REH-71)[/dim]")
+    return []
+```
+
+Add both to `.env.example` with a one-line comment each.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest -v`
+Expected: PASS across the whole suite. Investigate any auto_trader test that assumed flips were on — update it to set the switch explicitly rather than weakening the assertion.
+
+- [ ] **Step 5: Commit**
+
+```bash
+uv run black rehoboam/config.py rehoboam/auto_trader.py tests/test_auto_trader_flip_switches.py tests/test_replay/test_shipped_config.py
+uv run ruff check rehoboam/config.py rehoboam/auto_trader.py tests/test_auto_trader_flip_switches.py tests/test_replay/test_shipped_config.py --fix
+git add rehoboam/config.py rehoboam/auto_trader.py .env.example tests/test_auto_trader_flip_switches.py tests/test_replay/test_shipped_config.py
+git commit -m "feat(config): enable_flip_buys / enable_profit_sells switches (REH-71)"
+```
+
+______________________________________________________________________
+
+### Task 12: Run the 2×2 and record the verdict
+
+Not a TDD task — this is the measurement the whole ticket exists for. Run once. Do not tune and re-run.
+
+**Files:**
+
+- Create: `docs/superpowers/specs/2026-08-05-reh-71-flip-policy-results.md`
+
+- Modify: `rehoboam/config.py` (only if an effect clears the noise floor)
+
+- [ ] **Step 1: Record the pre-run integrity baseline**
+
+```bash
+shasum -a 256 logs/training_corpus.db logs/bid_learning.db rehoboam/scoring/v2/coefficients.json | tee /tmp/reh71-before.txt
+```
+
+- [ ] **Step 2: Confirm determinism before trusting any number**
+
+```bash
+uv run rehoboam replay-season --with-competition --with-flips --with-flip-buys > /tmp/reh71-det-1.txt
+uv run rehoboam replay-season --with-competition --with-flips --with-flip-buys > /tmp/reh71-det-2.txt
+diff /tmp/reh71-det-1.txt /tmp/reh71-det-2.txt && echo "DETERMINISTIC"
+```
+
+Expected: `DETERMINISTIC`. If the files differ, STOP — a nondeterministic harness cannot support any verdict. Find the source (dict ordering, unsorted SQL, floating-point accumulation order) and fix it before continuing.
+
+- [ ] **Step 3: Run the factorial once**
+
+```bash
+uv run rehoboam replay-flip-policy | tee /tmp/reh71-factorial.txt
+```
+
+- [ ] **Step 4: Verify nothing was mutated**
+
+```bash
+shasum -a 256 logs/training_corpus.db logs/bid_learning.db rehoboam/scoring/v2/coefficients.json > /tmp/reh71-after.txt
+diff /tmp/reh71-before.txt /tmp/reh71-after.txt && echo "READ-ONLY CONFIRMED"
+```
+
+Expected: `READ-ONLY CONFIRMED`.
+
+- [ ] **Step 5: Write the results document**
+
+Create `docs/superpowers/specs/2026-08-05-reh-71-flip-policy-results.md` containing, verbatim: the four arm totals, the three main effects, the per-arm trading P&L / round trips / win rate, the tool's own INCONCLUSIVE verdict or the effect that cleared the floor, and the resulting switch values. State plainly which evidence decided it — points or cash. Do not editorialise the number upward.
+
+- [ ] **Step 6: Set the defaults if — and only if — an effect cleared the floor**
+
+If `INCONCLUSIVE`, the `False` defaults from Task 11 already encode the verdict; change nothing. Otherwise update the relevant `Settings` default and the assertion in `test_the_flip_switches_default_off`, renaming that test to match what it now asserts.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-08-05-reh-71-flip-policy-results.md rehoboam/config.py tests/test_replay/test_shipped_config.py
+git commit -m "docs(replay): the 2x2 flip-policy result and the verdict it supports (REH-71)"
+```
+
+- [ ] **Step 8: Full suite and lint before opening the PR**
+
+```bash
+uv run pytest
+uv run ruff check rehoboam/ tests/
+uv run mypy rehoboam/ --ignore-missing-imports
+```
+
+Expected: green. Then open the PR against `main` referencing REH-71, quoting the factorial table in the body.
+
+______________________________________________________________________
+
+## Notes for the implementer
+
+- **`_would_create_dead_weight` duck-types.** It is annotated `MarketPlayer` but reads only `.position` (`decision.py:803`), so a `ReplayPlayer` works. Do not build a real `MarketPlayer` to satisfy the annotation.
+- **`min_ep_gain=1_000_000.0` is the idiom** for silencing the EP buy pass in a test that wants to observe the flip pass alone.
+- **Do not add flips to `attribution_rows`.** The whole point of the cash block is that euros never enter a points column.
+- **`INSTANT_SELL_PCT` is 1.0, not 0.95.** REH-67 measured it. If you see 0.95 anywhere, that is a bug, not a convention.

--- a/docs/superpowers/specs/2026-08-05-reh-71-flip-policy-design.md
+++ b/docs/superpowers/specs/2026-08-05-reh-71-flip-policy-design.md
@@ -129,8 +129,38 @@ faithful reading: the live bot only flips `is_kickbase_seller()` listings
 (`trader.py:685`), where price *is* market value by construction.
 
 - **Decision**: the adapter sets `price = market_value = corpus.market_value_at(pid, decide_at)`.
-- **Execution**: the engine pays `listing.price`, or our winning bid when
-  competition is modelled.
+- **Execution**: the engine pays our winning bid, sized as below.
+
+### Flip bids face competition, at an economically-derived ceiling
+
+Rival managers can target the same flip candidate, so flip buys are subject to
+the same competition model as EP buys. But `make_ep_bid_fn` is the wrong bidder
+for them: it sizes from `marginal_ep_gain`, which is ~0 for a flip by
+construction, so every flip bid would land in the bottom tier, fail the
+`our_bid > listing.price` test, and collapse arms C and D into A and B — the
+experiment would report "flip buys do nothing" as a modelling artifact.
+
+Flips bid on their own economics instead. Paying `P` is only rational if the
+expected exit still clears the margin `ProfitTrader` itself demands. Exit
+proceeds are `MV × 1.00` (`INSTANT_SELL_PCT`, measured in REH-67), so:
+
+```
+ceiling = MV_now × (1 + expected_appreciation / 100) / (1 + min_profit_pct / 100)
+```
+
+`expected_appreciation` comes from the `ProfitOpportunity`; `min_profit_pct` is
+8.0, read from `Trader.find_profit_opportunities`'s call site (`trader.py:719`)
+rather than `ProfitTrader.__init__`'s unused default. The bid is additionally
+capped by what the budget allows, and we win only if it exceeds
+`listing.price`.
+
+Losing a contested flip is a real economic outcome — a rival paid more than the
+flip could ever return — and must not be papered over by bidding higher.
+
+The alternative considered and rejected: paying `listing.price` uncontested.
+That charges a measured 11.7% premium against an 8% expected appreciation, so
+nearly every flip loses by construction and the verdict is baked in before the
+run.
 
 ### Pinned inputs
 

--- a/docs/superpowers/specs/2026-08-05-reh-71-flip-policy-design.md
+++ b/docs/superpowers/specs/2026-08-05-reh-71-flip-policy-design.md
@@ -1,0 +1,251 @@
+# REH-71 — Decide the flip policy: should `auto` trade for profit at all?
+
+Ticket: https://linear.app/jovily/issue/REH-71
+Date: 2026-08-05
+Status: design approved, not yet implemented
+
+## Problem
+
+Real profit flipping in 2025/26 destroyed money:
+
+|                       |                               |
+| --------------------- | ----------------------------- |
+| Completed round trips | 151 (2025-08-10 → 2026-05-15) |
+| Net profit            | −€55,256,064                  |
+| Win rate              | 27.8% (42 of 151)             |
+| Average win / loss    | €1,873,614 / −€1,228,879      |
+
+€55M is comparable to the entire €80M starting budget. If it is recoverable it
+converts directly into squad quality, which is the only thing that scores
+points. But the inference "turn flipping off" is not yet supported: the two
+replay runs that bracket it are not comparable, because `competition, no flips`
+(−1,158) predates the fieldability fix and starter protection that
+`competition + flips` (+512) has.
+
+## What the ticket assumed, and what is actually true
+
+REH-71 was written expecting "one flag and two runs". Reading the code changed
+the scope twice.
+
+**The `--with-flips` flag models only half the behaviour.** `_flip_sells`
+(`rehoboam/replay/engine.py:157-212`) is purely sell-side: take profit at
+`min_sell_profit_pct`, cut losses at `max_loss_pct`, on squad players who are
+not best-eleven starters. The live bot *also buys players purely to flip* —
+`auto_trader.py:342-392` pulls `Trader.find_profit_opportunities` candidates and
+buys them for expected appreciation rather than expected points. The −€55M came
+from both halves. Deciding "should auto trade for profit at all" from a
+sell-side-only flag would answer a different question than the one asked.
+
+**Flip income is euros; the attribution table is points.** `attribution_rows`
+(`rehoboam/replay/attribution.py:37-58`) decomposes a points delta as
+`other = delta - zero_recovered`. Flip P&L cannot be subtracted from it — euros
+minus points is a category error. Flips reach the scoreboard only indirectly,
+through cash that funds subsequent buys.
+
+## Decisions taken
+
+1. **Model flip buys before running the A/B.** The replay gains a flip-buy pass
+   so `--with-flips` covers both halves of the live behaviour.
+1. **Call the real shipped heuristics**, not reimplementations — the pattern
+   REH-68 established when `make_ep_bid_fn` wired in the actual `SmartBidding`
+   rather than approximating it.
+1. **Report cash as cash.** A separate Trading block in euros; the points
+   contribution is the measured difference between paired runs, not a
+   decomposed term.
+1. **Two independent Settings switches**, because flip buys and profit sells are
+   distinct behaviours that may not warrant the same verdict.
+
+## 1. The experiment: a 2×2 factorial
+
+Separate switches make a single A/B confounded. Four arms, all run with
+`--with-competition`, nothing else varying:
+
+| Arm | flip buys | profit sells | what it is                        |
+| --- | --------- | ------------ | --------------------------------- |
+| A   | off       | off          | pure EP bot — the floor           |
+| B   | off       | on           | today's `--with-flips`            |
+| C   | on        | off          | buys to appreciate, never banks   |
+| D   | on        | on           | closest to live 2025/26 behaviour |
+
+Main effects:
+
+- buy-side effect = mean(C, D) − mean(A, B)
+- sell-side effect = mean(B, D) − mean(A, C)
+- interaction = (D − C) − (B − A)
+
+The interaction is not decoration. Arm C opens positions it never closes and
+arm B closes positions it never opened, so a flip policy that only pays off as a
+matched pair would show up here and nowhere else.
+
+### Pre-committed decision rule
+
+REH-68 recorded that a single faithfulness decision moved the season total by
+6,162 points. Against a ~27,000-point season that noise floor will plausibly
+swallow every flip delta. The rule is therefore fixed **in advance**, so the
+result cannot be rationalised after it is seen:
+
+> If every |delta| \< 6,162 points, the points evidence is declared
+> **inconclusive** and the decision falls to the cash evidence: real flipping
+> lost €55,256,064 at a 27.8% win rate, and every round trip pays a measured
+> 11.7% toll (mean transaction price 1.117× market value against an instant sell
+> returning 1.00×). Both switches default **off**, and this document records that
+> the decision was made on cash, not on points.
+
+If a delta does clear 6,162 points, that arm's verdict is adopted for its
+switch, and the other switch follows the same rule independently.
+
+## 2. Flip buys: reuse both shipped heuristics
+
+New module `rehoboam/replay/flip_buys.py`. Two seams make heuristic
+reimplementation unnecessary:
+
+- **`TrendService.analyze(history_data, current_market_value)`**
+  (`services/trend_service.py:243`) is already a pure `@staticmethod` with no
+  I/O. Its input is synthesised from the corpus `mv_series` table, whose
+  `snapshot_at` is exactly `dt × 86400` (`enrichment/corpus.py:336-345`), so the
+  round trip back to the API's `{"it": [{"dt": …, "mv": …}], "hmv": …, "lmv": …}`
+  shape is lossless.
+- **`ProfitTrader.find_profit_opportunities(...)`** is called for real, fed a
+  `CorpusMarketPlayer` adapter satisfying the attribute surface it reads:
+  `.id`, `.price`, `.market_value`, `.average_points`, `.status`, `.position`,
+  `.first_name`, `.last_name`.
+
+### Two traps that would each silently zero the pass
+
+**Leak via `peak_value`.** `hmv` must be computed from the window truncated at
+`decide_at`, never season-wide. `ProfitTrader`'s mean-reversion branch gates on
+`current_vs_peak_pct < -25` (`profit_trader.py:172-175`); a season-wide peak
+lets the bot know in August what a player will be worth in March.
+
+**The `is_kickbase` test inverts the model.** `ProfitTrader` branches on
+`player.price == player.market_value` (`profit_trader.py:121`). Replay listings
+carry real transaction prices, which average 1.117× market value, so equality
+never holds. Every candidate would fall to the non-Kickbase branch, where
+`value_gap = market_value - price` is negative and the candidate is skipped at
+`profit_trader.py:194`. Flip buys would appear modelled and never fire once.
+
+The fix separates decision price from execution price, which is also the
+faithful reading: the live bot only flips `is_kickbase_seller()` listings
+(`trader.py:685`), where price *is* market value by construction.
+
+- **Decision**: the adapter sets `price = market_value = corpus.market_value_at(pid, decide_at)`.
+- **Execution**: the engine pays `listing.price`, or our winning bid when
+  competition is modelled.
+
+### Pinned inputs
+
+Documented as bounds, exactly as `make_ep_bid_fn` pins `offer_count=0` and
+`trend_change_pct=0.0`:
+
+- `status = 0` (available). The corpus's per-match status is participation, not
+  injury or market availability. Pinning it means nothing is skipped as injured,
+  so the replay buys **more** flips than live — an upper bound on flip activity,
+  and therefore on flip harm.
+
+### Engine integration
+
+A new `flip_buy_fn` parameter on `run_season`, running **after** the EP buy loop
+— mirroring `auto_trader.py:533`, "Execute profit flips with remaining slots" —
+and only while `squad_size < MAX_SQUAD_SIZE`. A flip never displaces a squad
+member, because the live bot does not sell to make room for one. The same
+guards apply as for EP buys: `can_buy`, `_solvent_after`, fieldability, and the
+dead-weight check.
+
+Flip-bought players are not best-eleven starters (they are chosen for
+appreciation, not points), so `_flip_sells`'s starter protection does not block
+them and the round trip closes naturally.
+
+## 3. Reporting: cash stays cash
+
+`attribution_rows` stays in points and is not modified.
+
+`SeasonResult` gains a flip ledger: one `FlipRecord` per closed round trip
+(`player_id`, `buy_price`, `proceeds`, `bought_at`, `sold_at`). The report gains
+a clearly separated block — the figures below are **illustrative layout only**,
+not results:
+
+```
+Trading (cash — does not enter the points attribution above)
+--------------------------------------------------------------------
+  Realised flip P&L                        EUR -3,204,118
+  Round trips completed                               18
+  Win rate                                         33.3%   (6 of 18)
+  Real 2025/26, for comparison             EUR -55,256,064
+                                                     151 trips, 27.8%
+```
+
+Round trips count only players the replay **bought**. The opening squad carries
+a cost basis — market value at assignment (`state.py:96-100`) — so without an
+explicit `acquired: "assigned" | "bought"` field on `ReplayPlayer`, assigned
+disposals would inflate the count and make it incomparable to the real 151.
+
+`FIDELITY_NOTES` is updated: "Sell decisions … profit flips NOT modelled" is now
+conditional on the arm.
+
+### CLI
+
+- `rehoboam replay-flip-policy` — runs all four arms, prints the factorial
+  table, and applies the pre-committed decision rule to its own output. Sits
+  apart from `replay-season` the way `replay-buy-control` does, because it is a
+  labelled control, not a counterfactual result.
+- `--with-flip-buys` added to `replay-season`, so each arm is individually
+  reproducible.
+
+The Trading block appears in both.
+
+## 4. Settings
+
+```python
+# Shown with the inconclusive-case values. Each default is set by §1's
+# pre-committed rule once the four arms have run — fixing a default before the
+# measurement is exactly what that rule exists to prevent.
+enable_flip_buys: bool = Field(
+    default=False,
+    description="Buy players for expected appreciation rather than expected points (REH-71)",
+)
+enable_profit_sells: bool = Field(
+    default=False,
+    description="Take profit / cut losses on squad players against their cost basis (REH-71)",
+)
+```
+
+Gating:
+
+- `enable_flip_buys` → the flip-candidate block at `auto_trader.py:344`
+- `enable_profit_sells` → `run_profit_sell_phase` at `auto_trader.py:751`
+
+Defaults are whatever §1's decision rule yields once the runs are in. The replay
+reads both through the existing `_shipped_default` helper (`driver.py:159-167`),
+so a production re-tune cannot leave the harness describing a bot nobody
+deployed.
+
+Out of scope: `min_value_score_to_buy` and `min_buy_value_increase_pct` are dead
+fields belonging to REH-73.
+
+## 5. Testing
+
+- **Leak**: a market value recorded after `decide_at` must not reach `hmv`.
+- **Contract**: `CorpusMarketPlayer` satisfies every attribute `ProfitTrader`
+  reads, failing loudly if `ProfitTrader` grows a new one.
+- **Fires at all**: at least one flip buy occurs in a season containing obvious
+  momentum candidates. The `is_kickbase` trap produces a silent zero, and only a
+  positive assertion catches it.
+- **Guards**: never exceeds `MAX_SQUAD_SIZE`, never displaces a squad member,
+  respects `_solvent_after`.
+- **Round-trip closure**: a flip buy that later crosses the profit target is
+  sold by `_flip_sells` and lands in the ledger as exactly one round trip.
+- **Ledger scope**: assigned opening-squad disposals are excluded from round
+  trips.
+- **Determinism**: two consecutive runs are byte-identical.
+- **Settings gating**: each phase is skipped when its switch is off.
+
+## Carried constraints
+
+- Read-only: both DB SHA-256s unchanged, `coefficients.json` byte-identical.
+- Run once per arm. Credibility decays with every tuning iteration.
+- All four arms are labelled control runs, never the headline counterfactual.
+- No threshold may be adopted from these runs; that is a separate decision with
+  its own evidence.
+- A favourable result does not vindicate live behaviour. The replay's flip model
+  protects best-eleven starters and pins injury status to available, so it is
+  both more disciplined and more active than whatever produced the −€55M.

--- a/docs/superpowers/specs/2026-08-05-reh-71-flip-policy-results.md
+++ b/docs/superpowers/specs/2026-08-05-reh-71-flip-policy-results.md
@@ -2,12 +2,29 @@
 
 Ticket: https://linear.app/jovily/issue/REH-71
 Date: 2026-08-06
-Status: measurement complete, decision recorded
+Status: measurement complete, decision recorded (corrected 2026-08-06 — see
+"Correction" note below)
 
 This document records the single, once-only run of `rehoboam replay-flip-policy`
 against the 2025/26 season replay, per the design in
 `2026-08-05-reh-71-flip-policy-design.md`. All four arms run with
 `--with-competition`. Nothing else varies between arms.
+
+**Correction (fix round 1):** the first version of this document mischaracterised
+arm C as having opened flip-buy positions that a disabled profit-sell pass
+then failed to realise. That is wrong — arm C executed **zero** flip buys and
+is identical to arm A in every respect, not only in points. See "Arm C: flip
+buying was unreachable" below for the corrected account, its arithmetic
+consequence for the buy-side main effect, and the mechanism established from
+source. The measurement protocol and the verdict are unaffected.
+
+**Every points effect measured positive** — flip buying +734, profit selling
++2,057, interaction +1,468 — even though the decision that follows goes
+*against* turning flipping on. That is the pre-committed noise-floor rule
+doing its job, not a contradiction to paper over: none of the three effects
+clears the bar that would let them override the cash evidence, so the rule
+routes to cash regardless of sign. A reader should see this tension plainly
+rather than have it smoothed away.
 
 ## Determinism gate
 
@@ -51,6 +68,24 @@ Noise floor (REH-68, fixed before any run in this ticket): **6,162 points**.
 All three effects (734, 2,057, 1,468) are smaller in magnitude than the
 6,162-point noise floor.
 
+**The buy-side effect carries no independent information.** Arm C executed
+zero flip buys (see "Arm C: flip buying was unreachable" below) and is
+therefore identical to arm A, so `C − A = 0` exactly. Substituting into the
+main-effect formula:
+
+```
+buy_effect  = mean(C, D) − mean(A, B) = (C + D)/2 − (A + B)/2
+            = (A + D)/2 − (A + B)/2        [C = A]
+            = (D − B)/2
+            = 1,468 / 2 = 734
+```
+
+The reported "flip buying" effect of +734 is the interaction, halved, and
+nothing else. This run did not measure flip buying as a separable effect —
+it measured what happens when flip buying is added on top of profit selling
+that is already on (arm B → D), because that is the only pair in which flip
+buying ever actually fired.
+
 ## Per-arm trading P&L / round trips / win rate
 
 Recovered from `rehoboam replay-season` run once per arm's exact flag
@@ -59,16 +94,80 @@ itself, only by the underlying per-arm `replay-season` report; arm D's figures
 below are the ones already captured by the determinism-gate runs above, so no
 arm was replayed more than the gate + one confirmatory pass required).
 
-| Arm                                 | Realised flip P&L                                                            | Round trips completed | Win rate                                                                                                  |
-| ----------------------------------- | ---------------------------------------------------------------------------- | --------------------- | --------------------------------------------------------------------------------------------------------- |
-| A (flip buys off, profit sells off) | *(no Trading section — neither flip pass is enabled, so nothing is tracked)* | —                     | —                                                                                                         |
-| B (flip buys off, profit sells ON)  | EUR -49,947,285                                                              | 14                    | 7.1% (1 of 14)                                                                                            |
-| C (flip buys ON, profit sells off)  | EUR +0                                                                       | 0                     | 0.0% (0 of 0) — flip-buy positions open but the profit-sell pass that would realise or record them is off |
-| D (flip buys ON, profit sells ON)   | EUR -34,442,588                                                              | 23                    | 21.7% (5 of 23)                                                                                           |
+| Arm                                 | Realised flip P&L                                                            | Round trips completed | Win rate                                                                |
+| ----------------------------------- | ---------------------------------------------------------------------------- | --------------------- | ----------------------------------------------------------------------- |
+| A (flip buys off, profit sells off) | *(no Trading section — neither flip pass is enabled, so nothing is tracked)* | —                     | —                                                                       |
+| B (flip buys off, profit sells ON)  | EUR -49,947,285                                                              | 14                    | 7.1% (1 of 14)                                                          |
+| C (flip buys ON, profit sells off)  | EUR +0                                                                       | 0                     | 0.0% (0 of 0) — zero flip buys executed, not zero flips sold; see below |
+| D (flip buys ON, profit sells ON)   | EUR -34,442,588                                                              | 23                    | 21.7% (5 of 23)                                                         |
 
 Real 2025/26, for comparison (printed in every arm that shows a Trading
 section, and reproduced by the tool's own INCONCLUSIVE message below): **EUR
 -55,256,064, 151 round trips, 27.8% win rate**.
+
+## Arm C: flip buying was unreachable
+
+Arm C (flip buys ON, profit sells off) is identical to arm A (flip buys OFF,
+profit sells OFF) in every measured respect, not only in points:
+
+| Arm | points | total buys | total sells | final budget |
+| --- | ------ | ---------- | ----------- | ------------ |
+| A   | 26,391 | 5          | 2           | EUR 500,000  |
+| C   | 26,391 | 5          | 2           | EUR 500,000  |
+
+(from `reh71-armA.txt` / `reh71-armC.txt`, the confirmatory `replay-season`
+captures behind the per-arm cash table above). Turning flip buying on changed
+nothing whatsoever: arm C executed **zero** flip buys across the whole season,
+not merely zero *sold* flips.
+
+**Mechanism, established from `rehoboam/replay/engine.py` rather than
+speculated:**
+
+- `_flip_buys` (`engine.py:244-324`) runs after the ordinary EP-buy pass, and
+  by design **never displaces a squad member** to fund itself — its own
+  docstring: "A flip never displaces a squad member, so this stops at
+  `MAX_SQUAD_SIZE` rather than calling `_fieldable_sale_victim`." There is no
+  sale attached to a flip buy that could raise cash for it.
+- Every flip candidate must clear `_solvent_after(state, cost)`
+  (`engine.py:315-316`), called with `proceeds=0`. `_solvent_after`
+  (`engine.py:89-109`) requires `state.budget - cost >= 0` — the *literal*
+  cash balance must cover the purchase, with **no debt allowance**. This is
+  deliberately stricter than `can_buy`'s own credit-line check
+  (`rules.py:29-31`), which permits going negative up to a team-value-based
+  floor; the docstring on `_solvent_after` explains why: a negative balance at
+  kickoff zeroes the whole matchday, so this is an additional decision-time
+  gate on top of the standing legality rule.
+- Both arms A and C end the season on **EUR 500,000** — a balance far below
+  the real transaction prices observed throughout the replay (asks in the
+  captured logs range from ~EUR 4,000,000 to ~EUR 71,000,000). Because the EP
+  pass runs first and spends the budget down, and because profit selling is
+  off in both A and C so nothing replenishes it, the cash balance available to
+  `_flip_buys` for the rest of the season sits far under what any candidate
+  costs.
+- This is consistent with what the arm C output actually shows: candidates
+  *were* being generated and evaluated — `ProfitTrader.find_profit_opportunities`
+  printed 49 "Filtered ... from profit trades: Likely small sample size"
+  warnings during the arm C run, meaning that many candidates cleared its own
+  affordability check (`profit_trader.py:88-102`) far enough to reach the
+  small-sample filter. That affordability check is *more lenient* than
+  `_solvent_after`: it uses `current_budget + max_debt`, a debt-capacity figure
+  derived from team value, not the literal cash balance. So the opportunity
+  finder kept finding and screening candidates throughout the season, while
+  the engine's actual purchase gate — which allows no debt at all for a flip —
+  rejected every single one.
+
+**What the captured output cannot settle:** there is no per-candidate log
+inside `_flip_buys` itself, so this run cannot distinguish "every candidate
+was rejected specifically by `_solvent_after`" from "some were instead
+rejected earlier by the wash-trade guard, the team-limit check, or the
+`with_competition` ask-vs-ceiling comparison at `engine.py:303-305`." The
+identical A/C trade counts prove the *outcome* (zero flip buys) beyond doubt;
+the architecture (flips fund nothing, and the solvency gate is the strictest
+budget check in the path, with budget already exhausted by the EP pass) makes
+insufficient real cash the best-supported explanation for *why*, but it is an
+inference from reading the code together with the aggregate result, not a
+traced observation of each rejected candidate. No new replay was run to
+settle this further, per instruction.
 
 ## The tool's own verdict
 
@@ -89,7 +188,12 @@ A labelled control, not the counterfactual season result.
 **Points evidence was inconclusive.** All three main effects (buy-side +734,
 sell-side +2,057, interaction +1,468) are smaller than the 6,162-point noise
 floor REH-68 measured for a single faithfulness decision, on a ~27,000-point
-season. None of them can be distinguished from replay-harness noise.
+season. None of them can be distinguished from replay-harness noise — and, per
+the correction above, the buy-side figure is not even an independent
+measurement to begin with (it is the interaction halved, because arm C never
+executed a flip buy). Every effect that was measured came out positive, which
+makes the routing to cash evidence a deliberate application of the
+pre-committed rule, not a coincidence that happened to favour it.
 
 Per the rule fixed in advance of this run (design doc §1), when points are
 inconclusive the decision falls to **cash evidence**: real 2025/26 flipping

--- a/docs/superpowers/specs/2026-08-05-reh-71-flip-policy-results.md
+++ b/docs/superpowers/specs/2026-08-05-reh-71-flip-policy-results.md
@@ -3,7 +3,8 @@
 Ticket: https://linear.app/jovily/issue/REH-71
 Date: 2026-08-06
 Status: measurement complete, decision recorded (corrected 2026-08-06 — see
-"Correction" note below)
+"Correction" note below; further corrections from the whole-branch review
+appended 2026-08-07, marked "fix round 2")
 
 This document records the single, once-only run of `rehoboam replay-flip-policy`
 against the 2025/26 season replay, per the design in
@@ -94,6 +95,12 @@ itself, only by the underlying per-arm `replay-season` report; arm D's figures
 below are the ones already captured by the determinism-gate runs above, so no
 arm was replayed more than the gate + one confirmatory pass required).
 
+**Fixed in fix round 2 (I1):** `replay-flip-policy` now prints a per-arm cash
+block of its own, so the four confirmatory runs described above are no longer
+needed to read these figures. The numbers in the table below are the ones
+measured at the time and are unchanged — the tool was taught to print what it
+already held, not re-run.
+
 | Arm                                 | Realised flip P&L                                                            | Round trips completed | Win rate                                                                |
 | ----------------------------------- | ---------------------------------------------------------------------------- | --------------------- | ----------------------------------------------------------------------- |
 | A (flip buys off, profit sells off) | *(no Trading section — neither flip pass is enabled, so nothing is tracked)* | —                     | —                                                                       |
@@ -104,6 +111,48 @@ arm was replayed more than the gate + one confirmatory pass required).
 Real 2025/26, for comparison (printed in every arm that shows a Trading
 section, and reproduced by the tool's own INCONCLUSIVE message below): **EUR
 -55,256,064, 151 round trips, 27.8% win rate**.
+
+### The replay's round trips are NOT the same thing as the real 151
+
+The two round-trip counts sit next to each other in the table above and invite
+a like-for-like reading. They are not like-for-like, and the difference runs in
+the direction that flatters the replay.
+
+`FlipRecord` is appended in exactly one place, `engine._flip_sells` — so the
+replay counts a round trip only when the **profit-taking pass** is what closed
+the position. The live counterpart, `LearningTracker.record_flip_outcome`,
+fires on *every* instant sell of a tracked purchase, including forced ones: a
+player liquidated to restore solvency, or sold to make room for a better
+signing, is a completed round trip in the real ledger and invisible in the
+replay's.
+
+The arithmetic shows the gap plainly. Arm D:
+
+| Arm D                | count |
+| -------------------- | ----- |
+| Total buys           | 35    |
+| Total sells          | 32    |
+| Round trips recorded | 23    |
+
+Nine sells closed positions the ledger never saw. Those are exactly the forced
+exits — sales made under budget pressure or to fund an upgrade — which skew
+loss-making, because a position sold because you *had* to sell it is not a
+position sold at a moment of your choosing. Excluding them makes the replay's
+realised P&L **optimistic**.
+
+So: EUR -34,442,588 over 23 replay round trips is a **narrower, optimistic**
+definition than EUR -55,256,064 over the real 151. It is a lower bound on flip
+harm, not a measurement of it, and the two figures must not be differenced,
+ratioed, or otherwise treated as the same quantity at different scales.
+
+This gap is documented, not closed. Fixing the definition would change the
+figures printed above, and REH-71's protocol fixed those numbers to a single
+run by design. The comment on `FlipRecord` (`rehoboam/replay/engine.py`) states
+the same caveat at the point where a future reader would extend the ledger.
+
+Note this cuts the same way as the verdict rather than against it: the cash
+evidence that decided the ticket is the *real* -EUR 55,256,064, and the replay
+figure understating flip harm cannot have made flipping look worse than it is.
 
 ## Arm C: flip buying was unreachable
 
@@ -208,3 +257,122 @@ Both `Settings.enable_flip_buys` and `Settings.enable_profit_sells` remain
 change anything in `rehoboam/config.py`: an INCONCLUSIVE points result means
 the pre-committed rule's cash branch applies, and that branch is what the
 existing `False` defaults already encode. `tests/test_replay/test_shipped_config.py::test_the_flip_switches_default_off` continues to assert exactly this and was left unchanged, since what it asserts is still what this run supports.
+
+**Scope of `enable_profit_sells` (corrected in fix round 2, I2).** The switch
+originally early-returned from `AutoTrader.run_profit_sell_phase`, which also
+contains the **dead-weight sell** branch — releasing a position-saturated bench
+player (a 5th goalkeeper, a 6th defender) so the squad slot is free for a
+points upgrade. That branch serves points, not profit; the replay never
+modelled it and this factorial measured nothing about it, so switching it off
+with the flip verdict would have been an unmeasured live regression. The gate
+now covers profit-taking and loss-cutting only, and the dead-weight release
+runs regardless of the switch. No measured number in this document is affected
+— the change is to live `auto` behaviour, not to the harness.
+
+## Static checks
+
+`uv run mypy rehoboam/ --ignore-missing-imports`:
+
+| commit                                       | errors |
+| -------------------------------------------- | ------ |
+| `5592a3d` (main, the branch point)           | 68     |
+| `feat/reh-71-flip-policy` before fix round 2 | 71     |
+
+An earlier task report recorded all 71 as pre-existing. That was wrong: the
+true baseline is **68 pre-existing + 3 introduced by this branch**.
+
+The three:
+
+- `rehoboam/replay/engine.py` — two `arg-type` errors on the
+  `_would_create_dead_weight(player, state.players)` call. This is the
+  deliberate duck typing the plan sanctions: the shipped guard is annotated
+  against `MarketPlayer` but reads only `.position`, which `ReplayPlayer` has.
+  Calling the real rule beats reimplementing it, and widening the shipped
+  signature to a `Protocol` would be a refactor of live scoring code that a
+  replay-only change has no business making.
+- `rehoboam/replay/flip_buys.py` — one `attr-defined` error on `o.player.id`.
+  `ProfitOpportunity.player` is annotated `any` (the builtin function, not
+  `typing.Any`) in shipped code this module does not own.
+
+All three now carry narrowly-scoped `# type: ignore[...]` comments explaining
+why, which returns the branch to the 68-error baseline. No unrelated typing
+debt was touched.
+
+## Appendix: the arm A / arm C captures
+
+The correction above ("Arm C: flip buying was unreachable") is load-bearing —
+it is what establishes that the +734 buy-side effect is the interaction halved
+rather than an independent measurement. Its evidence was a pair of
+confirmatory `replay-season` captures held in a session scratchpad. Reproduced
+here verbatim so the claim stays verifiable after that scratchpad ages out.
+
+**Arm A** — `replay-season --with-competition` (flip buys off, profit sells
+off). No Trading section is printed, because neither flip pass is enabled:
+
+```
+Simulated total:    26,391 points
+Actual total:       26,172 points
+Difference:           +219 points
+
+FINISHING POSITION: 9 of 14
+
+Matchdays zeroed by negative budget: none
+Total buys: 5   Total sells: 2
+Final budget: EUR 500,000
+
+Bid competition IS modelled: a listing is won only by bidding above
+what the real buyer paid, and the winning bid is what we pay.
+Profit flipping is NOT modelled: the bot sells only to make room or
+to restore solvency, while the live bot also trades for gain.
+Flip BUYING is NOT modelled: every buy here is justified by expected
+points, while the live bot also buys purely for appreciation.
+```
+
+**Arm C** — `replay-season --with-competition --with-flip-buys` (flip buys ON,
+profit sells off). Identical points, identical trade counts, identical final
+budget; the Trading section appears but is empty:
+
+```
+Simulated total:    26,391 points
+Actual total:       26,172 points
+Difference:           +219 points
+
+FINISHING POSITION: 9 of 14
+
+Trading (cash - does not enter the points attribution above)
+--------------------------------------------------------------------
+  Realised flip P&L                                EUR +0
+  Round trips completed                                 0
+  Win rate                                           0.0%   (0 of 0)
+  Real 2025/26, for comparison            EUR -55,256,064
+                                                      151 trips, 27.8%
+
+Matchdays zeroed by negative budget: none
+Total buys: 5   Total sells: 2
+Final budget: EUR 500,000
+
+Bid competition IS modelled: a listing is won only by bidding above
+what the real buyer paid, and the winning bid is what we pay.
+Profit flipping is NOT modelled: the bot sells only to make room or
+to restore solvency, while the live bot also trades for gain.
+Flip BUYING is modelled: candidates come from the real ProfitTrader,
+bid at an economic ceiling rather than by marginal EP gain.
+```
+
+The arm C capture also carried 49 `⚠️ Filtered ... from profit trades: Likely small sample size` warnings ahead of the report, from
+`ProfitTrader.find_profit_opportunities` — the evidence cited above that
+candidates were being generated and screened throughout the season while the
+engine's purchase gate rejected every one. Two of them, verbatim:
+
+```
+⚠️  Filtered   from profit trades: Likely small sample size (101.5 pts/game,
++232.4% trend)
+⚠️  Filtered   from profit trades: Likely small sample size (80.2 pts/game,
++226.4% trend)
+```
+
+Fix round 2 note: arm C's `EUR +0 / 0 trips / 0.0%` above is a **structural
+zero** — with profit selling off, `_flip_sells` returns before the ledger is
+ever written, so no round trip could close there regardless of how much the
+arm bought. The report now says so on its face (M1); the capture above predates
+that annotation.

--- a/docs/superpowers/specs/2026-08-05-reh-71-flip-policy-results.md
+++ b/docs/superpowers/specs/2026-08-05-reh-71-flip-policy-results.md
@@ -1,0 +1,106 @@
+# REH-71 — Flip policy 2×2 results
+
+Ticket: https://linear.app/jovily/issue/REH-71
+Date: 2026-08-06
+Status: measurement complete, decision recorded
+
+This document records the single, once-only run of `rehoboam replay-flip-policy`
+against the 2025/26 season replay, per the design in
+`2026-08-05-reh-71-flip-policy-design.md`. All four arms run with
+`--with-competition`. Nothing else varies between arms.
+
+## Determinism gate
+
+`rehoboam replay-season --with-competition --with-flips --with-flip-buys`
+(arm D's configuration) was run twice and diffed byte-for-byte. The two runs
+produced identical output — `diff` exited 0. The harness is deterministic; its
+result may be recorded.
+
+## Integrity
+
+SHA-256 of `logs/training_corpus.db`, `logs/bid_learning.db`, and
+`rehoboam/scoring/v2/coefficients.json` was recorded before any replay command
+ran and re-recorded after the full factorial (plus the two determinism-gate
+runs and one confirmatory `replay-season` run per arm to recover each arm's
+cash figures, all read-only). All three hashes are byte-identical before and
+after. Nothing was mutated.
+
+## The four arm totals
+
+Human actual (real 2025/26 season): **26,172 points**
+
+| Arm | flip buys | profit sells | points | delta vs actual |
+| --- | --------- | ------------ | ------ | --------------- |
+| A   | off       | off          | 26,391 | +219            |
+| B   | off       | ON           | 27,714 | +1,542          |
+| C   | ON        | off          | 26,391 | +219            |
+| D   | ON        | ON           | 29,182 | +3,010          |
+
+(Verbatim from `rehoboam replay-flip-policy`.)
+
+## Three main effects (points)
+
+| Effect         | value  |
+| -------------- | ------ |
+| Flip buying    | +734   |
+| Profit selling | +2,057 |
+| Interaction    | +1,468 |
+
+Noise floor (REH-68, fixed before any run in this ticket): **6,162 points**.
+
+All three effects (734, 2,057, 1,468) are smaller in magnitude than the
+6,162-point noise floor.
+
+## Per-arm trading P&L / round trips / win rate
+
+Recovered from `rehoboam replay-season` run once per arm's exact flag
+combination (each arm's cash section is not printed by `replay-flip-policy`
+itself, only by the underlying per-arm `replay-season` report; arm D's figures
+below are the ones already captured by the determinism-gate runs above, so no
+arm was replayed more than the gate + one confirmatory pass required).
+
+| Arm                                 | Realised flip P&L                                                            | Round trips completed | Win rate                                                                                                  |
+| ----------------------------------- | ---------------------------------------------------------------------------- | --------------------- | --------------------------------------------------------------------------------------------------------- |
+| A (flip buys off, profit sells off) | *(no Trading section — neither flip pass is enabled, so nothing is tracked)* | —                     | —                                                                                                         |
+| B (flip buys off, profit sells ON)  | EUR -49,947,285                                                              | 14                    | 7.1% (1 of 14)                                                                                            |
+| C (flip buys ON, profit sells off)  | EUR +0                                                                       | 0                     | 0.0% (0 of 0) — flip-buy positions open but the profit-sell pass that would realise or record them is off |
+| D (flip buys ON, profit sells ON)   | EUR -34,442,588                                                              | 23                    | 21.7% (5 of 23)                                                                                           |
+
+Real 2025/26, for comparison (printed in every arm that shows a Trading
+section, and reproduced by the tool's own INCONCLUSIVE message below): **EUR
+-55,256,064, 151 round trips, 27.8% win rate**.
+
+## The tool's own verdict
+
+Verbatim from `rehoboam replay-flip-policy`:
+
+```
+INCONCLUSIVE on points - every effect is inside the noise floor.
+Per the pre-committed rule, the decision falls to the cash evidence:
+real flipping lost EUR 55,256,064 at a 27.8% win rate over 151 round trips,
+and every round trip pays a measured 11.7% toll. Both switches
+default OFF, decided on cash rather than on points.
+
+A labelled control, not the counterfactual season result.
+```
+
+## Which evidence decided it
+
+**Points evidence was inconclusive.** All three main effects (buy-side +734,
+sell-side +2,057, interaction +1,468) are smaller than the 6,162-point noise
+floor REH-68 measured for a single faithfulness decision, on a ~27,000-point
+season. None of them can be distinguished from replay-harness noise.
+
+Per the rule fixed in advance of this run (design doc §1), when points are
+inconclusive the decision falls to **cash evidence**: real 2025/26 flipping
+lost EUR 55,256,064 over 151 round trips at a 27.8% win rate, with every round
+trip paying a measured 11.7% toll (mean transaction price 1.117× market value
+against an instant sell returning 1.00×).
+
+## Resulting switch values
+
+Both `Settings.enable_flip_buys` and `Settings.enable_profit_sells` remain
+**`False`** (unchanged from their Task 11 defaults). The verdict did not
+change anything in `rehoboam/config.py`: an INCONCLUSIVE points result means
+the pre-committed rule's cash branch applies, and that branch is what the
+existing `False` defaults already encode. `tests/test_replay/test_shipped_config.py::test_the_flip_switches_default_off` continues to assert exactly this and was left unchanged, since what it asserts is still what this run supports.

--- a/rehoboam/auto_trader.py
+++ b/rehoboam/auto_trader.py
@@ -753,21 +753,44 @@ class AutoTrader:
         return trend_7d_pct < 1.0
 
     def run_profit_sell_phase(self, league, ctx: EPSessionContext) -> list[AutoTradeResult]:
-        """Trend-aware profit sell monitoring.
+        """Trend-aware sell monitoring: profit/loss exits AND dead-weight release.
 
         Uses formation-aware best-11 to protect true starters, and trend data
         to dynamically adjust sell thresholds. Only sells best-11 members when
         a replacement is lined up in the EP pipeline.
-        """
-        if not self.settings.enable_profit_sells:
-            console.print("[dim]Profit selling disabled (REH-71)[/dim]")
-            return []
 
+        Two different behaviours live in this one method, and only one of them
+        is flipping (REH-71):
+
+        * **Profit-taking / loss-cutting** against the cost basis. This is
+          trading for cash, and it is what ``Settings.enable_profit_sells``
+          exists to switch off.
+        * **Dead-weight release** — dumping a position-saturated bench player
+          (a 5th goalkeeper, a 6th defender) who can never enter any starting
+          eleven under any formation, so that the squad slot is free for a
+          points upgrade. The slot is the asset; the branch deliberately
+          accepts a small market-value loss to obtain it.
+
+        The dead-weight branch serves POINTS, not profit. It was never part of
+        the flip question REH-71 asked, the season replay never modelled it,
+        and the 2x2 factorial measured nothing about it — so
+        ``enable_profit_sells=False`` must leave it running. Gating it too
+        would be an unmeasured live regression, not a decision anyone made.
+        Hence the switch guards the candidate loop below rather than the whole
+        method: both branches share the squad refresh, the best-11
+        computation, the position counts and the trend lookups.
+        """
         from .formation import select_best_eleven
         from .trader import Trader
 
+        profit_sells_enabled = self.settings.enable_profit_sells
+
         results = []
-        console.print("\n[bold cyan]📈 Profit Sell Monitoring (trend-aware)[/bold cyan]")
+        console.print("\n[bold cyan]📈 Sell Monitoring (trend-aware)[/bold cyan]")
+        if not profit_sells_enabled:
+            console.print(
+                "[dim]Profit selling disabled (REH-71) — dead-weight release still runs[/dim]"
+            )
 
         # Refresh squad — earlier phases (auction resolution, deferred sells)
         # may have changed the squad since ctx was built.
@@ -823,82 +846,91 @@ class AutoTrader:
         trend_7d_by_id: dict[str, float | None] = {}
 
         sell_candidates = []
-        for player in squad:
-            if player.id in best_11_ids:
-                continue
+        # Profit-taking and loss-cutting: the flip behaviour, and the only
+        # part of this method REH-71's switch governs.
+        if profit_sells_enabled:
+            for player in squad:
+                if player.id in best_11_ids:
+                    continue
 
-            if not player.buy_price or player.buy_price <= 0:
-                continue
+                if not player.buy_price or player.buy_price <= 0:
+                    continue
 
-            # Min-hold guard: refuse to sell a player we just bought. Same-
-            # session reversals (bid → win → instant-sell at -71% within 7h
-            # for Niang in production) cost both the bid spread and a
-            # market-value loss, with no signal change to justify them.
-            held_too_briefly, hours_held = self._was_recently_bought(player.id)
-            if held_too_briefly:
-                console.print(
-                    f"[dim]Hold-period guard {player.last_name} — "
-                    f"held {hours_held:.1f}h (< {self._min_hold_seconds() / 3600:.0f}h min)[/dim]"
-                )
-                continue
-
-            # Hard block: never sell if it would drop a position below its
-            # formation minimum. A squad with 0 FW loses -100 pts every matchday.
-            pos_min = POSITION_MINIMUMS.get(player.position, 0)
-            if position_counts.get(player.position, 0) <= pos_min:
-                console.print(
-                    f"[dim]Protected {player.last_name} ({player.position}) — "
-                    f"at position minimum ({pos_min})[/dim]"
-                )
-                continue
-
-            profit = player.market_value - player.buy_price
-            profit_pct = (profit / player.buy_price) * 100
-
-            # Get trend to determine dynamic threshold
-            try:
-                trend = trader.trend_service.get_trend(player.id, player.market_value, league.id)
-                trend_7d = trend.trend_7d_pct
-            except Exception:
-                trend_7d = None
-            trend_7d_by_id[player.id] = trend_7d
-
-            sell_threshold = self._sell_threshold_for_trend(trend_7d)
-
-            # Profit target hit (trend-adjusted)
-            if profit_pct >= sell_threshold:
-                trend_info = f", trend {trend_7d:+.1f}%/wk" if trend_7d is not None else ""
-                sell_candidates.append(
-                    (
-                        player,
-                        profit_pct,
-                        f"Profit target ({sell_threshold:.0f}%) hit: +{profit_pct:.1f}% (€{profit:,}{trend_info})",
+                # Min-hold guard: refuse to sell a player we just bought. Same-
+                # session reversals (bid → win → instant-sell at -71% within 7h
+                # for Niang in production) cost both the bid spread and a
+                # market-value loss, with no signal change to justify them.
+                held_too_briefly, hours_held = self._was_recently_bought(player.id)
+                if held_too_briefly:
+                    console.print(
+                        f"[dim]Hold-period guard {player.last_name} — held "
+                        f"{hours_held:.1f}h (< {self._min_hold_seconds() / 3600:.0f}h min)[/dim]"
                     )
-                )
-            # Stop-loss: only if a same-position upgrade is queued AND the
-            # price isn't already rebounding (locking in a loss while the
-            # recovery is in progress is the worst possible exit).
-            elif (
-                profit_pct <= -5.0
-                and self._has_position_replacement(
-                    player.position, buy_recs, trade_pairs, stop_loss_min_ep_gain
-                )
-                and self._can_loss_sell_with_replacement(trend_7d)
-            ):
-                sell_candidates.append(
-                    (
-                        player,
-                        profit_pct,
-                        f"Stop-loss ({player.position} upgrade queued): "
-                        f"{profit_pct:.1f}% (€{profit:,})",
+                    continue
+
+                # Hard block: never sell if it would drop a position below its
+                # formation minimum. A squad with 0 FW loses -100 pts every matchday.
+                pos_min = POSITION_MINIMUMS.get(player.position, 0)
+                if position_counts.get(player.position, 0) <= pos_min:
+                    console.print(
+                        f"[dim]Protected {player.last_name} ({player.position}) — "
+                        f"at position minimum ({pos_min})[/dim]"
                     )
-                )
+                    continue
+
+                profit = player.market_value - player.buy_price
+                profit_pct = (profit / player.buy_price) * 100
+
+                # Get trend to determine dynamic threshold
+                try:
+                    trend = trader.trend_service.get_trend(
+                        player.id, player.market_value, league.id
+                    )
+                    trend_7d = trend.trend_7d_pct
+                except Exception:
+                    trend_7d = None
+                trend_7d_by_id[player.id] = trend_7d
+
+                sell_threshold = self._sell_threshold_for_trend(trend_7d)
+
+                # Profit target hit (trend-adjusted)
+                if profit_pct >= sell_threshold:
+                    trend_info = f", trend {trend_7d:+.1f}%/wk" if trend_7d is not None else ""
+                    sell_candidates.append(
+                        (
+                            player,
+                            profit_pct,
+                            f"Profit target ({sell_threshold:.0f}%) hit: "
+                            f"+{profit_pct:.1f}% (€{profit:,}{trend_info})",
+                        )
+                    )
+                # Stop-loss: only if a same-position upgrade is queued AND the
+                # price isn't already rebounding (locking in a loss while the
+                # recovery is in progress is the worst possible exit).
+                elif (
+                    profit_pct <= -5.0
+                    and self._has_position_replacement(
+                        player.position, buy_recs, trade_pairs, stop_loss_min_ep_gain
+                    )
+                    and self._can_loss_sell_with_replacement(trend_7d)
+                ):
+                    sell_candidates.append(
+                        (
+                            player,
+                            profit_pct,
+                            f"Stop-loss ({player.position} upgrade queued): "
+                            f"{profit_pct:.1f}% (€{profit:,})",
+                        )
+                    )
 
         # Dead-weight sell: surplus-position bench players (e.g. 2nd/3rd GK)
         # that block the squad from buying useful players.  Even at a small
         # loss, freeing the slot is worth it when the EP pipeline has buy
         # candidates waiting — the matchday points gained over a season
         # vastly outweigh a one-time market value loss.
+        #
+        # DELIBERATELY NOT gated on `enable_profit_sells` (REH-71): this is a
+        # points move, not a flip. See the method docstring.
         from .formation import _POSITION_MAX_STARTERS
 
         already_selling = {p.id for p, _, _ in sell_candidates}
@@ -912,6 +944,10 @@ class AutoTrader:
             if held_too_briefly:
                 continue  # Already logged in the loop above; skip silently here.
 
+            # Saturation implies the position is comfortably above its
+            # formation minimum (max starters >= minimum for every position),
+            # so loop 1's explicit POSITION_MINIMUMS guard is redundant here —
+            # which is why this branch stays correct when loop 1 is skipped.
             max_starters = _POSITION_MAX_STARTERS.get(player.position, 3)
             if position_counts.get(player.position, 0) <= max_starters:
                 continue  # Position not saturated — not dead weight
@@ -919,11 +955,13 @@ class AutoTrader:
             profit = player.market_value - player.buy_price
             profit_pct = (profit / player.buy_price) * 100
 
-            # Reuse the trend cached in the first loop. Every player that
-            # reaches this point passed the same best_11 + buy_price gates
-            # in loop 1 and either landed in `already_selling` (filtered
-            # above) or had its trend cached, so a missing key would mean
-            # an upstream filter changed — fetch defensively in that case.
+            # Reuse the trend cached in the first loop when there is one. With
+            # profit selling enabled, every player reaching this point passed
+            # the same best_11 + buy_price gates in loop 1 and either landed in
+            # `already_selling` (filtered above) or had its trend cached, so a
+            # missing key would mean an upstream filter changed. With profit
+            # selling disabled the cache is empty by construction because loop
+            # 1 never ran. Both cases fall through to the same lookup.
             if player.id in trend_7d_by_id:
                 trend_7d = trend_7d_by_id[player.id]
             else:

--- a/rehoboam/auto_trader.py
+++ b/rehoboam/auto_trader.py
@@ -341,7 +341,11 @@ class AutoTrader:
 
         # Also add profit flip candidates if phase allows and there are open slots
         profit_flip_candidates = []
-        if ctx.matchday_phase.allow_flips and available_slots > 0:
+        if (
+            self.settings.enable_flip_buys
+            and ctx.matchday_phase.allow_flips
+            and available_slots > 0
+        ):
             try:
                 from .trader import Trader
 
@@ -755,6 +759,10 @@ class AutoTrader:
         to dynamically adjust sell thresholds. Only sells best-11 members when
         a replacement is lined up in the EP pipeline.
         """
+        if not self.settings.enable_profit_sells:
+            console.print("[dim]Profit selling disabled (REH-71)[/dim]")
+            return []
+
         from .formation import select_best_eleven
         from .trader import Trader
 

--- a/rehoboam/cli.py
+++ b/rehoboam/cli.py
@@ -758,6 +758,28 @@ def replay_buy_control(
     console.print(run_buy_control(corpus_path=corpus, learning_db_path=learning_db))
 
 
+@app.command("replay-flip-policy")
+def replay_flip_policy(
+    corpus: Path = typer.Option(  # noqa: B008
+        Path("logs/training_corpus.db"), help="Path to the training corpus DB"
+    ),
+    learning_db: Path = typer.Option(  # noqa: B008
+        Path("logs/bid_learning.db"), help="Path to the learning DB with real standings"
+    ),
+) -> None:
+    """REH-71: 2x2 over flip buys x profit sells, with competition on."""
+    from rehoboam.replay.driver import run_flip_policy
+
+    if not corpus.exists():
+        console.print(f"[red]Corpus not found: {corpus}[/red]")
+        raise typer.Exit(1)
+    if not learning_db.exists():
+        console.print(f"[red]Learning DB not found: {learning_db}[/red]")
+        raise typer.Exit(1)
+
+    console.print(run_flip_policy(corpus_path=corpus, learning_db_path=learning_db))
+
+
 @app.command("fit-scorer")
 def fit_scorer(
     availability_k: float = typer.Option(

--- a/rehoboam/cli.py
+++ b/rehoboam/cli.py
@@ -705,6 +705,15 @@ def replay_season(
             "lands, so treat the output as a diagnostic, not a season result."
         ),
     ),
+    with_flip_buys: bool = typer.Option(
+        False,
+        "--with-flip-buys",
+        help=(
+            "Model profit-flip BUYING (REH-71): candidates from the real "
+            "ProfitTrader, bid at an economic ceiling. The live bot does this; "
+            "--with-flips alone only models the selling half."
+        ),
+    ),
 ) -> None:
     """Replay the full bot across 2025/26 and report the counterfactual finish."""
     from rehoboam.replay.driver import run_replay
@@ -722,6 +731,7 @@ def replay_season(
         min_ep_gain=min_ep_gain,
         with_competition=with_competition,
         with_flips=with_flips,
+        with_flip_buys=with_flip_buys,
     )
     console.print(report)
 

--- a/rehoboam/config.py
+++ b/rehoboam/config.py
@@ -71,6 +71,10 @@ class Settings(BaseSettings):
         default=False,
         description="Buy players for expected appreciation rather than expected points",
     )
+    # Scope note: this switches off profit-taking and loss-cutting only. The
+    # dead-weight release inside the same phase (dumping a position-saturated
+    # bench player to free a squad slot for a points upgrade) keeps running —
+    # it serves points, not profit, and was never part of what REH-71 measured.
     enable_profit_sells: bool = Field(
         default=False,
         description="Take profit / cut losses on squad players against their cost basis",

--- a/rehoboam/config.py
+++ b/rehoboam/config.py
@@ -63,6 +63,18 @@ class Settings(BaseSettings):
         default=-15.0,
         description="Maximum loss percentage before triggering sell (relaxed — daily fluctuations of 3-10% are normal)",
     )
+    # REH-71. Real flipping lost EUR 55,256,064 over 151 round trips at a 27.8%
+    # win rate, and every round trip pays a measured 11.7% toll. Split in two
+    # because buying for appreciation and taking profit on the squad are
+    # distinct behaviours that need not share a verdict.
+    enable_flip_buys: bool = Field(
+        default=False,
+        description="Buy players for expected appreciation rather than expected points",
+    )
+    enable_profit_sells: bool = Field(
+        default=False,
+        description="Take profit / cut losses on squad players against their cost basis",
+    )
     min_buy_value_increase_pct: float = Field(
         default=10.0,
         description="Minimum market value increase to consider buying",

--- a/rehoboam/replay/attribution.py
+++ b/rehoboam/replay/attribution.py
@@ -180,3 +180,66 @@ def format_report(
         "=" * 68,
     ]
     return "\n".join(lines)
+
+
+# REH-68 measured a single faithfulness decision moving the season total by this
+# much. Any flip delta smaller than it is modelling noise, not a finding. Fixed
+# BEFORE the runs so the result cannot be rationalised after it is seen.
+NOISE_FLOOR_POINTS = 6_162
+
+ARM_LABELS = {
+    "A": "flip buys off, profit sells off",
+    "B": "flip buys off, profit sells ON",
+    "C": "flip buys ON,  profit sells off",
+    "D": "flip buys ON,  profit sells ON",
+}
+
+
+def format_flip_policy(arms: dict, *, actual_total: int) -> str:
+    """The 2x2, its main effects, and the pre-committed decision rule."""
+    points = {key: arms[key].total_points for key in ("A", "B", "C", "D")}
+    buy_effect = (points["C"] + points["D"]) / 2 - (points["A"] + points["B"]) / 2
+    sell_effect = (points["B"] + points["D"]) / 2 - (points["A"] + points["C"]) / 2
+    interaction = (points["D"] - points["C"]) - (points["B"] - points["A"])
+
+    lines = [
+        "=" * 68,
+        "FLIP POLICY 2x2 - REH-71",
+        "=" * 68,
+        "",
+        f"Human actual: {actual_total:>8,}",
+        "",
+    ]
+    for key in ("A", "B", "C", "D"):
+        delta = points[key] - actual_total
+        lines.append(f"  {key}  {ARM_LABELS[key]:<34}{points[key]:>9,}  ({delta:+,})")
+
+    lines += [
+        "",
+        "Main effects (points)",
+        "-" * 68,
+        f"  {'Flip buying':<34}{buy_effect:>+9,.0f}",
+        f"  {'Profit selling':<34}{sell_effect:>+9,.0f}",
+        f"  {'Interaction':<34}{interaction:>+9,.0f}",
+        "",
+        f"Noise floor (REH-68): {NOISE_FLOOR_POINTS:,} points",
+        "",
+    ]
+
+    effects = (abs(buy_effect), abs(sell_effect), abs(interaction))
+    if max(effects) < NOISE_FLOOR_POINTS:
+        lines += [
+            "INCONCLUSIVE on points - every effect is inside the noise floor.",
+            "Per the pre-committed rule, the decision falls to the cash evidence:",
+            f"real flipping lost EUR {abs(REAL_FLIP_PNL):,} at a "
+            f"{REAL_FLIP_WIN_RATE}% win rate over {REAL_FLIP_TRIPS} round trips,",
+            "and every round trip pays a measured 11.7% toll. Both switches",
+            "default OFF, decided on cash rather than on points.",
+        ]
+    else:
+        lines += [
+            "An effect clears the noise floor. Adopt that arm's verdict for its",
+            "own switch; the other switch follows the same rule independently.",
+        ]
+    lines += ["", "A labelled control, not the counterfactual season result.", "=" * 68]
+    return "\n".join(lines)

--- a/rehoboam/replay/attribution.py
+++ b/rehoboam/replay/attribution.py
@@ -14,7 +14,7 @@ FIDELITY_NOTES = [
     ("Points scoring", "exact", "real per-match points from the corpus"),
     ("Penalty avoidance", "exact", "deterministic"),
     ("Lineup selection", "high", "real squad, real formation rules"),
-    ("Sell decisions", "medium", "instant sell at MV; profit flips NOT modelled"),
+    ("Sell decisions", "medium", "instant sell at MV; profit flips per --with-flips"),
     ("Buy prices", "high", "real transaction prices"),
     ("Buy availability", "medium", "only players who actually traded are visible"),
     ("Bid competition", "see footer", "absent unless --with-competition"),
@@ -32,6 +32,20 @@ def place_in_league(simulated_total: int, standings: list[LeagueStanding]) -> in
     """1-indexed finishing position. Ties do not overtake the real manager."""
     ahead = sum(1 for s in standings if s.total_points >= simulated_total)
     return ahead + 1
+
+
+# The real 2025/26 season, for comparison. Without a reference the replay's own
+# P&L is uninterpretable.
+REAL_FLIP_PNL = -55_256_064
+REAL_FLIP_TRIPS = 151
+REAL_FLIP_WIN_RATE = 27.8
+
+
+def trading_summary(result: SeasonResult) -> tuple[int, int, int]:
+    """``(realised_pnl, round_trips, wins)`` over completed round trips."""
+    pnl = sum(f.proceeds - f.buy_price for f in result.flips)
+    wins = sum(1 for f in result.flips if f.proceeds > f.buy_price)
+    return pnl, len(result.flips), wins
 
 
 def attribution_rows(
@@ -67,6 +81,7 @@ def format_report(
     min_ep_gain: float,
     with_competition: bool = False,
     with_flips: bool = False,
+    with_flip_buys: bool = False,
 ) -> str:
     """Human-readable replay report with fidelity caveats attached.
 
@@ -100,6 +115,20 @@ def format_report(
         f"  {'Marginal EP gain floor':<34}{min_ep_gain:>9,.1f}   real points, "
         "buys below this are skipped"
     )
+
+    if with_flips or with_flip_buys:
+        pnl, trips, wins = trading_summary(result)
+        rate = (100.0 * wins / trips) if trips else 0.0
+        lines += [
+            "",
+            "Trading (cash - does not enter the points attribution above)",
+            "-" * 68,
+            f"  {'Realised flip P&L':<34}{'EUR ' + format(pnl, '+,'):>21}",
+            f"  {'Round trips completed':<34}{trips:>21,}",
+            f"  {'Win rate':<34}{rate:>20.1f}%   ({wins} of {trips})",
+            f"  {'Real 2025/26, for comparison':<34}" f"{'EUR ' + format(REAL_FLIP_PNL, '+,'):>21}",
+            f"  {'':<34}{REAL_FLIP_TRIPS:>21,} trips, {REAL_FLIP_WIN_RATE}%",
+        ]
 
     lines += ["", "Fidelity", "-" * 68]
     for component, level, basis in FIDELITY_NOTES:
@@ -135,7 +164,17 @@ def format_report(
             "Profit flipping is NOT modelled: the bot sells only to make room or",
             "to restore solvency, while the live bot also trades for gain.",
         ]
-    if not (with_competition and with_flips):
+    if with_flip_buys:
+        lines += [
+            "Flip BUYING is modelled: candidates come from the real ProfitTrader,",
+            "bid at an economic ceiling rather than by marginal EP gain.",
+        ]
+    else:
+        lines += [
+            "Flip BUYING is NOT modelled: every buy here is justified by expected",
+            "points, while the live bot also buys purely for appreciation.",
+        ]
+    if not (with_competition and with_flips and with_flip_buys):
         lines += ["INCOMPLETE - diagnostic only, not a season result."]
     lines += [
         "=" * 68,

--- a/rehoboam/replay/attribution.py
+++ b/rehoboam/replay/attribution.py
@@ -48,6 +48,18 @@ def trading_summary(result: SeasonResult) -> tuple[int, int, int]:
     return pnl, len(result.flips), wins
 
 
+# Printed whenever a Trading block appears with profit selling switched off.
+# The ledger is only ever appended to by `_flip_sells`, which returns
+# immediately when both thresholds are None, so such a run CANNOT close a round
+# trip no matter how much it bought. Without this note "EUR +0 / 0 trips /
+# 0.0%" reads as "flipping cost nothing here", which is the opposite of what a
+# structural zero means.
+STRUCTURAL_ZERO_NOTE = [
+    "  NOTE: profit selling is OFF in this run, so no round trip can close and",
+    "  the zero above is STRUCTURAL - not evidence that flipping was free.",
+]
+
+
 def attribution_rows(
     result: SeasonResult,
     *,
@@ -129,6 +141,8 @@ def format_report(
             f"  {'Real 2025/26, for comparison':<34}" f"{'EUR ' + format(REAL_FLIP_PNL, '+,'):>21}",
             f"  {'':<34}{REAL_FLIP_TRIPS:>21,} trips, {REAL_FLIP_WIN_RATE}%",
         ]
+        if not with_flips:
+            lines += STRUCTURAL_ZERO_NOTE
 
     lines += ["", "Fidelity", "-" * 68]
     for component, level, basis in FIDELITY_NOTES:
@@ -194,6 +208,10 @@ ARM_LABELS = {
     "D": "flip buys ON,  profit sells ON",
 }
 
+# Which arms have the sell side enabled — the arms in which a round trip is
+# even capable of closing. Kept beside ARM_LABELS so the two cannot drift.
+ARM_PROFIT_SELLS = {"A": False, "B": True, "C": False, "D": True}
+
 
 def format_flip_policy(arms: dict, *, actual_total: int) -> str:
     """The 2x2, its main effects, and the pre-committed decision rule."""
@@ -221,6 +239,31 @@ def format_flip_policy(arms: dict, *, actual_total: int) -> str:
         f"  {'Flip buying':<34}{buy_effect:>+9,.0f}",
         f"  {'Profit selling':<34}{sell_effect:>+9,.0f}",
         f"  {'Interaction':<34}{interaction:>+9,.0f}",
+        "",
+    ]
+
+    # Per-arm cash, printed HERE rather than left to a separate `replay-season`
+    # run per arm (design doc S3: "The Trading block appears in both"). The
+    # decision rule below routes an inconclusive points result to the cash
+    # evidence, so a report that shows no cash sends the reader looking for
+    # numbers this command already holds.
+    lines += [
+        "Trading (cash - does not enter the points above)",
+        "-" * 68,
+        f"  {'Arm':<4}{'Realised flip P&L':>20}{'Round trips':>13}{'Win rate':>11}",
+    ]
+    for key in ("A", "B", "C", "D"):
+        pnl, trips, wins = trading_summary(arms[key])
+        rate = (100.0 * wins / trips) if trips else 0.0
+        note = "" if ARM_PROFIT_SELLS[key] else "  structural zero"
+        lines.append(f"  {key:<4}{'EUR ' + format(pnl, '+,'):>20}{trips:>13,}{rate:>10.1f}%{note}")
+    lines += [
+        f"  {'real':<4}{'EUR ' + format(REAL_FLIP_PNL, '+,'):>20}"
+        f"{REAL_FLIP_TRIPS:>13,}{REAL_FLIP_WIN_RATE:>10.1f}%",
+        "",
+        "'structural zero' marks an arm with profit selling OFF: the ledger is",
+        "only written when a position is sold back, so no round trip can close",
+        "there however much the arm bought. Read it as unmeasurable, not free.",
         "",
         f"Noise floor (REH-68): {NOISE_FLOOR_POINTS:,} points",
         "",

--- a/rehoboam/replay/driver.py
+++ b/rehoboam/replay/driver.py
@@ -186,6 +186,7 @@ def run_replay(
     buy_quota: dict[int, int] | None = None,
     with_competition: bool = False,
     with_flips: bool = False,
+    with_flip_buys: bool = False,
 ) -> tuple[SeasonResult, str]:
     """Replay the whole season and return the result plus a formatted report.
 
@@ -220,6 +221,19 @@ def run_replay(
 
     gain_floor = shipped_min_ep_gain() if min_ep_gain is None else min_ep_gain
 
+    flip_buy_fn = None
+    if with_flip_buys:
+        from rehoboam.replay.flip_buys import make_flip_buy_fn
+
+        flip_buy_fn = make_flip_buy_fn(
+            corpus,
+            season=SEASON,
+            # The SAME resolver the scorer uses, so the flip path and the EP
+            # path cannot disagree about which matchday is being predicted.
+            day_fn=lambda at: day_for_kickoff(kickoffs, at),
+            position_fn=position_fn,
+        )
+
     result = run_season(
         state=state,
         market=market,
@@ -241,6 +255,11 @@ def run_replay(
         # re-tune must not leave the harness describing a bot nobody deployed.
         profit_take_pct=_shipped_default("min_sell_profit_pct") if with_flips else None,
         loss_cut_pct=_shipped_default("max_loss_pct") if with_flips else None,
+        flip_buy_fn=flip_buy_fn,
+        # Wired unconditionally: this guards how the bot trades, not which
+        # experiment arm is running. `_flip_buys` is the only consumer, so it
+        # is a no-op whenever flip_buy_fn is None (REH-71 review of REH-66/68).
+        wash_trade_block_seconds=_shipped_default("wash_trade_block_hours") * 3600.0,
     )
 
     with sqlite3.connect(learning_db_path) as conn:
@@ -261,6 +280,7 @@ def run_replay(
         min_ep_gain=gain_floor,
         with_competition=with_competition,
         with_flips=with_flips,
+        with_flip_buys=with_flip_buys,
     )
     return result, report
 

--- a/rehoboam/replay/driver.py
+++ b/rehoboam/replay/driver.py
@@ -345,6 +345,38 @@ def run_buy_control(*, corpus_path: Path, learning_db_path: Path) -> str:
     return "\n".join(lines)
 
 
+def run_flip_policy(*, corpus_path: Path, learning_db_path: Path) -> str:
+    """REH-71: the 2x2 over flip buys x profit sells.
+
+    Every arm runs with bid competition on, because the whole question is what
+    flipping is worth when rivals contest the same listings. Nothing else varies
+    between arms.
+    """
+    from rehoboam.replay.attribution import format_flip_policy
+
+    arms = {}
+    for key, flip_buys, profit_sells in (
+        ("A", False, False),
+        ("B", False, True),
+        ("C", True, False),
+        ("D", True, True),
+    ):
+        arms[key], _report = run_replay(
+            corpus_path=corpus_path,
+            learning_db_path=learning_db_path,
+            with_competition=True,
+            with_flips=profit_sells,
+            with_flip_buys=flip_buys,
+        )
+
+    with sqlite3.connect(learning_db_path) as conn:
+        actual_total = conn.execute(
+            "SELECT MAX(total_points) FROM league_rank_history WHERE is_self = 1"
+        ).fetchone()[0]
+
+    return format_flip_policy(arms, actual_total=int(actual_total or 0))
+
+
 def make_ep_bid_fn(
     *,
     mv_fn: Callable[[str, float], int | None],

--- a/rehoboam/replay/engine.py
+++ b/rehoboam/replay/engine.py
@@ -212,6 +212,74 @@ def _flip_sells(
     return sells
 
 
+def _flip_buys(
+    state: ReplayState,
+    scores: dict[str, float],
+    listings: list,
+    at: float,
+    *,
+    flip_buy_fn: Callable[[list, float, int, int], list],
+    score_fn: Callable[[str, float], float],
+    mv_fn: Callable[[str, float], int | None],
+    position_fn: Callable[[str], str | None],
+    team_fn: Callable[[str], str | None],
+    with_competition: bool,
+) -> int:
+    """Buy for expected appreciation with the slots the EP pass left (REH-71).
+
+    Mirrors the live ordering: EP candidates execute first and flips take
+    "remaining slots" (auto_trader.py:533). A flip never displaces a squad
+    member, so this stops at MAX_SQUAD_SIZE rather than calling
+    ``_fieldable_sale_victim``.
+
+    Candidates carry their own ``max_bid`` from ``flip_buys.flip_bid_ceiling``
+    rather than going through ``bid_fn``: a flip's marginal EP gain is ~0 by
+    construction, so the EP bidder would put every flip in its bottom tier and
+    lose every contested listing, reporting a bidder artifact as a fact about
+    flipping.
+    """
+    from rehoboam.scoring.decision import _would_create_dead_weight
+
+    by_id = {listing.player_id: listing for listing in listings}
+    team_value = _team_value(state, mv_fn, at)
+    buys = 0
+
+    for candidate in flip_buy_fn(listings, at, state.budget, team_value):
+        if state.squad_size >= MAX_SQUAD_SIZE:
+            break
+        pid = candidate.player_id
+        listing = by_id.get(pid)
+        position = position_fn(pid)
+        if listing is None or not position or pid in state.squad:
+            continue
+
+        # Under competition we must outbid what the real buyer paid, and we then
+        # pay our own bid. Without it the listing is ours at its asking price --
+        # but never above the ceiling, which is an economic limit either way.
+        if with_competition:
+            if candidate.max_bid <= listing.price:
+                continue
+            cost = int(candidate.max_bid)
+        else:
+            if listing.price > candidate.max_bid:
+                continue
+            cost = int(listing.price)
+
+        player = ReplayPlayer(id=pid, position=position, team_id=team_fn(pid))
+        if _would_create_dead_weight(player, state.players):
+            continue
+        allowed, _reason = can_buy(state, player, cost, team_value=team_value)
+        if not allowed or not _solvent_after(state, cost):
+            continue
+
+        state.buy(player, cost, at=at)
+        scores[pid] = score_fn(pid, at)
+        team_value = _team_value(state, mv_fn, at)
+        buys += 1
+
+    return buys
+
+
 def shipped_min_ep_gain() -> float:
     """The marginal-gain floor the live bot actually ships with (REH-66).
 
@@ -265,6 +333,10 @@ def run_season(
     # sells only to make room or to restore solvency.
     profit_take_pct: float | None = None,
     loss_cut_pct: float | None = None,
+    # REH-71 flip buys. Given (listings, at, budget, team_value), returns
+    # candidates carrying their own economic max_bid. None keeps the shipped
+    # behaviour, in which every buy is justified by marginal expected points.
+    flip_buy_fn: Callable[[list, float, int, int], list] | None = None,
 ) -> SeasonResult:
     """Replay every matchday in order, mutating ``state`` as the bot would."""
     result = SeasonResult()
@@ -364,6 +436,20 @@ def run_season(
             state.buy(candidate, cost, at=decide_at)
             scores[candidate.id] = cand_ep
             buys += 1
+
+        if flip_buy_fn is not None:
+            buys += _flip_buys(
+                state,
+                scores,
+                listings,
+                decide_at,
+                flip_buy_fn=flip_buy_fn,
+                score_fn=score_fn,
+                mv_fn=mv_fn,
+                position_fn=position_fn,
+                team_fn=team_fn,
+                with_competition=bid_fn is not None,
+            )
 
         # Budget must be non-negative at kickoff or the matchday scores zero.
         sells += _restore_budget(state, scores, mv_fn, decide_at)

--- a/rehoboam/replay/engine.py
+++ b/rehoboam/replay/engine.py
@@ -195,6 +195,12 @@ def _flip_sells(
     worse, since re-entry pays a measured 1.117x market value.
 
     Players with no cost basis are skipped rather than assumed free.
+
+    Every sale here also gets a shot at ``ledger``: a completed round trip is
+    recorded, but only for players whose ``acquired == "bought"``. The opening
+    squad was *assigned*, not bought (REH-68), so counting its disposals would
+    inflate the round-trip count and make ``ledger`` incomparable to the real
+    151 round trips it exists to be compared against (REH-71).
     """
     if profit_take_pct is None and loss_cut_pct is None:
         return 0

--- a/rehoboam/replay/engine.py
+++ b/rehoboam/replay/engine.py
@@ -58,11 +58,23 @@ class MatchdayOutcome:
     sells: int
 
 
+@dataclass(frozen=True)
+class FlipRecord:
+    """One completed round trip: a player the replay bought and later sold."""
+
+    player_id: str
+    buy_price: int
+    proceeds: int
+    bought_at: float | None
+    sold_at: float
+
+
 @dataclass
 class SeasonResult:
     outcomes: list[MatchdayOutcome] = field(default_factory=list)
     total_points: int = 0
     final_budget: int = 0
+    flips: list[FlipRecord] = field(default_factory=list)
 
 
 def _team_value(state: ReplayState, mv_fn: Callable[[str, float], int | None], at: float) -> int:
@@ -162,6 +174,7 @@ def _flip_sells(
     *,
     profit_take_pct: float | None,
     loss_cut_pct: float | None,
+    ledger: list[FlipRecord],
 ) -> int:
     """Take profit and cut losses on squad players; returns sells (REH-68).
 
@@ -206,6 +219,16 @@ def _flip_sells(
         remaining = {k: v for k, v in state.squad.items() if k != pid}
         if not can_field_eleven(ReplayState(budget=state.budget, squad=remaining)):
             continue
+        if player.acquired == "bought":
+            ledger.append(
+                FlipRecord(
+                    player_id=pid,
+                    buy_price=int(player.buy_price),
+                    proceeds=_proceeds(pid, mv_fn, at),
+                    bought_at=player.bought_at,
+                    sold_at=at,
+                )
+            )
         state.sell(pid, _proceeds(pid, mv_fn, at))
         scores.pop(pid, None)
         sells += 1
@@ -354,6 +377,7 @@ def run_season(
             decide_at,
             profit_take_pct=profit_take_pct,
             loss_cut_pct=loss_cut_pct,
+            ledger=result.flips,
         )
         rank_fn = buy_rank_fn or score_fn
         quota = None if buy_quota is None else buy_quota.get(md.day_number, 0)

--- a/rehoboam/replay/engine.py
+++ b/rehoboam/replay/engine.py
@@ -160,7 +160,7 @@ def _restore_budget(
             # Nothing can be sold without breaking the eleven, but a zero is
             # worse than the penalty — sell the cheapest player regardless.
             victim = min(state.player_ids, key=lambda p: scores.get(p, 0.0))
-        state.sell(victim, _proceeds(victim, mv_fn, at))
+        state.sell(victim, _proceeds(victim, mv_fn, at), at=at)
         scores.pop(victim, None)
         sells += 1
     return sells
@@ -229,7 +229,7 @@ def _flip_sells(
                     sold_at=at,
                 )
             )
-        state.sell(pid, _proceeds(pid, mv_fn, at))
+        state.sell(pid, _proceeds(pid, mv_fn, at), at=at)
         scores.pop(pid, None)
         sells += 1
     return sells
@@ -247,6 +247,7 @@ def _flip_buys(
     position_fn: Callable[[str], str | None],
     team_fn: Callable[[str], str | None],
     with_competition: bool,
+    wash_trade_block_seconds: float | None = None,
 ) -> int:
     """Buy for expected appreciation with the slots the EP pass left (REH-71).
 
@@ -275,6 +276,20 @@ def _flip_buys(
         position = position_fn(pid)
         if listing is None or not position or pid in state.squad:
             continue
+
+        # Live wash-trade guard (auto_trader.py:374, applying
+        # Settings.wash_trade_block_hours, default 168h/7d): refuse to re-buy a
+        # player sold within the block window. Applied here only, not in the EP
+        # loop above -- the EP loop already gates on gain >= min_ep_gain, so
+        # re-buying a just-sold player there requires them to be a large
+        # upgrade, whereas the flip pass has no such gate and is where a
+        # same-matchday wash trade actually appeared (REH-71). Extending the
+        # guard to the EP loop would also change that experiment's baseline
+        # arms, which is not this task's call to make.
+        if wash_trade_block_seconds is not None:
+            sold = state.sold_at.get(pid)
+            if sold is not None and at - sold < wash_trade_block_seconds:
+                continue
 
         # Under competition we must outbid what the real buyer paid, and we then
         # pay our own bid. Without it the listing is ours at its asking price --
@@ -360,6 +375,12 @@ def run_season(
     # candidates carrying their own economic max_bid. None keeps the shipped
     # behaviour, in which every buy is justified by marginal expected points.
     flip_buy_fn: Callable[[list, float, int, int], list] | None = None,
+    # REH-71 wash-trade guard, ported from the live bot's
+    # `AutoTrader._is_wash_trade` (auto_trader.py:667) and
+    # `Settings.wash_trade_block_hours` (config.py, default 168h/7d). Applied
+    # to flip candidates only (see `_flip_buys`). None keeps the shipped
+    # replay behaviour, in which nothing blocks a re-buy.
+    wash_trade_block_seconds: float | None = None,
 ) -> SeasonResult:
     """Replay every matchday in order, mutating ``state`` as the bot would."""
     result = SeasonResult()
@@ -441,7 +462,7 @@ def run_season(
                 # candidate never costs us a player we then cannot replace.
                 if not _solvent_after(state, cost, sale_proceeds):
                     continue
-                state.sell(sold_id, sale_proceeds)
+                state.sell(sold_id, sale_proceeds, at=decide_at)
                 scores.pop(sold_id, None)
                 sells += 1
                 # The credit floor is 70% of *current* team value, so it has to
@@ -473,6 +494,7 @@ def run_season(
                 position_fn=position_fn,
                 team_fn=team_fn,
                 with_competition=bid_fn is not None,
+                wash_trade_block_seconds=wash_trade_block_seconds,
             )
 
         # Budget must be non-negative at kickoff or the matchday scores zero.

--- a/rehoboam/replay/engine.py
+++ b/rehoboam/replay/engine.py
@@ -60,7 +60,27 @@ class MatchdayOutcome:
 
 @dataclass(frozen=True)
 class FlipRecord:
-    """One completed round trip: a player the replay bought and later sold."""
+    """One completed round trip: a player the replay bought and later sold.
+
+    NARROWER THAN THE LIVE DEFINITION, AND OPTIMISTIC (REH-71 review). Records
+    are appended in exactly one place — ``_flip_sells`` — so a round trip
+    counts here only when the *profit-taking* pass is what closed it. The live
+    counterpart, ``LearningTracker.record_flip_outcome``, fires on every instant
+    sell of a tracked purchase, forced and make-room exits included (see
+    ``services/execution.py:instant_sell``).
+
+    So a replay player liquidated by ``_restore_budget`` or sold to make room
+    for an EP buy never enters this ledger at all: arm D of the 2x2 shows 35
+    buys and 32 sells against only 23 recorded round trips. The excluded exits
+    are precisely the forced ones — sales made under solvency pressure or to
+    fund a better player — which skew loss-making, so omitting them flatters
+    the replay's P&L.
+
+    The reported cash figure is therefore NOT like-for-like with the real 151
+    round trips printed beside it. It is a lower bound on flip harm, not a
+    measurement of it. Left as measured on purpose: REH-71's numbers were
+    recorded once and are not to be re-cut after the fact.
+    """
 
     player_id: str
     buy_price: int
@@ -201,6 +221,14 @@ def _flip_sells(
     squad was *assigned*, not bought (REH-68), so counting its disposals would
     inflate the round-trip count and make ``ledger`` incomparable to the real
     151 round trips it exists to be compared against (REH-71).
+
+    THIS IS ALSO THE ONLY PLACE THE LEDGER IS WRITTEN, which makes the replay's
+    round-trip definition narrower than the live one and its cash figure
+    optimistic. Sales by ``_restore_budget`` and by the EP make-room path are
+    invisible to it, while ``LearningTracker.record_flip_outcome`` counts them.
+    See ``FlipRecord`` for the full statement of the gap; it is documented
+    rather than closed, because closing it would change numbers that were
+    recorded once by design.
     """
     if profit_take_pct is None and loss_cut_pct is None:
         return 0
@@ -310,7 +338,13 @@ def _flip_buys(
             cost = int(listing.price)
 
         player = ReplayPlayer(id=pid, position=position, team_id=team_fn(pid))
-        if _would_create_dead_weight(player, state.players):
+        # Deliberate duck typing, sanctioned by the REH-71 plan: the shipped
+        # guard is annotated against `MarketPlayer` but reads only `.position`,
+        # which `ReplayPlayer` has. Calling the real rule beats reimplementing
+        # it; the alternative -- widening the shipped signature to a Protocol --
+        # is a refactor of live scoring code that this replay-only change has no
+        # business making. Scoped to this call, not silenced module-wide.
+        if _would_create_dead_weight(player, state.players):  # type: ignore[arg-type]
             continue
         allowed, _reason = can_buy(state, player, cost, team_value=team_value)
         if not allowed or not _solvent_after(state, cost):

--- a/rehoboam/replay/flip_buys.py
+++ b/rehoboam/replay/flip_buys.py
@@ -61,3 +61,31 @@ def history_at(corpus: TrainingCorpus, player_id: str, at: float) -> dict:
             (str(player_id), float(at)),
         ).fetchall()
     return {"it": [{"dt": int(snapshot / SECONDS_PER_DAY), "mv": int(mv)} for snapshot, mv in rows]}
+
+
+# Statuses in which the player actually took the pitch: 3 = came on as a sub,
+# 5 = started. Deliberately NARROWER than `driver.PLAYED_STATUSES`, which is
+# (1, 3, 4, 5) because the availability model needs a fitted rate for every
+# state including "not in squad". Kickbase's own average points is per
+# APPEARANCE, so counting non-appearances here would understate every player.
+APPEARANCE_STATUSES = (3, 5)
+
+
+def average_points_at(
+    corpus: TrainingCorpus, player_id: str, *, season: str, day_number: int
+) -> float:
+    """Mean points per appearance over matches strictly before ``day_number``.
+
+    Reuses the v2 scorer's ``matches_before`` boundary rather than introducing a
+    second truncation rule, so the flip path and the EP path cannot disagree
+    about what was knowable at the decision instant.
+    """
+    from rehoboam.backtest.snapshot import matches_before
+
+    history = matches_before(
+        corpus.matches_for_player(player_id), season=season, day_number=day_number
+    )
+    played = [m for m in history if m.get("status") in APPEARANCE_STATUSES]
+    if not played:
+        return 0.0
+    return sum(float(m["points"] or 0) for m in played) / len(played)

--- a/rehoboam/replay/flip_buys.py
+++ b/rehoboam/replay/flip_buys.py
@@ -89,3 +89,30 @@ def average_points_at(
     if not played:
         return 0.0
     return sum(float(m["points"] or 0) for m in played) / len(played)
+
+
+def flip_bid_ceiling(
+    market_value: int, expected_appreciation: float, *, min_profit_pct: float
+) -> int:
+    """The most a flip can rationally cost and still clear its own margin.
+
+    A flip bought at ``P`` exits at ``MV x (1 + a/100) x INSTANT_SELL_PCT``,
+    where ``INSTANT_SELL_PCT`` is 1.00 as measured in REH-67. Requiring the
+    round trip to still return ``min_profit_pct`` gives::
+
+        P <= MV x (1 + a/100) / (1 + m/100)
+
+    Bidding above this guarantees a loss even when the expected appreciation
+    fully materialises, so losing a listing to a rival who paid more is the
+    correct outcome, not a modelling failure.
+
+    Deliberately NOT `SmartBidding.calculate_ep_bid`: that sizes an overbid from
+    the marginal-gain tier, and a flip's marginal EP gain is ~0 by construction,
+    so every flip would bid into the bottom tier and lose every contested
+    listing -- reporting "flip buys do nothing" as an artifact of the bidder
+    rather than a fact about flipping.
+    """
+    from rehoboam.replay.engine import INSTANT_SELL_PCT
+
+    exit_value = market_value * (1.0 + expected_appreciation / 100.0) * INSTANT_SELL_PCT
+    return int(exit_value / (1.0 + min_profit_pct / 100.0))

--- a/rehoboam/replay/flip_buys.py
+++ b/rehoboam/replay/flip_buys.py
@@ -8,7 +8,10 @@ shipped rule shows up in the replay instead of silently drifting from it.
 
 from __future__ import annotations
 
+import sqlite3
 from dataclasses import dataclass
+
+from rehoboam.enrichment.corpus import TrainingCorpus
 
 
 @dataclass(frozen=True)
@@ -33,3 +36,28 @@ class CorpusMarketPlayer:
     status: int = 0
     first_name: str = ""
     last_name: str = ""
+
+
+SECONDS_PER_DAY = 86400.0
+
+
+def history_at(corpus: TrainingCorpus, player_id: str, at: float) -> dict:
+    """A `TrendService.analyze`-shaped history, truncated strictly before ``at``.
+
+    ``hmv``/``lmv`` are deliberately omitted rather than computed. ``analyze``
+    derives ``peak_value = max(api_peak, data_peak, current)`` and
+    ``low_value = min(v for v in [api_low, data_low, current] if v > 0)``, so an
+    absent key drops out of both and the extremes come from the truncated series
+    alone. Supplying the season-wide peak would leak the future into
+    ``ProfitTrader``'s mean-reversion branch.
+
+    ``snapshot_at`` is exactly ``dt * 86400`` (``corpus.record_mv_series``), so
+    the round trip back to ``dt`` is lossless.
+    """
+    with sqlite3.connect(corpus.db_path) as conn:
+        rows = conn.execute(
+            "SELECT snapshot_at, market_value FROM mv_series "
+            "WHERE player_id = ? AND snapshot_at < ? ORDER BY snapshot_at",
+            (str(player_id), float(at)),
+        ).fetchall()
+    return {"it": [{"dt": int(snapshot / SECONDS_PER_DAY), "mv": int(mv)} for snapshot, mv in rows]}

--- a/rehoboam/replay/flip_buys.py
+++ b/rehoboam/replay/flip_buys.py
@@ -1,0 +1,35 @@
+"""Model the live bot's profit-flip BUYS inside the replay (REH-71).
+
+Nothing here reimplements a heuristic. `TrendService.analyze` and
+`ProfitTrader.find_profit_opportunities` are called for real, exactly as
+`driver.make_ep_bid_fn` calls the real `SmartBidding` -- so a change to either
+shipped rule shows up in the replay instead of silently drifting from it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CorpusMarketPlayer:
+    """The attribute surface `ProfitTrader.find_profit_opportunities` reads.
+
+    Deliberately a stand-in for `kickbase_client.MarketPlayer` rather than the
+    real thing: the real one is built from a live API payload carrying dozens of
+    fields the corpus cannot supply, and constructing it would mean inventing
+    values that then look authoritative.
+
+    `price == market_value` at every construction site is not an oversight --
+    see `make_flip_buy_fn` for why feeding a real transaction price here
+    silently disables the entire pass.
+    """
+
+    id: str
+    price: int
+    market_value: int
+    average_points: float
+    position: str
+    status: int = 0
+    first_name: str = ""
+    last_name: str = ""

--- a/rehoboam/replay/flip_buys.py
+++ b/rehoboam/replay/flip_buys.py
@@ -9,6 +9,7 @@ shipped rule shows up in the replay instead of silently drifting from it.
 from __future__ import annotations
 
 import sqlite3
+from collections.abc import Callable
 from dataclasses import dataclass
 
 from rehoboam.enrichment.corpus import TrainingCorpus
@@ -116,3 +117,101 @@ def flip_bid_ceiling(
 
     exit_value = market_value * (1.0 + expected_appreciation / 100.0) * INSTANT_SELL_PCT
     return int(exit_value / (1.0 + min_profit_pct / 100.0))
+
+
+# Thresholds read from `Trader.find_profit_opportunities`'s call site
+# (trader.py:715-721), NOT from `ProfitTrader.__init__`'s defaults, which no
+# caller in the codebase actually uses.
+FLIP_MIN_PROFIT_PCT = 8.0
+FLIP_MAX_HOLD_DAYS = 7
+FLIP_MAX_RISK_SCORE = 60.0
+# The live path scores only the first 50 market entries (trader.py:711).
+FLIP_MARKET_SCAN_LIMIT = 50
+
+
+@dataclass(frozen=True)
+class FlipCandidate:
+    """A player worth buying for appreciation, with what he is worth paying."""
+
+    player_id: str
+    market_value: int
+    expected_appreciation: float
+    max_bid: int
+
+
+def make_flip_buy_fn(
+    corpus: TrainingCorpus,
+    *,
+    season: str,
+    day_fn: Callable[[float], int],
+    position_fn: Callable[[str], str | None],
+) -> Callable[[list, float, int, int], list[FlipCandidate]]:
+    """Rank flip candidates with the bot's own profit-trading logic (REH-71).
+
+    DECISION PRICE vs EXECUTION PRICE. The adapter reports
+    ``price == market_value`` while the engine pays a bid derived from
+    ``flip_bid_ceiling``. This is not a fudge. The live bot only ever flips
+    ``is_kickbase_seller()`` listings (trader.py:685), where the two are equal by
+    construction, and ``ProfitTrader`` *branches* on that equality
+    (profit_trader.py:121). Feeding it a real transaction price -- which averages
+    1.117x market value -- sends every candidate down the non-Kickbase branch,
+    where ``value_gap`` is negative and the candidate is dropped at
+    profit_trader.py:194. The pass would look modelled and never fire once.
+
+    ``status`` is pinned to 0 (available) because the corpus's per-match status
+    is participation, not injury. Nothing is therefore skipped as injured, so
+    this buys MORE flips than the live bot would -- an upper bound on flip
+    activity, and hence on flip harm.
+    """
+    from rehoboam.profit_trader import ProfitTrader
+    from rehoboam.services.trend_service import TrendService
+
+    trader = ProfitTrader(
+        min_profit_pct=FLIP_MIN_PROFIT_PCT,
+        max_hold_days=FLIP_MAX_HOLD_DAYS,
+        max_risk_score=FLIP_MAX_RISK_SCORE,
+    )
+
+    def candidates(listings: list, at: float, budget: int, team_value: int) -> list[FlipCandidate]:
+        day = day_fn(at)
+        players: list[CorpusMarketPlayer] = []
+        trends: dict[str, dict] = {}
+
+        for listing in listings[:FLIP_MARKET_SCAN_LIMIT]:
+            pid = listing.player_id
+            market_value = corpus.market_value_at(pid, at)
+            position = position_fn(pid)
+            if not market_value or not position:
+                continue
+            players.append(
+                CorpusMarketPlayer(
+                    id=pid,
+                    price=market_value,
+                    market_value=market_value,
+                    average_points=average_points_at(corpus, pid, season=season, day_number=day),
+                    position=position,
+                )
+            )
+            trends[pid] = TrendService.analyze(history_at(corpus, pid, at), market_value).to_dict()
+
+        opportunities = trader.find_profit_opportunities(
+            market_players=players,
+            current_budget=budget,
+            player_trends=trends,
+            team_value=team_value,
+        )
+        return [
+            FlipCandidate(
+                player_id=o.player.id,
+                market_value=o.market_value,
+                expected_appreciation=o.expected_appreciation,
+                max_bid=flip_bid_ceiling(
+                    o.market_value,
+                    o.expected_appreciation,
+                    min_profit_pct=FLIP_MIN_PROFIT_PCT,
+                ),
+            )
+            for o in opportunities
+        ]
+
+    return candidates

--- a/rehoboam/replay/flip_buys.py
+++ b/rehoboam/replay/flip_buys.py
@@ -129,6 +129,26 @@ FLIP_MAX_RISK_SCORE = 60.0
 FLIP_MARKET_SCAN_LIMIT = 50
 
 
+def shipped_max_debt_pct() -> float:
+    """The debt ceiling the live flip path actually passes (REH-71 review).
+
+    ``ProfitTrader.find_profit_opportunities`` *defaults* ``max_debt_pct`` to
+    60.0, and ``Settings.max_debt_pct_of_team_value`` is also 60.0 today — but
+    the live call site forwards the Settings field explicitly
+    (``trader.py:728``), so the agreement is a coincidence, not a contract.
+    Leaning on it is exactly the config drift this harness reads shipped
+    defaults to avoid: re-tune the field in production and the replay would go
+    on describing a bot nobody deployed.
+
+    Reuses ``driver._shipped_default`` rather than a fourth copy of the same
+    two-line read. No import cycle: ``driver`` imports this module lazily,
+    inside ``run_replay``.
+    """
+    from rehoboam.replay.driver import _shipped_default
+
+    return _shipped_default("max_debt_pct_of_team_value")
+
+
 @dataclass(frozen=True)
 class FlipCandidate:
     """A player worth buying for appreciation, with what he is worth paying."""
@@ -171,6 +191,7 @@ def make_flip_buy_fn(
         max_hold_days=FLIP_MAX_HOLD_DAYS,
         max_risk_score=FLIP_MAX_RISK_SCORE,
     )
+    max_debt_pct = shipped_max_debt_pct()
 
     def candidates(listings: list, at: float, budget: int, team_value: int) -> list[FlipCandidate]:
         day = day_fn(at)
@@ -199,10 +220,17 @@ def make_flip_buy_fn(
             current_budget=budget,
             player_trends=trends,
             team_value=team_value,
+            max_debt_pct=max_debt_pct,
         )
         return [
             FlipCandidate(
-                player_id=o.player.id,
+                # `ProfitOpportunity.player` is annotated `any` -- the builtin
+                # function, not `typing.Any` -- in shipped code this module does
+                # not own (profit_trader.py:14), so mypy cannot see `.id` on it.
+                # Scoped to this expression rather than fixed here: retyping a
+                # shipped dataclass is a separate change with its own blast
+                # radius, and REH-71 is not the ticket for it.
+                player_id=o.player.id,  # type: ignore[attr-defined]
                 market_value=o.market_value,
                 expected_appreciation=o.expected_appreciation,
                 max_bid=flip_bid_ceiling(

--- a/rehoboam/replay/state.py
+++ b/rehoboam/replay/state.py
@@ -44,6 +44,7 @@ class ReplayState:
 
     budget: int
     squad: dict[str, ReplayPlayer] = field(default_factory=dict)
+    sold_at: dict[str, float] = field(default_factory=dict)
 
     @property
     def squad_size(self) -> int:
@@ -64,9 +65,19 @@ class ReplayState:
         )
         self.budget -= int(price)
 
-    def sell(self, player_id: str, proceeds: int) -> None:
+    def sell(self, player_id: str, proceeds: int, at: float | None = None) -> None:
+        """Remove ``player_id`` from the squad, crediting ``proceeds`` (REH-71).
+
+        Records ``at`` in ``sold_at`` regardless of *why* the sale happened —
+        make-room, solvency, or profit-taking — mirroring the live bot, where
+        the ``recently_sold`` table (``auto_trader.py``) is written on every
+        sale, not just profit-motivated ones. This is the wash-trade block's
+        data source: it must see every disposal to refuse every re-buy.
+        """
         del self.squad[player_id]
         self.budget += int(proceeds)
+        if at is not None:
+            self.sold_at[player_id] = at
 
     def team_counts(self) -> dict[str, int]:
         counts: dict[str, int] = {}

--- a/rehoboam/replay/state.py
+++ b/rehoboam/replay/state.py
@@ -31,6 +31,11 @@ class ReplayPlayer:
     team_id: str | None = None
     buy_price: int | None = None
     bought_at: float | None = None
+    # "assigned" for the randomly-allocated opening squad, "bought" for anything
+    # the replay actually purchased. Both carry a cost basis, so the basis alone
+    # cannot distinguish them -- and counting assigned disposals as round trips
+    # would make the ledger incomparable to the real 151 flips (REH-71).
+    acquired: str = "assigned"
 
 
 @dataclass
@@ -54,7 +59,9 @@ class ReplayState:
 
     def buy(self, player: ReplayPlayer, price: int, at: float | None = None) -> None:
         """Add ``player`` to the squad, recording the cost basis (REH-68)."""
-        self.squad[player.id] = replace(player, buy_price=int(price), bought_at=at)
+        self.squad[player.id] = replace(
+            player, buy_price=int(price), bought_at=at, acquired="bought"
+        )
         self.budget -= int(price)
 
     def sell(self, player_id: str, proceeds: int) -> None:

--- a/tests/test_auto_trader_flip_switches.py
+++ b/tests/test_auto_trader_flip_switches.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 import inspect
+from types import SimpleNamespace
+from unittest.mock import MagicMock, Mock, patch
 
-from rehoboam.auto_trader import AutoTrader
+import pytest
+
+from rehoboam.auto_trader import AutoTrader, EPSessionContext, MatchdayPhase
 from rehoboam.config import Settings
 
 
@@ -23,3 +27,153 @@ def test_the_profit_sell_phase_is_gated_on_its_switch():
     source = inspect.getsource(AutoTrader.run_profit_sell_phase)
 
     assert "enable_profit_sells" in source
+
+
+# ---------------------------------------------------------------------------
+# Fix round 1: the two source-inspection tests above pass on an inverted
+# gate, a gate that reads the setting and ignores it, or a gate sitting in
+# unreachable code — they only prove the setting name is *mentioned*. These
+# tests observe actual behaviour instead, for the one task in this plan that
+# flips live trading defaults.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def settings(monkeypatch) -> Settings:
+    monkeypatch.setenv("KICKBASE_EMAIL", "test@example.com")
+    monkeypatch.setenv("KICKBASE_PASSWORD", "test")
+    return Settings()
+
+
+@pytest.fixture
+def trader(tmp_path, settings, monkeypatch) -> AutoTrader:
+    """An AutoTrader wired to a MagicMock API so its calls are directly
+    observable, with no real network or DB IO. dry_run=True keeps the
+    execution service side-effect-free (no api.buy_player call), so the
+    EP-driven buy path can run to completion without extra scaffolding.
+    """
+    monkeypatch.chdir(tmp_path)  # BidLearner/ActivityFeedLearner default to ./logs
+    api = MagicMock()
+    return AutoTrader(api=api, settings=settings, dry_run=True)
+
+
+class TestProfitSellPhaseGate:
+    """`run_profit_sell_phase` must return [] AND do no work when disabled.
+
+    Returning [] alone is a weak assertion — an enabled run that finds no
+    sell candidates also returns []. The "did no work" half (never even
+    fetching the squad) is what actually distinguishes disabled from
+    enabled-but-idle.
+    """
+
+    def test_disabled_returns_empty_and_never_touches_the_squad(self, trader):
+        trader.settings.enable_profit_sells = False
+
+        result = trader.run_profit_sell_phase(league=SimpleNamespace(id="L"), ctx=SimpleNamespace())
+
+        assert result == []
+        trader.api.get_squad.assert_not_called()
+
+    def test_enabled_gets_past_the_early_return(self, trader):
+        trader.settings.enable_profit_sells = True
+        # Empty squad short-circuits the method shortly after — that's fine,
+        # we only need proof it got past the disabled-path's early return.
+        trader.api.get_squad.return_value = []
+
+        trader.run_profit_sell_phase(league=SimpleNamespace(id="L"), ctx=SimpleNamespace())
+
+        trader.api.get_squad.assert_called_once()
+
+
+class TestFlipBuyBlockGate:
+    """The flip-candidate block inside `run_unified_trade_phase`, gated on
+    `enable_flip_buys`, with the surrounding EP-driven buy path proven
+    unaffected by the gate.
+    """
+
+    @staticmethod
+    def _ctx(*, allow_flips: bool = True, max_trades: int = 5) -> EPSessionContext:
+        """One affordable plain-buy candidate, an open squad slot (empty
+        squad/bids refreshed via the mocked API below), and a matchday
+        phase that allows flips — the exact preconditions the flip block
+        checks alongside its own switch.
+        """
+        buy_rec = SimpleNamespace(
+            player=SimpleNamespace(id="p1", first_name="Test", last_name="Buyer"),
+            recommended_bid=1_000_000,
+            marginal_ep_gain=10.0,
+            reason="test upgrade",
+            sell_plan=None,
+        )
+        phase = MatchdayPhase(
+            days_until_match=5,
+            phase="aggressive",
+            max_trades=max_trades,
+            allow_flips=allow_flips,
+            reason="test",
+        )
+        return EPSessionContext(
+            ep_result={"buy_recs": [buy_rec], "trade_pairs": []},
+            matchday_phase=phase,
+            my_bids=[],
+            my_bid_amounts={},
+            squad=[],
+            current_budget=5_000_000,
+            team_value=20_000_000,
+            flip_budget=5_000_000,
+        )
+
+    @staticmethod
+    def _configure_trader(trader) -> None:
+        """Wire the mid-phase squad/bid/budget refresh to an empty, open
+        squad, and stub the wash-trade learner lookup to a real bool — a
+        bare Mock's auto-attribute would return a truthy MagicMock and
+        wrongly filter our one candidate out before the gate is even
+        reached.
+        """
+        trader.api.get_squad.return_value = []
+        trader.api.get_my_bids.return_value = []
+        trader.api.get_team_info.return_value = {
+            "budget": 5_000_000,
+            "team_value": 20_000_000,
+        }
+        trader.learner = Mock()
+        trader.learner.was_recently_sold.return_value = False
+
+    def test_flip_search_not_called_when_disabled(self, trader):
+        trader.settings.enable_flip_buys = False
+        self._configure_trader(trader)
+        ctx = self._ctx()
+
+        with patch("rehoboam.trader.Trader.find_profit_opportunities") as mock_find:
+            trader.run_unified_trade_phase(league=SimpleNamespace(id="L"), ctx=ctx)
+
+        mock_find.assert_not_called()
+
+    def test_flip_search_called_when_enabled_with_open_slot_and_phase_allows(self, trader):
+        trader.settings.enable_flip_buys = True
+        self._configure_trader(trader)
+        ctx = self._ctx(allow_flips=True)
+
+        with patch("rehoboam.trader.Trader.find_profit_opportunities") as mock_find:
+            mock_find.return_value = []
+            trader.run_unified_trade_phase(league=SimpleNamespace(id="L"), ctx=ctx)
+
+        mock_find.assert_called_once()
+
+    def test_ep_buy_path_still_executes_when_flip_buys_disabled(self, trader):
+        """The gate must disable only the flip block, not the surrounding
+        EP-driven buy/trade-pair loop it lives inside — pinning the failure
+        mode of a gate that accidentally disables more than the flip block.
+        """
+        trader.settings.enable_flip_buys = False
+        self._configure_trader(trader)
+        ctx = self._ctx()
+
+        with patch("rehoboam.trader.Trader.find_profit_opportunities") as mock_find:
+            results = trader.run_unified_trade_phase(league=SimpleNamespace(id="L"), ctx=ctx)
+
+        mock_find.assert_not_called()
+        assert len(results) == 1
+        assert results[0].success is True
+        assert results[0].action == "BUY"

--- a/tests/test_auto_trader_flip_switches.py
+++ b/tests/test_auto_trader_flip_switches.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import inspect
 from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock, patch
 
@@ -17,23 +16,12 @@ def test_both_switches_exist():
     assert "enable_profit_sells" in Settings.model_fields
 
 
-def test_the_flip_buy_block_is_gated_on_its_switch():
-    source = inspect.getsource(AutoTrader.run_unified_trade_phase)
-
-    assert "enable_flip_buys" in source
-
-
-def test_the_profit_sell_phase_is_gated_on_its_switch():
-    source = inspect.getsource(AutoTrader.run_profit_sell_phase)
-
-    assert "enable_profit_sells" in source
-
-
 # ---------------------------------------------------------------------------
-# Fix round 1: the two source-inspection tests above pass on an inverted
-# gate, a gate that reads the setting and ignores it, or a gate sitting in
-# unreachable code — they only prove the setting name is *mentioned*. These
-# tests observe actual behaviour instead, for the one task in this plan that
+# Fix round 1 added source-inspection gate tests here; fix round 2 deleted
+# them (M5). They passed on an inverted gate, on a gate that reads the setting
+# and ignores it, and on a gate sitting in unreachable code — they only proved
+# the setting name was *mentioned*. The behavioural tests below observe actual
+# behaviour and supersede them entirely, for the one task in this plan that
 # flips live trading defaults.
 # ---------------------------------------------------------------------------
 
@@ -57,30 +45,116 @@ def trader(tmp_path, settings, monkeypatch) -> AutoTrader:
     return AutoTrader(api=api, settings=settings, dry_run=True)
 
 
-class TestProfitSellPhaseGate:
-    """`run_profit_sell_phase` must return [] AND do no work when disabled.
+def _player(pid: str, position: str, buy_price: int, market_value: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=pid,
+        position=position,
+        buy_price=buy_price,
+        market_value=market_value,
+        first_name="P",
+        last_name=pid,
+    )
 
-    Returning [] alone is a weak assertion — an enabled run that finds no
-    sell candidates also returns []. The "did no work" half (never even
-    fetching the squad) is what actually distinguishes disabled from
-    enabled-but-idle.
+
+# A 14-man squad chosen so that exactly three players sit outside the
+# formation-aware best eleven, and each of them exercises a different branch:
+#
+#   f2  Forward, +20% — a PROFIT sell. Forwards are not position-saturated
+#       (2 of a possible 3 starters), so nothing else can pick him up.
+#   g2  Goalkeeper, -3% — DEAD WEIGHT. Three keepers against one startable
+#       slot; the loss is accepted to free the squad slot.
+#   g3  Goalkeeper, -3% — dead weight, same as g2.
+#
+# Everyone else is a best-eleven starter and therefore protected. Keeping the
+# profit candidate at an unsaturated position is what makes the two branches
+# separable: a saturated profit candidate would be sold by the dead-weight
+# branch anyway and the test would prove nothing.
+_SQUAD = [
+    _player("g1", "Goalkeeper", 1_000_000, 1_000_000),
+    _player("g2", "Goalkeeper", 1_000_000, 970_000),
+    _player("g3", "Goalkeeper", 2_000_000, 1_940_000),
+    *[_player(f"d{i}", "Defender", 1_000_000, 1_000_000) for i in range(1, 6)],
+    *[_player(f"m{i}", "Midfielder", 1_000_000, 1_000_000) for i in range(1, 5)],
+    _player("f1", "Forward", 1_000_000, 1_000_000),
+    _player("f2", "Forward", 1_000_000, 1_200_000),
+]
+
+_SCORES = {
+    "g1": 90.0,
+    "g2": 5.0,
+    "g3": 4.0,
+    "d1": 80.0,
+    "d2": 79.0,
+    "d3": 78.0,
+    "d4": 77.0,
+    "d5": 76.0,
+    "m1": 70.0,
+    "m2": 69.0,
+    "m3": 68.0,
+    "m4": 67.0,
+    "f1": 60.0,
+    "f2": 59.0,
+}
+
+
+def _sell_ctx() -> SimpleNamespace:
+    """A session context with one queued buy — the dead-weight branch requires
+    a buy to be waiting before it will realise a loss to free the slot."""
+    buy_rec = SimpleNamespace(
+        player=SimpleNamespace(id="x", position="Midfielder"),
+        marginal_ep_gain=100.0,
+    )
+    return SimpleNamespace(
+        ep_result={
+            "squad_scores": [
+                SimpleNamespace(player_id=pid, expected_points=ep) for pid, ep in _SCORES.items()
+            ],
+            "buy_recs": [buy_rec],
+            "trade_pairs": [],
+        }
+    )
+
+
+def _sold_names(results) -> set[str]:
+    return {r.player_name.split()[-1] for r in results if r.action == "SELL"}
+
+
+class TestProfitSellPhaseGate:
+    """`enable_profit_sells` must gate profit-taking and loss-cutting ONLY.
+
+    The same method also holds the dead-weight release: dumping a
+    position-saturated bench player to free a squad slot for a points upgrade.
+    That branch serves points, not profit — REH-71 never measured it, so the
+    flip switch must not silently disable it (fix round 2, I2).
     """
 
-    def test_disabled_returns_empty_and_never_touches_the_squad(self, trader):
-        trader.settings.enable_profit_sells = False
+    @staticmethod
+    def _run(trader, *, enabled: bool):
+        trader.settings.enable_profit_sells = enabled
+        trader.api.get_squad.return_value = list(_SQUAD)
+        trader.learner = Mock()
+        trader.learner.get_tracked_purchase.return_value = None
+        with patch(
+            "rehoboam.services.trend_service.TrendService.get_trend",
+            return_value=SimpleNamespace(trend_7d_pct=0.0),
+        ):
+            return trader.run_profit_sell_phase(league=SimpleNamespace(id="L"), ctx=_sell_ctx())
 
-        result = trader.run_profit_sell_phase(league=SimpleNamespace(id="L"), ctx=SimpleNamespace())
+    def test_disabled_still_releases_dead_weight_but_takes_no_profit(self, trader):
+        sold = _sold_names(self._run(trader, enabled=False))
 
-        assert result == []
-        trader.api.get_squad.assert_not_called()
+        assert sold == {"g2", "g3"}, "dead weight must still be released"
+        assert "f2" not in sold, "profit selling was disabled"
 
-    def test_enabled_gets_past_the_early_return(self, trader):
-        trader.settings.enable_profit_sells = True
-        # Empty squad short-circuits the method shortly after — that's fine,
-        # we only need proof it got past the disabled-path's early return.
-        trader.api.get_squad.return_value = []
+    def test_enabled_takes_profit_as_well_as_releasing_dead_weight(self, trader):
+        sold = _sold_names(self._run(trader, enabled=True))
 
-        trader.run_profit_sell_phase(league=SimpleNamespace(id="L"), ctx=SimpleNamespace())
+        assert sold == {"f2", "g2", "g3"}
+
+    def test_disabled_still_reads_the_squad(self, trader):
+        """The old gate early-returned before `get_squad`, which is precisely
+        how the dead-weight branch got switched off with it."""
+        self._run(trader, enabled=False)
 
         trader.api.get_squad.assert_called_once()
 

--- a/tests/test_auto_trader_flip_switches.py
+++ b/tests/test_auto_trader_flip_switches.py
@@ -1,0 +1,25 @@
+"""REH-71: the flip verdict must be honoured from .env, without a deploy."""
+
+from __future__ import annotations
+
+import inspect
+
+from rehoboam.auto_trader import AutoTrader
+from rehoboam.config import Settings
+
+
+def test_both_switches_exist():
+    assert "enable_flip_buys" in Settings.model_fields
+    assert "enable_profit_sells" in Settings.model_fields
+
+
+def test_the_flip_buy_block_is_gated_on_its_switch():
+    source = inspect.getsource(AutoTrader.run_unified_trade_phase)
+
+    assert "enable_flip_buys" in source
+
+
+def test_the_profit_sell_phase_is_gated_on_its_switch():
+    source = inspect.getsource(AutoTrader.run_profit_sell_phase)
+
+    assert "enable_profit_sells" in source

--- a/tests/test_replay/test_attribution.py
+++ b/tests/test_replay/test_attribution.py
@@ -115,3 +115,32 @@ def test_the_report_prints_the_real_season_for_comparison():
 
     assert "55,256,064" in report
     assert "151" in report
+
+
+def test_a_flip_buy_only_run_labels_its_zero_as_structural():
+    """With profit selling off the ledger can never be written, so `EUR +0 /
+    0 trips` is unmeasurable, not "flipping was free" (REH-71 fix round 2, M1).
+    """
+    report = format_report(
+        SeasonResult(),
+        actual_total=0,
+        actual_per_matchday={},
+        standings=[],
+        min_ep_gain=40.0,
+        with_flip_buys=True,
+    )
+
+    assert "STRUCTURAL" in report
+
+
+def test_a_run_that_can_close_round_trips_carries_no_structural_note():
+    report = format_report(
+        _result_with_flips(),
+        actual_total=0,
+        actual_per_matchday={},
+        standings=[],
+        min_ep_gain=40.0,
+        with_flips=True,
+    )
+
+    assert "STRUCTURAL" not in report

--- a/tests/test_replay/test_attribution.py
+++ b/tests/test_replay/test_attribution.py
@@ -3,8 +3,9 @@ from rehoboam.replay.attribution import (
     attribution_rows,
     format_report,
     place_in_league,
+    trading_summary,
 )
-from rehoboam.replay.engine import MatchdayOutcome, SeasonResult
+from rehoboam.replay.engine import FlipRecord, MatchdayOutcome, SeasonResult
 
 
 def _outcome(day, pts, zeroed=False, penalty=0):
@@ -71,3 +72,46 @@ def test_format_report_states_finishing_position_and_fidelity():
     )
     assert "FINISHING POSITION" in text
     assert "Bid competition" in text  # fidelity caveat must be printed
+
+
+def _result_with_flips() -> SeasonResult:
+    return SeasonResult(
+        flips=[
+            FlipRecord("a", 10_000_000, 12_000_000, 0.0, 1.0),
+            FlipRecord("b", 10_000_000, 7_000_000, 0.0, 1.0),
+        ]
+    )
+
+
+def test_trading_summary_nets_wins_against_losses():
+    assert trading_summary(_result_with_flips()) == (-1_000_000, 2, 1)
+
+
+def test_the_report_keeps_cash_out_of_the_points_attribution():
+    """Euros minus points is a category error. The Trading block must say so on
+    its face, so no reader ever adds it to the attribution table."""
+    report = format_report(
+        _result_with_flips(),
+        actual_total=0,
+        actual_per_matchday={},
+        standings=[],
+        min_ep_gain=40.0,
+        with_flips=True,
+    )
+
+    assert "does not enter the points attribution" in report
+
+
+def test_the_report_prints_the_real_season_for_comparison():
+    """A replay P&L with nothing to compare it against is uninterpretable."""
+    report = format_report(
+        _result_with_flips(),
+        actual_total=0,
+        actual_per_matchday={},
+        standings=[],
+        min_ep_gain=40.0,
+        with_flips=True,
+    )
+
+    assert "55,256,064" in report
+    assert "151" in report

--- a/tests/test_replay/test_driver.py
+++ b/tests/test_replay/test_driver.py
@@ -1,3 +1,4 @@
+import inspect
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
@@ -5,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from rehoboam.enrichment.corpus import TrainingCorpus
+from rehoboam.replay import driver
 from rehoboam.replay.driver import (
     LEAGUE_ID,
     build_matchdays,
@@ -148,3 +150,39 @@ def test_real_calendar_has_34_matchdays_starting_on_the_official_day_one():
     assert datetime.fromtimestamp(cal[1], timezone.utc) == datetime(
         2025, 8, 23, 13, 30, tzinfo=timezone.utc
     )
+
+
+def test_run_replay_accepts_a_flip_buy_switch():
+    assert "with_flip_buys" in inspect.signature(driver.run_replay).parameters
+
+
+def test_run_replay_passes_the_flip_buy_fn_to_the_engine():
+    """A switch that never reaches run_season changes nothing -- the exact
+    defect REH-66 caught on the gain floor."""
+    source = inspect.getsource(driver.run_replay)
+
+    assert "flip_buy_fn=" in source
+
+
+def test_the_flip_buy_fn_uses_the_same_matchday_resolver_as_the_scorer():
+    """Two different cutoff rules in one run would let the flip path see a
+    matchday the EP path cannot."""
+    source = inspect.getsource(driver.run_replay)
+
+    assert "day_fn=" in source
+    assert "day_for_kickoff" in source
+
+
+def test_run_replay_passes_the_wash_trade_guard_to_the_engine():
+    """Without this the flip pass can rebuy the very player the sell pass just
+    sold, paying the round-trip cost twice for nothing (REH-71 review of
+    REH-66/68: `wash_trade_block_seconds` existed on `run_season` but nothing
+    called it)."""
+    source = inspect.getsource(driver.run_replay)
+
+    assert "wash_trade_block_seconds=" in source
+    # Wired unconditionally -- it guards how the bot trades, not which
+    # experiment arm is running -- and it must read the shipped Settings
+    # default rather than a hard-coded literal, which is exactly the drift
+    # REH-66 exists to prevent.
+    assert '_shipped_default("wash_trade_block_hours")' in source

--- a/tests/test_replay/test_driver.py
+++ b/tests/test_replay/test_driver.py
@@ -186,3 +186,8 @@ def test_run_replay_passes_the_wash_trade_guard_to_the_engine():
     # default rather than a hard-coded literal, which is exactly the drift
     # REH-66 exists to prevent.
     assert '_shipped_default("wash_trade_block_hours")' in source
+    # The setting is in HOURS and the engine compares against SECONDS. Without
+    # this assertion a regression that forwards the raw 168 shrinks a seven-day
+    # guard to 168 seconds -- still a number, still passing every check above,
+    # and undetectable in a season total.
+    assert "* 3600" in source

--- a/tests/test_replay/test_flip_buy_pass.py
+++ b/tests/test_replay/test_flip_buy_pass.py
@@ -53,7 +53,14 @@ def _squad(n: int, basis: int = 10_000_000):
     }
 
 
-def _run(*, squad_size: int, listing_price: int, max_bid: int, budget: int = 50_000_000):
+def _run(
+    *,
+    squad_size: int,
+    listing_price: int,
+    max_bid: int,
+    budget: int = 50_000_000,
+    with_competition: bool = False,
+):
     state = ReplayState(budget=budget, squad=_squad(squad_size))
     result = run_season(
         state=state,
@@ -75,6 +82,11 @@ def _run(*, squad_size: int, listing_price: int, max_bid: int, budget: int = 50_
                 max_bid=max_bid,
             )
         ],
+        # bid_fn's mere presence -- not its return value -- is what flips
+        # `with_competition` True inside `_flip_buys`. The EP loop never calls
+        # it for real in these tests: the marginal-gain floor above always
+        # sends "new" through the `continue` before bid_fn would be reached.
+        bid_fn=(lambda player_id, price, at, gain, budget: price + 1) if with_competition else None,
     )
     return result, state
 
@@ -86,9 +98,39 @@ def test_a_flip_candidate_within_the_ceiling_is_bought():
 
 
 def test_a_flip_is_not_bought_above_its_economic_ceiling():
-    """Paying more than the flip can ever return is a guaranteed loss, so losing
-    the listing to a rival is the correct outcome."""
+    """Paying more than the flip can ever return is a guaranteed loss. No rival
+    is modelled here (no bid_fn) -- this is a plain price-vs-ceiling skip: the
+    listing's price exceeds max_bid, so the pass declines it outright."""
     _result, state = _run(squad_size=12, listing_price=12_000_000, max_bid=11_000_000)
+
+    assert "new" not in state.squad
+
+
+def test_a_flip_is_bought_at_its_own_bid_under_competition():
+    """Under competition the pass must pay what IT bid, not what the rival
+    paid. A membership-only assertion would pass even if the engine had wrongly
+    charged listing.price, so this pins the budget debit to max_bid."""
+    _result, state = _run(
+        squad_size=12,
+        listing_price=9_000_000,
+        max_bid=11_000_000,
+        with_competition=True,
+    )
+
+    assert "new" in state.squad
+    assert state.budget == 50_000_000 - 11_000_000
+
+
+def test_a_flip_is_outbid_when_its_ceiling_does_not_exceed_the_real_price():
+    """Without competition, a bid at or below the ceiling still wins (the
+    listing has no rival to beat). With competition the bid must strictly
+    exceed listing.price -- an equal max_bid still loses the auction."""
+    _result, state = _run(
+        squad_size=12,
+        listing_price=9_000_000,
+        max_bid=9_000_000,
+        with_competition=True,
+    )
 
     assert "new" not in state.squad
 

--- a/tests/test_replay/test_flip_buy_pass.py
+++ b/tests/test_replay/test_flip_buy_pass.py
@@ -1,0 +1,124 @@
+"""REH-71: the replay buys for appreciation, not only for points.
+
+The live bot buys flip candidates with whatever squad slots the EP pass leaves
+(auto_trader.py:533). A flip never displaces a squad member -- the live bot does
+not sell to make room for one -- so the pass simply stops at MAX_SQUAD_SIZE.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from rehoboam.replay.engine import Matchday, run_season
+from rehoboam.replay.market import MarketListing
+from rehoboam.replay.state import ReplayPlayer, ReplayState
+
+DAY = 86400.0
+# Fifteen slots, ordered so that _squad(12) is a legal eleven-fieldable squad
+# (1 GK / 5 DEF / 4 MID / 2 FW) with midfield still below the formation ceiling
+# of 5 -- otherwise `_would_create_dead_weight` refuses the candidate and every
+# assertion below fails for a reason unrelated to what it is testing.
+POS = (
+    ["Goalkeeper"]
+    + ["Defender"] * 5
+    + ["Midfielder"] * 4
+    + ["Forward"] * 3
+    + ["Goalkeeper"]
+    + ["Midfielder"]
+)
+
+
+@dataclass(frozen=True)
+class FakeCandidate:
+    player_id: str
+    market_value: int
+    expected_appreciation: float
+    max_bid: int
+
+
+class OneListing:
+    def __init__(self, price: int) -> None:
+        self.price = price
+
+    def available_before(self, at):
+        return [MarketListing(player_id="new", price=self.price, transfer_at=at - DAY)]
+
+
+def _squad(n: int, basis: int = 10_000_000):
+    return {
+        str(i): ReplayPlayer(
+            id=str(i), position=POS[i], team_id=str(i), buy_price=basis, bought_at=0.0
+        )
+        for i in range(n)
+    }
+
+
+def _run(*, squad_size: int, listing_price: int, max_bid: int, budget: int = 50_000_000):
+    state = ReplayState(budget=budget, squad=_squad(squad_size))
+    result = run_season(
+        state=state,
+        market=OneListing(listing_price),
+        matchdays=[Matchday(day_number=1, kickoff=10 * DAY, points={})],
+        # High floor so the EP pass never buys; the flip pass is what we measure.
+        min_ep_gain=1_000_000.0,
+        score_fn=lambda pid, at: 10.0,
+        mv_fn=lambda pid, at: 10_000_000,
+        # Midfield sits at 4 of a maximum 5, so the candidate is a real upgrade
+        # slot rather than permanent dead weight.
+        position_fn=lambda pid: "Midfielder",
+        team_fn=lambda pid: pid,
+        flip_buy_fn=lambda listings, at, budget, tv: [
+            FakeCandidate(
+                player_id="new",
+                market_value=10_000_000,
+                expected_appreciation=20.0,
+                max_bid=max_bid,
+            )
+        ],
+    )
+    return result, state
+
+
+def test_a_flip_candidate_within_the_ceiling_is_bought():
+    _result, state = _run(squad_size=12, listing_price=9_000_000, max_bid=11_000_000)
+
+    assert "new" in state.squad
+
+
+def test_a_flip_is_not_bought_above_its_economic_ceiling():
+    """Paying more than the flip can ever return is a guaranteed loss, so losing
+    the listing to a rival is the correct outcome."""
+    _result, state = _run(squad_size=12, listing_price=12_000_000, max_bid=11_000_000)
+
+    assert "new" not in state.squad
+
+
+def test_a_flip_never_displaces_a_squad_member():
+    """At 15/15 the live bot does not sell to make room for a flip."""
+    _result, state = _run(squad_size=15, listing_price=9_000_000, max_bid=11_000_000)
+
+    assert "new" not in state.squad
+    assert len(state.squad) == 15
+
+
+def test_a_flip_is_skipped_when_it_would_leave_the_budget_negative():
+    _result, state = _run(squad_size=12, listing_price=9_000_000, max_bid=11_000_000, budget=1_000)
+
+    assert "new" not in state.squad
+
+
+def test_flip_buying_is_off_by_default():
+    """The shipped replay path must be unchanged until the run that enables it."""
+    state = ReplayState(budget=50_000_000, squad=_squad(12))
+    run_season(
+        state=state,
+        market=OneListing(9_000_000),
+        matchdays=[Matchday(day_number=1, kickoff=10 * DAY, points={})],
+        min_ep_gain=1_000_000.0,
+        score_fn=lambda pid, at: 10.0,
+        mv_fn=lambda pid, at: 10_000_000,
+        position_fn=lambda pid: "Midfielder",
+        team_fn=lambda pid: pid,
+    )
+
+    assert "new" not in state.squad

--- a/tests/test_replay/test_flip_buys.py
+++ b/tests/test_replay/test_flip_buys.py
@@ -15,7 +15,12 @@ import sqlite3
 import textwrap
 
 from rehoboam.enrichment.corpus import TrainingCorpus
-from rehoboam.replay.flip_buys import CorpusMarketPlayer, average_points_at, history_at
+from rehoboam.replay.flip_buys import (
+    CorpusMarketPlayer,
+    average_points_at,
+    flip_bid_ceiling,
+    history_at,
+)
 
 
 def _attributes_read_off(name: str, *functions) -> set[str]:
@@ -134,3 +139,29 @@ def test_a_player_with_no_appearances_averages_zero(tmp_path):
     corpus = _corpus_with_matches(tmp_path, [(1, 0, 1)])
 
     assert average_points_at(corpus, "p1", season=SEASON, day_number=2) == 0.0
+
+
+def test_the_ceiling_leaves_the_required_margin_intact():
+    """Buy at the ceiling, sell at the appreciated value, and the round trip
+    still returns exactly min_profit_pct."""
+    ceiling = flip_bid_ceiling(10_000_000, 20.0, min_profit_pct=8.0)
+
+    exit_value = 10_000_000 * 1.20
+    realised_pct = (exit_value - ceiling) / ceiling * 100
+
+    assert abs(realised_pct - 8.0) < 0.01
+
+
+def test_a_bigger_expected_move_justifies_a_bigger_bid():
+    """The gradient must discriminate across the operating range -- the missing
+    test class that let REH-69 ship a saturated bid function."""
+    low = flip_bid_ceiling(10_000_000, 10.0, min_profit_pct=8.0)
+    mid = flip_bid_ceiling(10_000_000, 20.0, min_profit_pct=8.0)
+    high = flip_bid_ceiling(10_000_000, 40.0, min_profit_pct=8.0)
+
+    assert low < mid < high
+
+
+def test_a_flip_with_no_expected_upside_bids_below_market_value():
+    """Otherwise the bot pays full price for a player it expects to stagnate."""
+    assert flip_bid_ceiling(10_000_000, 0.0, min_profit_pct=8.0) < 10_000_000

--- a/tests/test_replay/test_flip_buys.py
+++ b/tests/test_replay/test_flip_buys.py
@@ -20,7 +20,9 @@ from rehoboam.replay.flip_buys import (
     average_points_at,
     flip_bid_ceiling,
     history_at,
+    make_flip_buy_fn,
 )
+from rehoboam.replay.market import MarketListing
 
 
 def _attributes_read_off(name: str, *functions) -> set[str]:
@@ -165,3 +167,61 @@ def test_a_bigger_expected_move_justifies_a_bigger_bid():
 def test_a_flip_with_no_expected_upside_bids_below_market_value():
     """Otherwise the bot pays full price for a player it expects to stagnate."""
     assert flip_bid_ceiling(10_000_000, 0.0, min_profit_pct=8.0) < 10_000_000
+
+
+def _rising_corpus(tmp_path) -> TrainingCorpus:
+    """A player on a steady climb who also scores well -- the shape
+    ProfitTrader's `rising` branch is looking for."""
+    corpus = TrainingCorpus(tmp_path / "corpus.db")
+    with sqlite3.connect(corpus.db_path) as conn:
+        conn.executemany(
+            "INSERT OR REPLACE INTO mv_series (player_id, snapshot_at, market_value) "
+            "VALUES ('p1', ?, ?)",
+            [(day * DAY, 10_000_000 + day * 400_000) for day in range(1, 31)],
+        )
+        conn.executemany(
+            "INSERT OR REPLACE INTO player_match_history "
+            "(player_id, season, day_number, points, minutes, is_home, status) "
+            "VALUES ('p1', ?, ?, ?, 90, 1, 5)",
+            [(SEASON, day, 80) for day in range(1, 5)],
+        )
+        conn.commit()
+    return corpus
+
+
+def _candidates(corpus, at: float):
+    fn = make_flip_buy_fn(
+        corpus,
+        season=SEASON,
+        day_fn=lambda _at: 10,
+        position_fn=lambda _pid: "Forward",
+    )
+    listings = [MarketListing(player_id="p1", price=11_000_000, transfer_at=at - DAY)]
+    return fn(listings, at, 50_000_000, 100_000_000)
+
+
+def test_a_rising_high_scorer_is_offered_as_a_flip_candidate(tmp_path):
+    """The regression test that matters most. If the adapter fed ProfitTrader a
+    real transaction price instead of market value, EVERY candidate would take
+    the non-Kickbase branch, `value_gap` would be negative, and the whole pass
+    would return an empty list on every matchday while appearing to work.
+    """
+    found = _candidates(_rising_corpus(tmp_path), 31 * DAY)
+
+    assert [c.player_id for c in found] == ["p1"]
+
+
+def test_the_candidate_carries_an_economically_sized_max_bid(tmp_path):
+    found = _candidates(_rising_corpus(tmp_path), 31 * DAY)
+
+    assert found[0].max_bid == flip_bid_ceiling(
+        found[0].market_value, found[0].expected_appreciation, min_profit_pct=8.0
+    )
+
+
+def test_a_player_with_no_market_value_is_skipped(tmp_path):
+    """`market_value_at` returns None outside the recorded series; a zero-value
+    adapter would divide by zero inside the trend model."""
+    corpus = TrainingCorpus(tmp_path / "corpus.db")
+
+    assert _candidates(corpus, 31 * DAY) == []

--- a/tests/test_replay/test_flip_buys.py
+++ b/tests/test_replay/test_flip_buys.py
@@ -219,6 +219,39 @@ def test_the_candidate_carries_an_economically_sized_max_bid(tmp_path):
     )
 
 
+def _forwarded_debt_pct(tmp_path) -> float:
+    from unittest.mock import patch
+
+    with patch(
+        "rehoboam.profit_trader.ProfitTrader.find_profit_opportunities", return_value=[]
+    ) as call:
+        _candidates(_rising_corpus(tmp_path), 31 * DAY)
+    return call.call_args.kwargs["max_debt_pct"]
+
+
+def test_the_debt_ceiling_is_the_one_the_live_call_site_passes(tmp_path):
+    """`ProfitTrader` defaults `max_debt_pct` to 60.0 and
+    `Settings.max_debt_pct_of_team_value` also ships 60.0, so leaving the
+    argument off looked harmless. The live call site forwards the Settings
+    field explicitly (trader.py:728), so the agreement is coincidence, not
+    contract (REH-71 fix round 2, M3).
+    """
+    from rehoboam.config import Settings
+
+    assert _forwarded_debt_pct(tmp_path) == float(
+        Settings.model_fields["max_debt_pct_of_team_value"].default
+    )
+
+
+def test_a_retuned_debt_ceiling_reaches_the_replay(tmp_path, monkeypatch):
+    """The half that catches a hard-coded 60.0 masquerading as the default."""
+    from rehoboam.config import Settings
+
+    monkeypatch.setattr(Settings.model_fields["max_debt_pct_of_team_value"], "default", 12.5)
+
+    assert _forwarded_debt_pct(tmp_path) == 12.5
+
+
 def test_a_player_with_no_market_value_is_skipped(tmp_path):
     """`market_value_at` returns None outside the recorded series; a zero-value
     adapter would divide by zero inside the trend model."""

--- a/tests/test_replay/test_flip_buys.py
+++ b/tests/test_replay/test_flip_buys.py
@@ -15,7 +15,7 @@ import sqlite3
 import textwrap
 
 from rehoboam.enrichment.corpus import TrainingCorpus
-from rehoboam.replay.flip_buys import CorpusMarketPlayer, history_at
+from rehoboam.replay.flip_buys import CorpusMarketPlayer, average_points_at, history_at
 
 
 def _attributes_read_off(name: str, *functions) -> set[str]:
@@ -94,3 +94,43 @@ def test_days_since_epoch_round_trips_exactly(tmp_path):
     corpus = _corpus_with_mv(tmp_path, [(7 * DAY, 500)])
 
     assert history_at(corpus, "p1", 8 * DAY)["it"] == [{"dt": 7, "mv": 500}]
+
+
+SEASON = "2025/2026"
+
+
+def _corpus_with_matches(tmp_path, rows: list[tuple[int, int, int]]) -> TrainingCorpus:
+    """rows: (day_number, points, status)."""
+    corpus = TrainingCorpus(tmp_path / "corpus.db")
+    with sqlite3.connect(corpus.db_path) as conn:
+        conn.executemany(
+            "INSERT OR REPLACE INTO player_match_history "
+            "(player_id, season, day_number, points, minutes, is_home, status) "
+            "VALUES ('p1', ?, ?, ?, 90, 1, ?)",
+            [(SEASON, day, points, status) for day, points, status in rows],
+        )
+        conn.commit()
+    return corpus
+
+
+def test_average_points_ignores_matchdays_at_or_after_the_cutoff(tmp_path):
+    corpus = _corpus_with_matches(tmp_path, [(1, 100, 5), (2, 200, 5), (3, 900, 5)])
+
+    assert average_points_at(corpus, "p1", season=SEASON, day_number=3) == 150.0
+
+
+def test_only_appearances_count_towards_the_average(tmp_path):
+    """Kickbase's own average is per appearance. Averaging in matchdays the
+    player was not in the squad (status 1) or sat unused (status 4) drags a fit
+    player under ProfitTrader's MIN_AVG_POINTS gate of 20 and silently removes
+    him from every flip branch.
+    """
+    corpus = _corpus_with_matches(tmp_path, [(1, 60, 5), (2, 0, 1), (3, 0, 4)])
+
+    assert average_points_at(corpus, "p1", season=SEASON, day_number=4) == 60.0
+
+
+def test_a_player_with_no_appearances_averages_zero(tmp_path):
+    corpus = _corpus_with_matches(tmp_path, [(1, 0, 1)])
+
+    assert average_points_at(corpus, "p1", season=SEASON, day_number=2) == 0.0

--- a/tests/test_replay/test_flip_buys.py
+++ b/tests/test_replay/test_flip_buys.py
@@ -11,9 +11,11 @@ from __future__ import annotations
 
 import ast
 import inspect
+import sqlite3
 import textwrap
 
-from rehoboam.replay.flip_buys import CorpusMarketPlayer
+from rehoboam.enrichment.corpus import TrainingCorpus
+from rehoboam.replay.flip_buys import CorpusMarketPlayer, history_at
 
 
 def _attributes_read_off(name: str, *functions) -> set[str]:
@@ -47,3 +49,48 @@ def test_the_adapter_satisfies_every_attribute_profit_trader_reads():
 
     missing = read - set(CorpusMarketPlayer.__dataclass_fields__)
     assert not missing, f"ProfitTrader reads attributes the adapter lacks: {missing}"
+
+
+DAY = 86400.0
+
+
+def _corpus_with_mv(tmp_path, series: list[tuple[float, int]]) -> TrainingCorpus:
+    corpus = TrainingCorpus(tmp_path / "corpus.db")
+    with sqlite3.connect(corpus.db_path) as conn:
+        conn.executemany(
+            "INSERT OR REPLACE INTO mv_series (player_id, snapshot_at, market_value) "
+            "VALUES ('p1', ?, ?)",
+            series,
+        )
+        conn.commit()
+    return corpus
+
+
+def test_history_stops_strictly_before_the_decision_time(tmp_path):
+    corpus = _corpus_with_mv(tmp_path, [(1 * DAY, 100), (2 * DAY, 200), (3 * DAY, 300)])
+
+    history = history_at(corpus, "p1", 3 * DAY)
+
+    assert [item["mv"] for item in history["it"]] == [100, 200]
+
+
+def test_a_future_spike_cannot_reach_the_peak(tmp_path):
+    """The leak that matters. ProfitTrader's mean-reversion branch gates on
+    `current_vs_peak_pct < -25` (profit_trader.py:172-175). A season-wide peak
+    would let the bot know in August what a player is worth in March.
+    """
+    from rehoboam.services.trend_service import TrendService
+
+    corpus = _corpus_with_mv(tmp_path, [(1 * DAY, 100), (2 * DAY, 110), (9 * DAY, 10_000)])
+
+    analysis = TrendService.analyze(history_at(corpus, "p1", 3 * DAY), 110)
+
+    assert analysis.peak_value == 110
+
+
+def test_days_since_epoch_round_trips_exactly(tmp_path):
+    """`record_mv_series` stores `dt * 86400`; `analyze` sorts on `dt`. A lossy
+    round trip would silently reorder the series."""
+    corpus = _corpus_with_mv(tmp_path, [(7 * DAY, 500)])
+
+    assert history_at(corpus, "p1", 8 * DAY)["it"] == [{"dt": 7, "mv": 500}]

--- a/tests/test_replay/test_flip_buys.py
+++ b/tests/test_replay/test_flip_buys.py
@@ -1,0 +1,49 @@
+"""REH-71: model the live bot's profit-flip BUYS inside the replay.
+
+The replay already models profit-taking sells (`engine._flip_sells`). The live
+bot also buys purely for expected appreciation (`auto_trader.py:342-392` ->
+`Trader.find_profit_opportunities` -> `ProfitTrader`), and the real
+-EUR 55.3M came from both halves. Deciding the flip policy from the sell half
+alone answers a question nobody asked.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+
+from rehoboam.replay.flip_buys import CorpusMarketPlayer
+
+
+def _attributes_read_off(name: str, *functions) -> set[str]:
+    """Every `<name>.<attr>` read anywhere in the given functions."""
+    found: set[str] = set()
+    for fn in functions:
+        tree = ast.parse(textwrap.dedent(inspect.getsource(fn)))
+        found |= {
+            node.attr
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Name)
+            and node.value.id == name
+        }
+    return found
+
+
+def test_the_adapter_satisfies_every_attribute_profit_trader_reads():
+    """A contract test, not a formality. ProfitTrader is shipped code this
+    module does not own. If it grows a new attribute read, the replay would
+    raise AttributeError deep inside a season run, most likely on one matchday
+    of thirty-four. Fail here instead.
+    """
+    from rehoboam.profit_trader import ProfitTrader
+
+    read = _attributes_read_off(
+        "player",
+        ProfitTrader.find_profit_opportunities,
+        ProfitTrader._calculate_risk,
+    )
+
+    missing = read - set(CorpusMarketPlayer.__dataclass_fields__)
+    assert not missing, f"ProfitTrader reads attributes the adapter lacks: {missing}"

--- a/tests/test_replay/test_flip_ledger.py
+++ b/tests/test_replay/test_flip_ledger.py
@@ -1,0 +1,130 @@
+"""REH-71: flip P&L is cash, and cash is counted separately from points.
+
+The attribution table decomposes a POINTS delta. Flip income is EUROS and
+reaches the scoreboard only indirectly, through buys it funds. Mixing the two
+would be a category error, so the ledger stands apart.
+"""
+
+from __future__ import annotations
+
+from rehoboam.replay.engine import Matchday, run_season
+from rehoboam.replay.state import ReplayPlayer, ReplayState
+
+DAY = 86400.0
+POS = ["Goalkeeper"] + ["Defender"] * 4 + ["Midfielder"] * 4 + ["Forward"] * 3
+
+
+class NoMarket:
+    def available_before(self, at):
+        return []
+
+
+def _squad_of_12(acquired: str = "bought"):
+    return {
+        str(i): ReplayPlayer(
+            id=str(i),
+            position=POS[i],
+            team_id=str(i),
+            buy_price=10_000_000,
+            bought_at=0.0,
+            acquired=acquired,
+        )
+        for i in range(12)
+    }
+
+
+def _run(*, current_mv: int, squad):
+    state = ReplayState(budget=10_000_000, squad=squad)
+    return run_season(
+        state=state,
+        market=NoMarket(),
+        matchdays=[Matchday(day_number=1, kickoff=10 * DAY, points={})],
+        score_fn=lambda pid, at: 0.0 if pid == "11" else 100.0,
+        mv_fn=lambda pid, at: current_mv if pid == "11" else 10_000_000,
+        position_fn=lambda pid: "Forward",
+        team_fn=lambda pid: pid,
+        profit_take_pct=15.0,
+    )
+
+
+def test_a_profitable_round_trip_is_recorded_with_its_pnl():
+    result = _run(current_mv=12_000_000, squad=_squad_of_12())
+
+    assert len(result.flips) == 1
+    assert result.flips[0].proceeds - result.flips[0].buy_price == 2_000_000
+
+
+def test_an_assigned_player_sold_is_not_a_round_trip():
+    """The opening squad was assigned, not bought (state.py:96-100). Counting
+    its disposals would inflate the count and make it incomparable to the real
+    151 flips."""
+    result = _run(current_mv=12_000_000, squad=_squad_of_12(acquired="assigned"))
+
+    assert result.flips == []
+
+
+def test_players_bought_during_the_season_are_marked_as_bought():
+    state = ReplayState(budget=10_000_000, squad={})
+    state.buy(ReplayPlayer(id="x", position="Forward"), 5_000_000, at=1.0)
+
+    assert state.squad["x"].acquired == "bought"
+
+
+def test_a_flip_bought_then_sold_closes_as_exactly_one_round_trip():
+    """The end-to-end shape the ledger exists to count: the flip pass opens a
+    position on matchday 1, the market moves, and the sell pass banks it on
+    matchday 2. Anything other than a single record means the two halves
+    disagree about what a round trip is.
+    """
+    from dataclasses import dataclass
+
+    from rehoboam.replay.market import MarketListing
+
+    @dataclass(frozen=True)
+    class FakeCandidate:
+        player_id: str
+        market_value: int
+        expected_appreciation: float
+        max_bid: int
+
+    class OneListing:
+        def available_before(self, at):
+            return [MarketListing(player_id="new", price=8_000_000, transfer_at=at - DAY)]
+
+    # "new" is worth 8M when bought and 12M by matchday 2 -- a 50% gain, well
+    # clear of the 15% take-profit threshold. He scores nothing, so he is never
+    # a best-eleven starter and starter protection does not hold him.
+    def mv_fn(pid, at):
+        if pid != "new":
+            return 10_000_000
+        return 8_000_000 if at < 15 * DAY else 12_000_000
+
+    state = ReplayState(budget=50_000_000, squad=_squad_of_12(acquired="assigned"))
+    result = run_season(
+        state=state,
+        market=OneListing(),
+        matchdays=[
+            Matchday(day_number=1, kickoff=10 * DAY, points={}),
+            Matchday(day_number=2, kickoff=20 * DAY, points={}),
+        ],
+        min_ep_gain=1_000_000.0,
+        score_fn=lambda pid, at: 0.0 if pid == "new" else 100.0,
+        mv_fn=mv_fn,
+        # The squad already holds 3 forwards, the formation ceiling, so a
+        # forward candidate would be refused as dead weight. Midfield has 4 of 5.
+        position_fn=lambda pid: "Midfielder" if pid == "new" else "Forward",
+        team_fn=lambda pid: pid,
+        profit_take_pct=15.0,
+        flip_buy_fn=lambda listings, at, budget, tv: [
+            FakeCandidate(
+                player_id="new",
+                market_value=8_000_000,
+                expected_appreciation=20.0,
+                max_bid=9_000_000,
+            )
+        ],
+    )
+
+    assert "new" not in state.squad
+    assert len(result.flips) == 1
+    assert result.flips[0].proceeds - result.flips[0].buy_price == 4_000_000

--- a/tests/test_replay/test_flip_ledger.py
+++ b/tests/test_replay/test_flip_ledger.py
@@ -7,6 +7,7 @@ would be a category error, so the ledger stands apart.
 
 from __future__ import annotations
 
+from rehoboam.config import Settings
 from rehoboam.replay.engine import Matchday, run_season
 from rehoboam.replay.state import ReplayPlayer, ReplayState
 
@@ -126,9 +127,11 @@ def test_a_flip_bought_then_sold_closes_as_exactly_one_round_trip():
         # Without this, the flip pass would re-buy "new" from the same stale
         # listing the instant _flip_sells closes him out, on the same
         # matchday -- the live bot's wash-trade guard (auto_trader.py:374,
-        # Settings.wash_trade_block_hours, default 168h) exists precisely to
-        # stop that.
-        wash_trade_block_seconds=168.0 * 3600.0,
+        # Settings.wash_trade_block_hours) exists precisely to stop that. Read
+        # off the field default rather than hard-coding it (REH-66): a
+        # production re-tune of wash_trade_block_hours must not leave this
+        # test silently asserting against a stale window.
+        wash_trade_block_seconds=Settings.model_fields["wash_trade_block_hours"].default * 3600.0,
     )
 
     assert "new" not in state.squad

--- a/tests/test_replay/test_flip_ledger.py
+++ b/tests/test_replay/test_flip_ledger.py
@@ -123,6 +123,12 @@ def test_a_flip_bought_then_sold_closes_as_exactly_one_round_trip():
                 max_bid=9_000_000,
             )
         ],
+        # Without this, the flip pass would re-buy "new" from the same stale
+        # listing the instant _flip_sells closes him out, on the same
+        # matchday -- the live bot's wash-trade guard (auto_trader.py:374,
+        # Settings.wash_trade_block_hours, default 168h) exists precisely to
+        # stop that.
+        wash_trade_block_seconds=168.0 * 3600.0,
     )
 
     assert "new" not in state.squad

--- a/tests/test_replay/test_flip_policy_report.py
+++ b/tests/test_replay/test_flip_policy_report.py
@@ -7,8 +7,12 @@ is the LIKELY one and has to be stated before the numbers arrive.
 
 from __future__ import annotations
 
-from rehoboam.replay.attribution import NOISE_FLOOR_POINTS, format_flip_policy
-from rehoboam.replay.engine import SeasonResult
+from rehoboam.replay.attribution import (
+    NOISE_FLOOR_POINTS,
+    REAL_FLIP_PNL,
+    format_flip_policy,
+)
+from rehoboam.replay.engine import FlipRecord, SeasonResult
 
 
 def _arms(a: int, b: int, c: int, d: int) -> dict[str, SeasonResult]:
@@ -40,3 +44,51 @@ def test_a_delta_clearing_the_noise_floor_is_not_inconclusive():
 
 def test_the_noise_floor_is_the_one_reh_68_measured():
     assert NOISE_FLOOR_POINTS == 6_162
+
+
+def _arms_with_cash() -> dict[str, SeasonResult]:
+    arms = _arms(27_000, 27_100, 27_050, 27_150)
+    arms["D"].flips = [
+        FlipRecord("a", 10_000_000, 12_000_000, 0.0, 1.0),  # +2M, a win
+        FlipRecord("b", 10_000_000, 7_000_000, 0.0, 1.0),  # -3M, a loss
+    ]
+    return arms
+
+
+def test_the_report_prints_each_arms_cash():
+    """Design S3: the Trading block appears in `replay-flip-policy` too.
+
+    Without it the INCONCLUSIVE verdict routes the decision to cash evidence
+    the report never shows, and recovering the per-arm figures costs one extra
+    confirmatory `replay-season` run per arm (REH-71 fix round 2, I1).
+    """
+    report = format_flip_policy(_arms_with_cash(), actual_total=26_172)
+
+    assert "Realised flip P&L" in report
+    assert "EUR -1,000,000" in report  # net of D's two round trips
+    assert "50.0%" in report  # 1 win of 2
+
+
+def test_the_per_arm_cash_is_anchored_to_the_real_season():
+    """A replay P&L with nothing to compare it against is uninterpretable."""
+    report = format_flip_policy(_arms_with_cash(), actual_total=26_172)
+
+    assert format(REAL_FLIP_PNL, "+,") in report
+    assert "151" in report
+
+
+def test_arms_without_profit_selling_are_marked_structural_zeros():
+    """A and C cannot close a round trip at all, so their EUR +0 is not a
+    measurement of harmless flipping."""
+    report = format_flip_policy(_arms_with_cash(), actual_total=26_172)
+
+    assert "structural zero" in report
+    assert "Read it as unmeasurable, not free." in report
+
+
+def test_adding_cash_left_the_points_verdict_untouched():
+    arms = _arms_with_cash()
+
+    assert format_flip_policy(arms, actual_total=26_172).count("INCONCLUSIVE") == 1
+    for total in (27_000, 27_100, 27_050, 27_150):
+        assert f"{total:,}" in format_flip_policy(arms, actual_total=26_172)

--- a/tests/test_replay/test_flip_policy_report.py
+++ b/tests/test_replay/test_flip_policy_report.py
@@ -1,0 +1,42 @@
+"""REH-71: the 2x2 report, and the decision rule fixed in advance.
+
+REH-68 measured a 6,162-point faithfulness swing. Against a ~27,000-point
+season that will plausibly swallow every flip delta, so the inconclusive branch
+is the LIKELY one and has to be stated before the numbers arrive.
+"""
+
+from __future__ import annotations
+
+from rehoboam.replay.attribution import NOISE_FLOOR_POINTS, format_flip_policy
+from rehoboam.replay.engine import SeasonResult
+
+
+def _arms(a: int, b: int, c: int, d: int) -> dict[str, SeasonResult]:
+    return {
+        key: SeasonResult(total_points=points)
+        for key, points in (("A", a), ("B", b), ("C", c), ("D", d))
+    }
+
+
+def test_the_report_names_all_four_arms():
+    report = format_flip_policy(_arms(27_000, 27_100, 27_050, 27_150), actual_total=26_172)
+
+    for label in ("A", "B", "C", "D"):
+        assert label in report
+
+
+def test_small_deltas_are_declared_inconclusive():
+    """Every arm within the noise floor of every other."""
+    report = format_flip_policy(_arms(27_000, 27_100, 27_050, 27_150), actual_total=26_172)
+
+    assert "INCONCLUSIVE" in report
+
+
+def test_a_delta_clearing_the_noise_floor_is_not_inconclusive():
+    report = format_flip_policy(_arms(27_000, 27_000, 20_000, 20_000), actual_total=26_172)
+
+    assert "INCONCLUSIVE" not in report
+
+
+def test_the_noise_floor_is_the_one_reh_68_measured():
+    assert NOISE_FLOOR_POINTS == 6_162

--- a/tests/test_replay/test_shipped_config.py
+++ b/tests/test_replay/test_shipped_config.py
@@ -58,3 +58,11 @@ def test_report_states_the_gain_floor_it_used():
 
     assert "40" in report
     assert "gain" in report.lower()
+
+
+def test_the_flip_switches_default_off():
+    """REH-71's pre-committed rule: absent a points effect clearing the 6,162
+    noise floor, the decision falls to cash evidence and both switches are off.
+    """
+    assert Settings.model_fields["enable_flip_buys"].default is False
+    assert Settings.model_fields["enable_profit_sells"].default is False


### PR DESCRIPTION
Closes REH-71.

## The decision

`enable_flip_buys` and `enable_profit_sells` both ship **`False`**. The bot no longer buys players for expected market-value appreciation, and no longer sells squad players at profit/loss targets.

Both are `Settings` fields, so either can be turned back on from `.env` without a deploy.

## Why

Real flipping in 2025/26 lost **EUR 55,256,064 over 151 round trips** at a 27.8% win rate. Every round trip pays a measured **11.7% toll** — the mean transaction price is 1.117x market value while an instant sell returns 1.00x — so a flip must appreciate more than 11.7% just to break even.

The ticket asked for one flag and two runs. Reading the code changed that twice:

- **`--with-flips` only modelled the selling half.** The live bot also buys purely to flip (`auto_trader.py` -> `Trader.find_profit_opportunities` -> `ProfitTrader`), and the -EUR 55.3M came from both halves. So this branch first teaches the replay to model flip *buying*, by calling the real shipped `ProfitTrader` and `TrendService.analyze` rather than reimplementing them — the seam REH-68 established with `SmartBidding`.
- **Flip P&L is euros; the attribution table is points.** `other = delta - zero_recovered` cannot absorb a cash term. Cash is now reported as cash, in its own block, and the points contribution is the measured difference between paired runs.

## The measurement

Four arms, all with `--with-competition`, nothing else varying. Run once; determinism gate passed; all three DB/coefficient SHA-256 hashes unchanged.

| Arm | flip buys | profit sells | points | trading P&L |
| --- | --------- | ------------ | ------ | ----------- |
| A   | off       | off          | 26,391 | -           |
| B   | off       | ON           | 27,714 | -EUR 49,947,285, 14 trips, 7.1% |
| C   | ON        | off          | 26,391 | zero flip buys executed |
| D   | ON        | ON           | 29,182 | -EUR 34,442,588, 23 trips, 21.7% |

Human actual: 26,172. Effects: buy +734, sell +2,057, interaction +1,468 — all inside REH-68's 6,162-point noise floor.

Points inconclusive, so the rule fixed **before** the run routed the decision to cash evidence, and cash says stop.

## Three caveats a reader should carry

1. **Every points effect measured positive.** The decision went the other way on cash. That is the pre-committed rule working, not a contradiction — but anyone revisiting this should do so on cash grounds or a lower-noise harness, not by rereading those three numbers.
2. **Flip buying was never measured independently.** Arm C is identical to arm A down to the euro. Flips never displace a squad member, so without profit selling recycling cash the bot is broke and no flip is affordable. `+734` reduces algebraically to `(D-B)/2` — the interaction halved.
3. **The replay's cash figures are optimistic against the real 151.** Its ledger records only profit-motivated exits, excluding forced and make-room sells, which skew loss-making. Documented, not adjusted.

## Two live bugs found on the way

- **The replay had no wash-trade guard.** Live refuses to re-buy a player sold within `wash_trade_block_hours` (168h). The replay modelled it nowhere, so the flip pass rebought what the sell pass had just sold, paying the toll twice for nothing.
- **The profit-sell switch was disabling a points behaviour.** `run_profit_sell_phase` also contains the dead-weight sell branch, which releases a position-saturated bench player to free a slot for a points upgrade. That serves points, not profit, and was never measured. The gate now covers only profit-taking and loss-cutting.

## Verification

- `uv run pytest` — 701 passed, 1 skipped
- `uv run ruff check rehoboam/ tests/` — clean
- `uv run mypy rehoboam/ --ignore-missing-imports` — 68 errors, exactly the `5592a3d` baseline (verified against a worktree at the branch point); this branch adds none
- Read-only: all three SHA-256 hashes byte-identical before and after every replay run

Design: `docs/superpowers/specs/2026-08-05-reh-71-flip-policy-design.md`
Results: `docs/superpowers/specs/2026-08-05-reh-71-flip-policy-results.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)