### PR TITLE
feat(scoring): discount the cold-start prior by the measured newcomer gap (REH-80)

### DIFF
--- a/rehoboam/scoring/v2/adapter.py
+++ b/rehoboam/scoring/v2/adapter.py
@@ -37,6 +37,27 @@ from rehoboam.scoring.v2.rate import RateModel
 
 DGW_MULTIPLIER = 1.8
 
+# REH-80: what an unmeasured player's prior is worth.
+#
+# A player with no fitted quality falls back to the position prior, which is
+# the median of ALL players at that position. Newcomers are not median players.
+# Measured over `training_corpus.player_match_history`, splitting each season's
+# players into those with a prior season in the corpus and those without:
+#
+#   season     newcomers                returning              gap
+#   2024/2025  56.7 pts/app (n=74)      74.0 pts/app (n=286)   -23%
+#   2025/2026  52.3 pts/app (n=86)      67.8 pts/app (n=365)   -23%
+#
+# The same -23% in two independent seasons, so 1 - 0.23 = 0.77. It corrects the
+# RATE only. Newcomers also play far less (median 19 appearances against 26),
+# but availability is the availability model's job, and for a player with no
+# history that model already falls back to its marginal prior -- discounting
+# here as well would count the same deficit twice.
+#
+# This is a measured population effect, not a taste setting. Re-derive it
+# against new seasons rather than nudging it; the query is in REH-80.
+COLD_START_DISCOUNT = 0.77
+
 
 @lru_cache(maxsize=1)
 def _models() -> tuple[AvailabilityModel, RateModel, dict]:
@@ -79,7 +100,15 @@ def compose_ep(
 ) -> float:
     """Probability-weighted expected points, in real Kickbase points."""
     probs = availability.predict(prev_status)
-    return sum(probs[s] * rate.predict(player_id, s, position) for s in PLAYED_STATUSES)
+    ep = sum(probs[s] * rate.predict(player_id, s, position) for s in PLAYED_STATUSES)
+    # Applied here rather than in `score_player_v2` because this is the one
+    # composition point every caller shares -- the lineup fallback in
+    # `auto_trader` scores cold players through this function too, and a
+    # discount that only the market path applied would rank the same player
+    # two different ways inside one session.
+    if player_id not in rate.quality:
+        ep *= COLD_START_DISCOUNT
+    return ep
 
 
 def score_player_v2(data: PlayerData) -> PlayerScore:
@@ -101,7 +130,10 @@ def score_player_v2(data: PlayerData) -> PlayerScore:
         f"rate={rate.predict(player.id, 5, position):.0f} pts if started"
     ]
     if player.id not in rate.quality:
-        notes.append("No fitted quality — using position prior (cold start)")
+        notes.append(
+            f"No fitted quality — position prior discounted ×{COLD_START_DISCOUNT:.2f} "
+            f"(cold start, REH-80)"
+        )
     if data.is_dgw:
         notes.append("DOUBLE GAMEWEEK ×1.8")
 

--- a/tests/test_scoring_v2/test_adapter.py
+++ b/tests/test_scoring_v2/test_adapter.py
@@ -7,6 +7,7 @@ import pytest
 from rehoboam.kickbase_client import MarketPlayer
 from rehoboam.scoring.models import PlayerData
 from rehoboam.scoring.v2.adapter import (
+    COLD_START_DISCOUNT,
     compose_ep,
     last_played_status,
     score_player_v2,
@@ -153,3 +154,48 @@ def test_dgw_multiplies_the_composed_score():
     doubled = score_player_v2(dgw_data)
     assert doubled.expected_points > single.expected_points
     assert doubled.is_dgw is True
+
+
+# --- REH-80: the cold-start discount ------------------------------------
+
+
+def test_an_unfitted_player_takes_the_measured_cold_start_discount():
+    """A player with no fitted quality falls back to the position prior, which
+    is the median of ALL players. Newcomers are not median players: measured
+    over 2024/25 and 2025/26 they score 23% fewer points per appearance than
+    returning players. The prior is therefore generous, and the discount is
+    what removes that bias."""
+    rows = [_row("1", 5, 5, 90)] * 20
+    av, rate = fit_availability(rows), fit_rate(rows, {"1": "Midfielder"})
+    probs = av.predict(5)
+    undiscounted = sum(probs[s] * rate.predict("newcomer", s, "Midfielder") for s in (1, 3, 4, 5))
+
+    assert compose_ep("newcomer", 5, "Midfielder", av, rate) == pytest.approx(
+        undiscounted * COLD_START_DISCOUNT
+    )
+
+
+def test_a_fitted_player_is_never_discounted():
+    """The discount corrects an unmeasured player's prior. A player with fitted
+    quality has been measured, so it must not touch him."""
+    rows = [_row("1", 5, 5, 90)] * 20
+    av, rate = fit_availability(rows), fit_rate(rows, {"1": "Midfielder"})
+    probs = av.predict(5)
+    expected = sum(probs[s] * rate.predict("1", s, "Midfielder") for s in (1, 3, 4, 5))
+
+    assert compose_ep("1", 5, "Midfielder", av, rate) == pytest.approx(expected)
+
+
+def test_the_discount_is_a_haircut_not_a_rescale():
+    """Guards the direction and the magnitude: it must reduce the score, and
+    must not be so severe that an unknown player becomes unbuyable."""
+    assert 0.5 < COLD_START_DISCOUNT < 1.0
+
+
+def test_score_player_v2_applies_the_discount_and_says_so():
+    """The note is load-bearing: a score that was quietly reduced is worse than
+    one that was not reduced at all."""
+    score = score_player_v2(_data("never-fitted", _perf([])))
+
+    assert any("cold start" in n.lower() for n in score.notes)
+    assert any(f"{COLD_START_DISCOUNT:.2f}" in n for n in score.notes)


### PR DESCRIPTION
Fixes [REH-80](https://linear.app/jovily/issue/REH-80).

## The ticket asked the wrong question, and the measurement says so

REH-80 opened as "`min_expected_points_to_buy` (35.0) is inert" — it blocks 3.3% of players who started their last match, and **cannot ever block an unknown player**, whose cold-start floor is 47.9.

That is true, but the gate is a symptom. Raising it to, say, 45 would block *known* mediocre players while leaving every unknown untouched at an inflated score. The defect is in the prior.

## What the prior gets wrong

A player with no fitted quality falls back to the position prior — the median of **all** players at that position. Newcomers are not median players. Splitting each season's players in `training_corpus.player_match_history` into those with a prior season in the corpus and those without:

| season | newcomers | returning | gap |
| -- | -- | -- | -- |
| 2024/2025 | 56.7 pts/app (n=74) | 74.0 pts/app (n=286) | **−23%** |
| 2025/2026 | 52.3 pts/app (n=86) | 67.8 pts/app (n=365) | **−23%** |

The same −23% in two independent seasons, on n=74 and n=86. That is a replication, not a coincidence, so the prior is scaled by **0.77**.

## Why it matters right now

**100 of the 436 players with 2026/2027 fixtures (23%) have no fitted quality.** Nearly a quarter of the league was going into the season scored as median players when the evidence says they will perform like newcomers.

Effect on an unknown player who started his last match:

| position | was | now |
| -- | --: | --: |
| Goalkeeper | 74.0 | 57.0 |
| Defender | 74.6 | 57.5 |
| Midfielder | 69.5 | 53.5 |
| Forward | 65.9 | 50.7 |

An unknown midfielder moves from the 47th percentile of fitted players to the 21st — from "scored as the median player" to "scored as the median newcomer".

## Placement and scope

Applied in `compose_ep`, the one composition point every caller shares. `auto_trader`'s lineup fallback scores cold players through it too, and a discount that only the market path applied would rank the same player two different ways inside one session.

It corrects the **rate only**. Newcomers also play far less (median 19 appearances against 26), but availability is the availability model's job, and for a player with no history that model already falls back to its marginal prior — discounting there as well would count the same deficit twice.

`min_expected_points_to_buy` stays at 35.0, deliberately.

## Tests

Four, all failing before the change: an unfitted player takes exactly the discount; a fitted player is never touched; the constant is a haircut and not a rescale (`0.5 < d < 1.0`); and `score_player_v2` says in its notes that it discounted, since a silently reduced score is worse than an unreduced one.

Full suite 792 passed / 1 skipped, ruff clean, 0 mypy errors in `adapter.py`.

## Caveats

- "Newcomer" means "no prior season **in the corpus**". The corpus sweeps per player, so a player in the universe has complete history — but players who left the league before the sweep are absent entirely, which biases early seasons. Both seasons used here are the densest available (378 and 488 players).
- The constant is a measured population effect, not a taste setting. Re-derive it against new seasons rather than nudging it; the derivation is committed beside it.
- A blanket discount treats a proven Ligue 1 signing and a third-choice teenager identically. Splitting them needs external data — Understat covers the top-5 leagues, OpenLigaDB covers 2. Bundesliga, and between them they would cover most of the 100. That is its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)