### PR TITLE
fix(squad): don't sell an unmeasured bench player as "very weak" (REH-83)

### DIFF
--- a/rehoboam/squad_optimizer.py
+++ b/rehoboam/squad_optimizer.py
@@ -165,7 +165,19 @@ class SquadOptimizer:
                 for player in bench_players_sorted:
                     if player not in players_to_sell:
                         value_score = player_values.get(player.id, 0)
-                        if value_score < 30:  # Very weak player
+                        # REH-83: `0 <`, not just `< 30`. `value_score` is
+                        # `average_points`, which is 0 for EVERY player before a
+                        # season's first matchday -- a bare `< 30` selects the
+                        # whole bench in week 1, and sells all injury cover in
+                        # the week the squad is least replaceable. Zero means
+                        # "no matches played yet", not "weak"; requiring a
+                        # positive measurement makes the rule act on evidence of
+                        # weakness rather than on its absence. Safe to decline
+                        # here: this branch runs only when the budget is already
+                        # POSITIVE (under EUR 2M), so it is opportunistic cash,
+                        # not the negative-budget rescue above -- that path
+                        # sells by market value and never reads this threshold.
+                        if 0 < value_score < 30:  # Measurably weak player
                             players_to_sell.append(player)
                             projected_budget += player.market_value
 

--- a/tests/test_squad_optimizer_weak_bench.py
+++ b/tests/test_squad_optimizer_weak_bench.py
@@ -1,0 +1,77 @@
+"""REH-83: the weak-bench sell rule must not fire on an unmeasured player.
+
+`value_score` here is `average_points`, which is ~0 for EVERY player before a
+season's first matchday. A bare `value_score < 30` therefore selects the whole
+bench in week 1 -- not because those players are weak, but because the season
+has not produced a statistic yet.
+
+This is the same error REH-80 fixed in the scorer's cold-start prior: absence
+of evidence treated as evidence of absence.
+"""
+
+from __future__ import annotations
+
+from rehoboam.kickbase_client import Player
+from rehoboam.squad_optimizer import SquadOptimizer
+
+# Positive, but under the rule's EUR 2M "budget is tight" line, so the
+# opportunistic branch is the one under test -- NOT the negative-budget rescue
+# above it, which sells by market value and never reads this threshold.
+TIGHT_BUDGET = 1_000_000
+GAMEDAY_SOON = 1
+
+
+def _p(pid: str, position: str, avg: float) -> Player:
+    return Player(
+        id=pid,
+        first_name="P",
+        last_name=pid,
+        position=position,
+        team_id="1",
+        team_name="T",
+        market_value=1_000_000,
+        points=0,
+        average_points=avg,
+    )
+
+
+def _squad_of_twelve(bench_avg: float, starters_avg: float = 80.0) -> list[Player]:
+    """Eleven fieldable starters plus one clearly-benched extra midfielder."""
+    squad = [_p("gk", "Goalkeeper", starters_avg)]
+    squad += [_p(f"def{i}", "Defender", starters_avg) for i in range(4)]
+    squad += [_p(f"mid{i}", "Midfielder", starters_avg) for i in range(4)]
+    squad += [_p(f"fw{i}", "Forward", starters_avg) for i in range(2)]
+    squad.append(_p("bench", "Midfielder", bench_avg))
+    return squad
+
+
+def _sell_ids(squad: list[Player]) -> set[str]:
+    optimizer = SquadOptimizer(min_squad_size=11, max_squad_size=15)
+    result = optimizer.optimize_squad(
+        squad=squad,
+        player_values={p.id: float(p.average_points or 0) for p in squad},
+        current_budget=TIGHT_BUDGET,
+        days_until_gameday=GAMEDAY_SOON,
+    )
+    return {p.id for p in result.players_to_sell}
+
+
+def test_an_unmeasured_bench_player_is_not_sold_as_weak():
+    """average_points == 0 means "no matches played yet", which is every player
+    before matchday 1. Selling the bench then costs all injury cover in the
+    week the squad is least replaceable."""
+    assert "bench" not in _sell_ids(_squad_of_twelve(bench_avg=0.0))
+
+
+def test_a_measured_weak_bench_player_is_still_sold():
+    """The rule must keep working mid-season, which is the case it was for."""
+    assert "bench" in _sell_ids(_squad_of_twelve(bench_avg=15.0))
+
+
+def test_a_measured_strong_bench_player_is_not_sold():
+    assert "bench" not in _sell_ids(_squad_of_twelve(bench_avg=50.0))
+
+
+def test_a_whole_squad_at_season_start_keeps_its_bench():
+    """The actual 2026-08-28 shape: nobody has played, so nobody has a score."""
+    assert _sell_ids(_squad_of_twelve(bench_avg=0.0, starters_avg=0.0)) == set()


### PR DESCRIPTION
Fixes [REH-83](https://linear.app/jovily/issue/REH-83). Found by the REH-73 scale audit. Urgent because its firing window is **matchday 1, 2026-08-28**, and it passes silently the rest of the year.

## The bug

`squad_optimizer.py:168` — not display code, it appends to `players_to_sell`:

```python
if gameday_approaching and budget_is_tight:      # <= 2 days, < EUR 2M
    value_score = player_values.get(player.id, 0)
    if value_score < 30:                          # "Very weak player"
        players_to_sell.append(player)
```

`value_score` is `average_points`, the API's `ap` (`kickbase_client.py:151`, defaulting to `0.0`). **That value is ~0 for every player before a season's first matchday.** Zero is less than 30, so the predicate selects the entire bench — and sells all injury and rotation cover in the week the squad is least replaceable.

The threshold isn't wrong. Measured over `training_corpus`, the median returning player scores ~68 per appearance and the median newcomer ~52, so 30 is a sensible "weakest players" cut *mid-season*. It's a correct constant meeting a value that is structurally zero at a known moment.

## The fix

```python
if 0 < value_score < 30:   # Measurably weak player
```

Zero means "no matches played yet", not "weak". Requiring a positive measurement makes the rule act on evidence of weakness rather than on its absence — the same correction [REH-80](https://linear.app/jovily/issue/REH-80) made to the scorer's cold-start prior this morning.

## Why declining to sell is safe here — checked, not assumed

This mattered enough to verify before writing the guard. If this rule were the negative-budget rescue, refusing to sell could leave the budget negative at kickoff, which zeroes the **entire matchday** — far worse than a thin bench.

It isn't. This branch runs only when the budget is already **positive** (merely under EUR 2M), so it's opportunistic cash-raising. The negative-budget rescue is a separate branch above it, which sells surplus keepers and then the worst bench players by market value until the projected budget clears EUR 500k, and **never consults this threshold**. Budget-at-kickoff safety is untouched.

## Robust to an open question

`ap` is documented only as "average points per matchday"; whether it is season- or career-scoped can't be observed yet, because Kickbase is still serving last season's values. This fix doesn't depend on the answer — if `ap` never resets, the guard is inert and costs nothing. That's why it's shipped now rather than after the 28th.

## Tests

Four, two of which failed before the change:

- an unmeasured bench player (`avg=0`) is not sold
- a measurably weak one (`avg=15`) still is — the mid-season case the rule exists for
- a strong one (`avg=50`) still is not
- a whole squad at season start keeps its bench — the actual 2026-08-28 shape

796 passed / 1 skipped, ruff clean.

## Known, not fixed

The display colour thresholds at `squad_optimizer.py:271` (`>= 60` green, `>= 40` yellow) skew nearly everything green on the real-points scale. Cosmetic, and out of scope for a fix landing a week before kickoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)