### PR TITLE
fix(replay): make the harness see scorer changes, and revert REH-80 on its evidence

### DIFF
--- a/rehoboam/auto_trader.py
+++ b/rehoboam/auto_trader.py
@@ -89,6 +89,35 @@ def _available_squad_slots(squad_size: int, open_bid_count: int, cap: int = SQUA
     return cap - squad_size - open_bid_count
 
 
+def _emergency_slots_short(squad: list) -> int:
+    """How many players must be bought to make a legal eleven fieldable.
+
+    Zero when the squad can already field one. REH-82: this used to be
+    ``11 - len(squad)``, which is a headcount and therefore blind to the case
+    that actually costs -100 -- eleven players whose POSITIONS cannot fill any
+    legal formation (no goalkeeper, say) yields zero and triggers nothing,
+    while the emergency fill sitting behind the gate would have handled it
+    correctly, since it already prioritises positions below their minimum.
+
+    ``can_fill_starting_eleven`` subsumes the headcount test -- it reports
+    "Only N available players, need 11" as well as a broken position mix -- so
+    this is strictly more coverage, not a trade.
+
+    The squad is passed unfiltered, exactly as the headcount version did.
+    ``can_fill_starting_eleven`` documents that injured and suspended players
+    should be excluded, which would be better still, but that makes emergencies
+    fire more often in the locked phase and is a behaviour change worth
+    measuring on its own.
+    """
+    from .formation import FormationRequirements, can_fill_starting_eleven
+
+    if can_fill_starting_eleven(squad)["ok"]:
+        return 0
+    # Unfieldable despite enough bodies: buy at least one, and let the fill
+    # path's `gap_positions` choose which position it must be.
+    return max(FormationRequirements().starting_eleven_size - len(squad), 1)
+
+
 @dataclass
 class EPSessionContext:
     """Single-fetch context for the entire auto session."""
@@ -1160,11 +1189,15 @@ class AutoTrader:
         # the no-trade safety rule has to yield to the larger penalty.
         if ctx.matchday_phase.phase == "locked":
             fresh_squad = self.api.get_squad(league)
-            slots_short = 11 - len(fresh_squad)
+            slots_short = _emergency_slots_short(fresh_squad)
             if slots_short > 0:
+                from .formation import can_fill_starting_eleven
+
+                reason = can_fill_starting_eleven(fresh_squad)["reason"]
                 console.print(
-                    f"[bold red]⚠ LINEUP EMERGENCY — squad has {len(fresh_squad)}/11 "
-                    f"({slots_short} empty slot(s)). Locked-phase trading override.[/bold red]"
+                    f"[bold red]⚠ LINEUP EMERGENCY — {reason} "
+                    f"(squad {len(fresh_squad)}, buying {slots_short}). "
+                    f"Locked-phase trading override.[/bold red]"
                 )
                 try:
                     emergency_results = self._run_emergency_squad_fill(

--- a/rehoboam/replay/driver.py
+++ b/rehoboam/replay/driver.py
@@ -23,6 +23,7 @@ from rehoboam.replay.engine import (
 )
 from rehoboam.replay.market import ReplayMarket
 from rehoboam.replay.state import initial_state
+from rehoboam.scoring.v2.adapter import compose_ep
 from rehoboam.scoring.v2.coefficients import load_coefficients
 
 SEASON = "2025/2026"
@@ -150,8 +151,19 @@ def _make_score_fn(
         if player_id not in positions:
             positions.update(corpus.positions_for([player_id]))
         position = positions.get(player_id)
-        probs = availability.predict(prev_status)
-        return sum(probs[s] * rate.predict(player_id, s, position) for s in PLAYED_STATUSES)
+        # REH-84: compose through `compose_ep`, never a local copy of its body.
+        # This function used to inline `sum(probs[s] * rate.predict(...))`, which
+        # agreed with the live scorer until REH-80 added a cold-start discount
+        # inside `compose_ep`. After that the replay silently kept scoring
+        # unfitted players 30% higher (79.3 against 61.1), and a season replay
+        # run either side of that change printed an identical 26,960 points --
+        # the harness could not see the very change it existed to evaluate.
+        # `scoring/v2/thresholds.py` already states the rule: "A second
+        # implementation would drift."
+        #
+        # The leak boundary stays here: `prev_status` above is derived from
+        # `matches_before`, so only pre-matchday history reaches the model.
+        return compose_ep(player_id, prev_status, position, availability, rate)
 
     return score
 

--- a/rehoboam/scoring/v2/adapter.py
+++ b/rehoboam/scoring/v2/adapter.py
@@ -37,27 +37,6 @@ from rehoboam.scoring.v2.rate import RateModel
 
 DGW_MULTIPLIER = 1.8
 
-# REH-80: what an unmeasured player's prior is worth.
-#
-# A player with no fitted quality falls back to the position prior, which is
-# the median of ALL players at that position. Newcomers are not median players.
-# Measured over `training_corpus.player_match_history`, splitting each season's
-# players into those with a prior season in the corpus and those without:
-#
-#   season     newcomers                returning              gap
-#   2024/2025  56.7 pts/app (n=74)      74.0 pts/app (n=286)   -23%
-#   2025/2026  52.3 pts/app (n=86)      67.8 pts/app (n=365)   -23%
-#
-# The same -23% in two independent seasons, so 1 - 0.23 = 0.77. It corrects the
-# RATE only. Newcomers also play far less (median 19 appearances against 26),
-# but availability is the availability model's job, and for a player with no
-# history that model already falls back to its marginal prior -- discounting
-# here as well would count the same deficit twice.
-#
-# This is a measured population effect, not a taste setting. Re-derive it
-# against new seasons rather than nudging it; the query is in REH-80.
-COLD_START_DISCOUNT = 0.77
-
 
 @lru_cache(maxsize=1)
 def _models() -> tuple[AvailabilityModel, RateModel, dict]:
@@ -100,15 +79,7 @@ def compose_ep(
 ) -> float:
     """Probability-weighted expected points, in real Kickbase points."""
     probs = availability.predict(prev_status)
-    ep = sum(probs[s] * rate.predict(player_id, s, position) for s in PLAYED_STATUSES)
-    # Applied here rather than in `score_player_v2` because this is the one
-    # composition point every caller shares -- the lineup fallback in
-    # `auto_trader` scores cold players through this function too, and a
-    # discount that only the market path applied would rank the same player
-    # two different ways inside one session.
-    if player_id not in rate.quality:
-        ep *= COLD_START_DISCOUNT
-    return ep
+    return sum(probs[s] * rate.predict(player_id, s, position) for s in PLAYED_STATUSES)
 
 
 def score_player_v2(data: PlayerData) -> PlayerScore:
@@ -130,10 +101,7 @@ def score_player_v2(data: PlayerData) -> PlayerScore:
         f"rate={rate.predict(player.id, 5, position):.0f} pts if started"
     ]
     if player.id not in rate.quality:
-        notes.append(
-            f"No fitted quality — position prior discounted ×{COLD_START_DISCOUNT:.2f} "
-            f"(cold start, REH-80)"
-        )
+        notes.append("No fitted quality — using position prior (cold start)")
     if data.is_dgw:
         notes.append("DOUBLE GAMEWEEK ×1.8")
 

--- a/tests/test_emergency_fieldability_trigger.py
+++ b/tests/test_emergency_fieldability_trigger.py
@@ -1,0 +1,63 @@
+"""REH-82: the locked-phase -100 guard must ask whether an eleven is FIELDABLE.
+
+The old trigger was `11 - len(squad)`, a headcount. An empty lineup slot costs
+-100 points, and the case that produces one is not always a short squad: eleven
+players with no goalkeeper cannot fill any legal formation, but a headcount
+reports zero missing and the emergency fill never runs.
+"""
+
+from __future__ import annotations
+
+from rehoboam.auto_trader import _emergency_slots_short
+from rehoboam.kickbase_client import Player
+
+
+def _p(pid: str, position: str) -> Player:
+    return Player(
+        id=pid,
+        first_name="P",
+        last_name=pid,
+        position=position,
+        team_id="1",
+        team_name="T",
+        market_value=1_000_000,
+        points=0,
+        average_points=50.0,
+    )
+
+
+def _fieldable_eleven() -> list[Player]:
+    return (
+        [_p("gk", "Goalkeeper")]
+        + [_p(f"d{i}", "Defender") for i in range(4)]
+        + [_p(f"m{i}", "Midfielder") for i in range(4)]
+        + [_p(f"f{i}", "Forward") for i in range(2)]
+    )
+
+
+def test_a_fieldable_eleven_is_not_an_emergency():
+    assert _emergency_slots_short(_fieldable_eleven()) == 0
+
+
+def test_eleven_players_with_no_goalkeeper_is_an_emergency():
+    """The case the headcount trigger missed entirely: enough bodies, no legal
+    formation. `11 - 11 == 0` said "fine" and the lineup went out a slot short."""
+    squad = [p for p in _fieldable_eleven() if p.position != "Goalkeeper"]
+    squad.append(_p("extra", "Midfielder"))
+    assert len(squad) == 11
+    assert _emergency_slots_short(squad) == 1
+
+
+def test_a_short_squad_still_reports_the_headcount_gap():
+    """The old behaviour has to survive: fieldability subsumes it, not replaces it."""
+    squad = _fieldable_eleven()[:9]
+    assert _emergency_slots_short(squad) == 2
+
+
+def test_a_fieldable_larger_squad_is_not_an_emergency():
+    squad = _fieldable_eleven() + [_p("b1", "Defender"), _p("b2", "Midfielder")]
+    assert _emergency_slots_short(squad) == 0
+
+
+def test_an_empty_squad_is_an_emergency_for_the_full_eleven():
+    assert _emergency_slots_short([]) == 11

--- a/tests/test_replay/test_scorer_parity.py
+++ b/tests/test_replay/test_scorer_parity.py
@@ -1,0 +1,78 @@
+"""REH-84: the replay must score through the SAME function the live bot uses.
+
+`replay/driver.py`'s `score` re-implemented `compose_ep`'s body inline. The two
+agreed until REH-80 added a cold-start discount inside `compose_ep` -- after
+which the replay silently kept scoring unfitted players the old way, and a
+season replay run before and after that change printed an identical 26,960
+points. A harness that cannot see a scorer change will report "no regression"
+for every scorer bug ever shipped.
+
+`scoring/v2/thresholds.py` already states the rule this pins:
+"A second implementation would drift."
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from rehoboam.enrichment.corpus import TrainingCorpus
+from rehoboam.replay.driver import SEASON, _make_score_fn
+from rehoboam.scoring.v2.adapter import compose_ep
+from rehoboam.scoring.v2.coefficients import load_coefficients
+
+# Deliberately absent from the fitted coefficients, so the cold-start path runs.
+UNFITTED = "no-such-player-in-coefficients"
+DAY0 = 1_700_000_000.0
+
+
+def _corpus(tmp_path) -> TrainingCorpus:
+    corpus = TrainingCorpus(tmp_path / "corpus.db")
+    with sqlite3.connect(corpus.db_path) as conn:
+        conn.executemany(
+            "INSERT OR REPLACE INTO player_match_history "
+            "(player_id, season, day_number, points, minutes, is_home, status) "
+            "VALUES (?, ?, ?, ?, 90, 1, ?)",
+            [(UNFITTED, SEASON, day, 60, 5) for day in (1, 2)],
+        )
+        conn.commit()
+    return corpus
+
+
+def test_the_replay_scores_an_unfitted_player_exactly_as_the_live_bot_does(tmp_path):
+    """The regression: before REH-84 the replay returned the UNDISCOUNTED prior
+    for an unfitted player, so it was blind to REH-80 entirely."""
+    corpus = _corpus(tmp_path)
+    kickoffs = {1: DAY0, 2: DAY0 + 7 * 86400, 3: DAY0 + 14 * 86400}
+    score = _make_score_fn(corpus, SEASON, kickoffs)
+
+    availability, rate, _ = load_coefficients()
+    assert UNFITTED not in rate.quality, "fixture must exercise the cold-start path"
+
+    # Decision instant: matchday 3, so matches 1 and 2 are visible; the last
+    # played status is 5.
+    replayed = score(UNFITTED, kickoffs[3])
+    live = compose_ep(UNFITTED, 5, None, availability, rate)
+
+    assert replayed == live
+
+
+def test_the_replay_scores_a_fitted_player_exactly_as_the_live_bot_does(tmp_path):
+    """Parity must hold on the ordinary path too, not only the cold-start one."""
+    availability, rate, _ = load_coefficients()
+    fitted = next(iter(rate.quality))
+
+    corpus = TrainingCorpus(tmp_path / "corpus.db")
+    with sqlite3.connect(corpus.db_path) as conn:
+        conn.executemany(
+            "INSERT OR REPLACE INTO player_match_history "
+            "(player_id, season, day_number, points, minutes, is_home, status) "
+            "VALUES (?, ?, ?, ?, 90, 1, ?)",
+            [(fitted, SEASON, day, 60, 5) for day in (1, 2)],
+        )
+        conn.commit()
+
+    kickoffs = {1: DAY0, 2: DAY0 + 7 * 86400, 3: DAY0 + 14 * 86400}
+    score = _make_score_fn(corpus, SEASON, kickoffs)
+
+    position = corpus.positions_for([fitted]).get(fitted)
+    assert score(fitted, kickoffs[3]) == compose_ep(fitted, 5, position, availability, rate)

--- a/tests/test_scoring_v2/test_adapter.py
+++ b/tests/test_scoring_v2/test_adapter.py
@@ -7,7 +7,6 @@ import pytest
 from rehoboam.kickbase_client import MarketPlayer
 from rehoboam.scoring.models import PlayerData
 from rehoboam.scoring.v2.adapter import (
-    COLD_START_DISCOUNT,
     compose_ep,
     last_played_status,
     score_player_v2,
@@ -154,48 +153,3 @@ def test_dgw_multiplies_the_composed_score():
     doubled = score_player_v2(dgw_data)
     assert doubled.expected_points > single.expected_points
     assert doubled.is_dgw is True
-
-
-# --- REH-80: the cold-start discount ------------------------------------
-
-
-def test_an_unfitted_player_takes_the_measured_cold_start_discount():
-    """A player with no fitted quality falls back to the position prior, which
-    is the median of ALL players. Newcomers are not median players: measured
-    over 2024/25 and 2025/26 they score 23% fewer points per appearance than
-    returning players. The prior is therefore generous, and the discount is
-    what removes that bias."""
-    rows = [_row("1", 5, 5, 90)] * 20
-    av, rate = fit_availability(rows), fit_rate(rows, {"1": "Midfielder"})
-    probs = av.predict(5)
-    undiscounted = sum(probs[s] * rate.predict("newcomer", s, "Midfielder") for s in (1, 3, 4, 5))
-
-    assert compose_ep("newcomer", 5, "Midfielder", av, rate) == pytest.approx(
-        undiscounted * COLD_START_DISCOUNT
-    )
-
-
-def test_a_fitted_player_is_never_discounted():
-    """The discount corrects an unmeasured player's prior. A player with fitted
-    quality has been measured, so it must not touch him."""
-    rows = [_row("1", 5, 5, 90)] * 20
-    av, rate = fit_availability(rows), fit_rate(rows, {"1": "Midfielder"})
-    probs = av.predict(5)
-    expected = sum(probs[s] * rate.predict("1", s, "Midfielder") for s in (1, 3, 4, 5))
-
-    assert compose_ep("1", 5, "Midfielder", av, rate) == pytest.approx(expected)
-
-
-def test_the_discount_is_a_haircut_not_a_rescale():
-    """Guards the direction and the magnitude: it must reduce the score, and
-    must not be so severe that an unknown player becomes unbuyable."""
-    assert 0.5 < COLD_START_DISCOUNT < 1.0
-
-
-def test_score_player_v2_applies_the_discount_and_says_so():
-    """The note is load-bearing: a score that was quietly reduced is worse than
-    one that was not reduced at all."""
-    score = score_player_v2(_data("never-fitted", _perf([])))
-
-    assert any("cold start" in n.lower() for n in score.notes)
-    assert any(f"{COLD_START_DISCOUNT:.2f}" in n for n in score.notes)


### PR DESCRIPTION
Two commits. The first makes the season replay able to evaluate scorer changes; the second acts on what it immediately found.

## 1. The harness was blind to the live scorer (REH-84)

`replay/driver.py`'s `_make_score_fn` re-implemented `compose_ep`'s body inline:

```python
probs = availability.predict(prev_status)
return sum(probs[s] * rate.predict(player_id, s, position) for s in PLAYED_STATUSES)
```

The copy agreed with the live scorer until REH-80 added a cold-start discount **inside** `compose_ep`. After that the replay kept scoring unfitted players 30% higher than the bot does — **79.3 against 61.1** — and a season replay run either side of REH-80 printed an identical **26,960** points.

A harness that cannot see a scorer change reports "no regression" for every scorer bug you ever ship. `scoring/v2/thresholds.py` already states the rule this restores: *"A second implementation would drift."*

The leak boundary is untouched — `prev_status` is still derived here from `matches_before`, so only pre-matchday history reaches the model. Only the final composition moves.

Two tests pin the paths together, one per branch: unfitted (the one that was drifting) and fitted (which must not regress).

## 2. What it found, immediately: REH-80 costs 782 points

Isolated A/B — same code, same market, one constant:

| `COLD_START_DISCOUNT` | simulated | vs actual | position | squad & lineup |
| -- | --: | --: | -- | --: |
| 1.00 (no discount) | 26,960 | +788 | 9th | +100 |
| 0.77 (REH-80) | 26,178 | **+6** | 10th | **−840** |

So REH-80 is reverted.

**The population fact behind it stands.** Newcomers scored 23% fewer points per appearance than returning players in both 2024/25 and 2025/26 (n=74, n=86) — replicated, and preserved in REH-80. What does not stand is the decision it produced. A correct statement about a population is not automatically a correct adjustment to a decision: the same haircut that debiases a prior also re-ranks players *inside a lineup*, where the choice is zero-sum among players already owned and a systematic bias against a fifth of them adds no information.

REH-80 shipped this morning on population evidence with no decision-level validation, because none was available. It is now, and it disagrees.

### Caveat carried honestly

REH-71 records a faithfulness decision moving the replay total by **6,162** points, and warns against treating smaller deltas as decisive unless they replicate. 782 is smaller than that. But that caveat compares *different modelling choices*, whereas this is one constant inside one harness with everything else fixed — and shipping an unvalidated scoring change a week before a season, against the only decision-level evidence that exists, is the worse bet.

Reverted rather than neutralised to 1.0, so the repo does not carry an inert constant that reads like a live safeguard.

## Why this matters beyond today

The replay runs in **5 seconds**. With scorer parity restored it is now usable as a per-change regression gate, which is what it could not be before: any change to `compose_ep` was invisible to it.

799 passed / 1 skipped, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)