### PR TITLE
fix(ci): repair the Azure Functions deploy, broken since the Bicep migration (REH-65)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,13 +184,16 @@ jobs:
             mcr.microsoft.com/azure-functions/python:4-python3.11 \
             bash -c "pip install --target=/pkg/.python_packages/lib/site-packages -r /pkg/requirements.txt"
 
+      - name: Install Azure Functions Core Tools
+        # Pinned, not floating on `@4`: this step runs package install scripts
+        # as root in a job that deploys to Azure, so the exact code executed
+        # here must change only when this file changes. Bump deliberately.
+        run: npm install -g azure-functions-core-tools@4.13.2 --unsafe-perm true
+
       - name: Login to Azure
         uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
-
-      - name: Install Azure Functions Core Tools
-        run: npm install -g azure-functions-core-tools@4 --unsafe-perm true
 
       - name: Deploy to Azure Functions
         # REH-65: `azure/functions-action@v1` cannot deploy this app since the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,16 @@ jobs:
     name: Deploy to Azure Functions
     runs-on: ubuntu-latest
     needs: [lint, test, deploy-deps-sync]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    # workflow_dispatch is included so this job can be run on demand. It is the
+    # only way to exercise a deploy without merging: REH-65 went unnoticed for
+    # months precisely because this job could only ever run post-merge, where
+    # nobody reviews the result.
+    if: >-
+      (github.ref == 'refs/heads/main' && github.event_name == 'push')
+      || github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@v4
 
@@ -180,9 +189,49 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
+      - name: Install Azure Functions Core Tools
+        run: npm install -g azure-functions-core-tools@4 --unsafe-perm true
+
       - name: Deploy to Azure Functions
-        uses: azure/functions-action@v1
-        with:
-          app-name: func-rehoboam
-          package: deploy_package
-          scm-do-build-during-deployment: true
+        # REH-65: `azure/functions-action@v1` cannot deploy this app since the
+        # REH-48 Bicep migration. On Linux Consumption the platform stages the
+        # package as a blob in the account named by `AzureWebJobsStorage` and
+        # points `WEBSITE_RUN_FROM_PACKAGE` at that blob URL, so the action
+        # calls `BlobServiceClient.fromConnectionString(AzureWebJobsStorage)`.
+        # REH-48 moved that setting to the identity-based
+        # `AzureWebJobsStorage__accountName` form, which is not a connection
+        # string, so the action throws `Invalid URL` at PublishContent --
+        # before uploading anything.
+        #
+        # Core Tools is used instead because it is the ONLY path known to work
+        # against this app in its current configuration: `deploy/deploy.sh`
+        # publishes with the same command and still succeeds. Swapping in
+        # `az functionapp deployment source config-zip` would be a third,
+        # unproven path through the same Linux Consumption zip-deploy
+        # machinery that requires the storage access REH-48 removed.
+        #
+        # `--no-build` because the previous step already installed the
+        # dependencies inside the official runtime image. That step exists to
+        # fix a real bug (a72fd1b: cryptography's _rust.abi3.so must match the
+        # runtime's glibc); letting Oryx rebuild remotely would discard it.
+        working-directory: deploy_package
+        run: func azure functionapp publish func-rehoboam --python --no-build
+
+      - name: Open an issue if the deploy failed
+        # A job that can only fail after merge is a job whose failures nobody
+        # sees. REH-65 accumulated silently for two PRs because PRs show green
+        # and the post-merge run goes unread.
+        if: failure() && github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue create \
+            --title "Deploy to Azure Functions failed on ${GITHUB_SHA::7}" \
+            --body "The \`Deploy to Azure Functions\` job failed on a push to \`main\`.
+
+          Commit: ${GITHUB_SHA}
+          Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+
+          The deployed function app is now behind \`main\`. Deploy manually with
+          \`bash deploy/deploy.sh code trading\`, or re-run this workflow from the
+          Actions tab once the cause is fixed." || true


### PR DESCRIPTION
Fixes [REH-65](https://linear.app/jovily/issue/REH-65). The `Deploy to Azure Functions` job has failed on every push to `main` since REH-48, so **the deployed function app is behind `main`** — this matters now because the season is starting.

## Why it broke

On Linux Consumption the platform stages the deployment package as a blob in the account named by `AzureWebJobsStorage`, then points `WEBSITE_RUN_FROM_PACKAGE` at that blob URL. So `azure/functions-action@v1` calls `BlobServiceClient.fromConnectionString(AzureWebJobsStorage)` to find it. REH-48 moved that setting to the identity-based `AzureWebJobsStorage__accountName` form, which is not a connection string — the action throws `Invalid URL` at `PublishContent`, before uploading anything.

The action was not being quirky; staging through storage is the platform's actual mechanism.

## Why Core Tools and not `az ... config-zip`

The ticket offered `az functionapp deployment source config-zip` as option 1. That routes through the *same* Linux Consumption zip-deploy machinery that needs the storage access REH-48 removed, so it is a third unproven path.

`deploy/deploy.sh` already publishes this app with `func azure functionapp publish` and still works. That is the only publish path with evidence against this app in its current configuration, so CI now does the same thing.

`--no-build` preserves a72fd1b: the previous step installs dependencies inside the official runtime image so `cryptography`'s `_rust.abi3.so` matches Azure's glibc. A remote Oryx build would discard that.

## Why it went unnoticed, also fixed

The job was gated to post-merge runs only, where nobody looks — PRs showed green while the failure accumulated across two merges. Now:

- the job accepts `workflow_dispatch`, so a deploy can be exercised on demand without merging
- a failed post-merge deploy opens an issue naming the commit, the run URL, and the `bash deploy/deploy.sh code trading` fallback

## Security

A commit review flagged CI/CD trust, and the step order made it worse than the flag suggested: `npm install -g azure-functions-core-tools@4 --unsafe-perm true` ran install scripts as root *after* `azure/login`, inside a job holding an authenticated service-principal session, on a floating major tag. Now pinned to `4.13.2` and moved ahead of the login.

Left deliberately: `mcr.microsoft.com/azure-functions/python:4-python3.11` is still a floating tag. First-party Microsoft, and pinning by digest needs a bump on every base image refresh — same class of issue, predates this change.

## Verification

YAML parses, both `run` blocks pass `bash -n`, job permissions reduced to `contents: read` + `issues: write`.

**The deploy itself cannot be verified until this is on `main`** — `workflow_dispatch` only appears in the Actions tab for workflows on the default branch. First real test is a manual dispatch after merge. If Core Tools also fails, the documented fallback is external-package-URL: blob URI without SAS plus `WEBSITE_RUN_FROM_PACKAGE_BLOB_MI_RESOURCE_ID`, the identity-native method for Linux Consumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)