### PR TITLE
feat(learning): record what the bot decided, not only what it did (REH-86)

### DIFF
--- a/rehoboam/auto_trader.py
+++ b/rehoboam/auto_trader.py
@@ -277,6 +277,33 @@ class AutoTrader:
             flip_budget=flip_budget,
         )
 
+    def _record_decline(self, player, reason: str, *, ep_gain=None, ceiling=None) -> None:
+        """Best-effort record of a candidate the bot evaluated and did not bid on.
+
+        REH-86. Declines were invisible: `run_unified_trade_phase` drops any
+        candidate whose `recommended_bid` is <= 0 without a trace, so a session
+        that bought nothing looked identical whether it found nothing worth
+        buying or wanted a player it could not afford. Wrapped in try/except
+        like every other learning write -- instrumentation must never be able
+        to stop a trade.
+        """
+        if self.learner is None:
+            return
+        try:
+            self.learner.record_buy_decision(
+                player_id=getattr(player, "id", ""),
+                player_name=getattr(player, "last_name", None),
+                decision="declined",
+                reason=reason,
+                marginal_ep_gain=ep_gain,
+                asking_price=getattr(player, "price", None)
+                or getattr(player, "market_value", None),
+                market_value=getattr(player, "market_value", None),
+                budget_ceiling=ceiling,
+            )
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug("record_buy_decision failed: %s", e)
+
     def run_unified_trade_phase(self, league, ctx: EPSessionContext) -> list[AutoTradeResult]:
         """Execute all qualifying trades from a single ranked candidate list.
 
@@ -302,6 +329,15 @@ class AutoTrader:
         for rec in buy_recs:
             if rec.recommended_bid and rec.recommended_bid > 0:
                 candidates.append(("buy", rec.marginal_ep_gain, rec))
+            else:
+                # REH-86: the bot looked at this player and did not bid. That
+                # is a decision, and it was previously unrecorded.
+                self._record_decline(
+                    rec.player,
+                    rec.reason or "no_bid",
+                    ep_gain=rec.marginal_ep_gain,
+                    ceiling=int(ctx.current_budget),
+                )
         for pair in trade_pairs:
             if pair.recommended_bid and pair.recommended_bid > 0:
                 candidates.append(("pair", pair.ep_gain, pair))
@@ -317,6 +353,12 @@ class AutoTrader:
             target_name = obj.player.last_name if kind == "buy" else obj.buy_player.last_name
             if self._is_wash_trade(target_id):
                 wash_skipped += 1
+                self._record_decline(
+                    obj.player if kind == "buy" else obj.buy_player,
+                    "wash_trade_block",
+                    ep_gain=ep_val,
+                    ceiling=int(ctx.current_budget),
+                )
                 console.print(f"[dim]Skip {target_name} — wash-trade block (sold recently)[/dim]")
                 logger.info(
                     "guard-wash-trade: skipped %s (id=%s) — sold within block window",
@@ -1093,6 +1135,16 @@ class AutoTrader:
         try:
             squad = self.api.get_squad(league)
             bids = self.api.get_my_bids(league)
+            # REH-86: fill winning_bid/winner_user_id on auctions we lost,
+            # from the transfer feed earlier sessions already ingested. Runs
+            # before resolution so this session's newly-resolved losses are
+            # picked up on the next pass, once their transfer has landed.
+            try:
+                if self.learner is not None:
+                    self.learner.resolve_auction_winners()
+            except Exception as e:  # pragma: no cover - defensive
+                logger.debug("resolve_auction_winners failed: %s", e)
+
             deferred_sell_ids = self.tracker.resolve_auctions(
                 squad_ids={p.id for p in squad},
                 active_bid_ids={p.id for p in bids},

--- a/rehoboam/bid_learner.py
+++ b/rehoboam/bid_learner.py
@@ -34,6 +34,30 @@ def _opt_int(value: Any) -> int | None:
     return int(value)
 
 
+def _opt_float(value: Any) -> float | None:
+    """None-preserving float coercion, matching `_opt_int`'s contract."""
+    if value is None:
+        return None
+    return float(value)
+
+
+def _iso_to_epoch(value: Any) -> float | None:
+    """Parse Kickbase's ISO-8601 transfer timestamps to epoch seconds.
+
+    The feed sends `2026-05-05T10:00:00Z`; `fromisoformat` rejects the literal
+    `Z` before Python 3.11, so it is normalised. Returns None on anything
+    unparseable rather than raising -- this feeds a best-effort learning join,
+    and a malformed row should be skipped, not crash a session.
+    """
+    if not value:
+        return None
+    try:
+        text = str(value).strip().replace("Z", "+00:00")
+        return datetime.fromisoformat(text).timestamp()
+    except (TypeError, ValueError):
+        return None
+
+
 @dataclass
 class FlipOutcome:
     """Record of a completed flip (buy + sell)"""
@@ -422,6 +446,28 @@ class BidLearner:
             # price + datetime. PK on (league, manager, dt, player) makes
             # re-imports idempotent: the same trade always collapses to one
             # row regardless of how many sessions see it.
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS buy_decisions (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    timestamp REAL NOT NULL,
+                    player_id TEXT NOT NULL,
+                    player_name TEXT,
+                    decision TEXT NOT NULL,
+                    reason TEXT NOT NULL,
+                    marginal_ep_gain REAL,
+                    asking_price INTEGER,
+                    market_value INTEGER,
+                    budget_ceiling INTEGER
+                )
+            """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_buy_decisions_at
+                ON buy_decisions(timestamp)
+            """
+            )
             conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS manager_transfers (
@@ -1037,6 +1083,124 @@ class BidLearner:
             )
             conn.commit()
         return len(rows)
+
+    def record_buy_decision(
+        self,
+        *,
+        player_id: str,
+        player_name: str | None,
+        decision: str,
+        reason: str,
+        marginal_ep_gain: float | None = None,
+        asking_price: int | None = None,
+        market_value: int | None = None,
+        budget_ceiling: int | None = None,
+        timestamp: float | None = None,
+    ) -> None:
+        """Record a buy candidate the bot evaluated, and what it decided.
+
+        REH-86. Until this existed the learning tables recorded only what the
+        bot DID, never what it considered and rejected -- so "the bot bought
+        nothing for three weeks" could not be distinguished from "the bot saw
+        nothing worth buying", and neither from "it wanted a player and could
+        not afford him". That last case is the one REH-85 turns on: a EUR 21.3m
+        listing bid at 1.0% over asking is a budget ceiling talking, not a
+        judgement about the player.
+
+        `reason` is a short stable slug (``below_ep_threshold``,
+        ``unaffordable``, ``contested_skip``, ``squad_full``) so the column can
+        be grouped without parsing prose.
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                INSERT INTO buy_decisions (
+                    timestamp, player_id, player_name, decision, reason,
+                    marginal_ep_gain, asking_price, market_value, budget_ceiling
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    float(
+                        timestamp
+                        if timestamp is not None
+                        else datetime.now(timezone.utc).timestamp()
+                    ),
+                    str(player_id),
+                    player_name,
+                    str(decision),
+                    str(reason),
+                    _opt_float(marginal_ep_gain),
+                    _opt_int(asking_price),
+                    _opt_int(market_value),
+                    _opt_int(budget_ceiling),
+                ),
+            )
+            conn.commit()
+
+    def resolve_auction_winners(self, *, window_days: float = 3.0) -> int:
+        """Fill `winning_bid` / `winner_user_id` on auctions we lost.
+
+        REH-86. `_record_outcome` marks a bid lost by ELIMINATION -- the player
+        is neither in our squad nor in our active bids -- and never asks who
+        actually took him. So all 26 rows recorded in 2025/26 carry a NULL
+        winning bid, and "how far over asking must we go to win a EUR 20m
+        player?" is unanswerable.
+
+        The answer is already arriving: every session ingests the league
+        transfer feed into `manager_transfers` with price and buyer. This joins
+        the two on `player_id` within `window_days` of the auction.
+
+        Deliberately conservative. A transfer outside the window is not
+        attributed, because a wrong `winning_bid` would corrupt the exact
+        distribution this exists to measure -- and an unfilled row is honestly
+        unknown, where a wrong one is silently misleading. Returns the number
+        of rows filled.
+        """
+        filled = 0
+        window = float(window_days) * 86400.0
+        with sqlite3.connect(self.db_path) as conn:
+            pending = conn.execute(
+                """
+                SELECT id, player_id, timestamp, our_bid, asking_price
+                FROM auction_outcomes
+                WHERE won = 0 AND winning_bid IS NULL
+                """
+            ).fetchall()
+            for row_id, player_id, ts, _our_bid, asking in pending:
+                if ts is None:
+                    continue
+                best = None
+                for mgr, price, dt_str in conn.execute(
+                    """
+                    SELECT manager_id, transfer_price, transfer_dt
+                    FROM manager_transfers
+                    WHERE player_id = ? AND transfer_price IS NOT NULL
+                    """,
+                    (str(player_id),),
+                ):
+                    epoch = _iso_to_epoch(dt_str)
+                    if epoch is None or abs(epoch - float(ts)) > window:
+                        continue
+                    gap = abs(epoch - float(ts))
+                    if best is None or gap < best[0]:
+                        best = (gap, mgr, price)
+                if best is None:
+                    continue
+                _, winner, price = best
+                overbid = None
+                if asking:
+                    overbid = (price - asking) / asking * 100.0
+                conn.execute(
+                    """
+                    UPDATE auction_outcomes
+                    SET winning_bid = ?, winner_user_id = ?, winning_overbid_pct = ?
+                    WHERE id = ?
+                    """,
+                    (int(price), str(winner), overbid, row_id),
+                )
+                filled += 1
+            conn.commit()
+        return filled
 
     def record_manager_transfers(self, rows: list[dict]) -> int:
         """Bulk-upsert per-trade rows into ``manager_transfers``.

--- a/tests/test_buy_decisions.py
+++ b/tests/test_buy_decisions.py
@@ -1,0 +1,183 @@
+"""REH-86: record what the bot decided, not only what it did.
+
+Four analyses in one day stalled on the same gap. REH-75 could not attribute
+round trips because `flip_outcomes` records no motive. REH-72 could not
+attribute the capital collapse because `manager_transfers` records no actor.
+The bidding question ("how hard must we bid to win a EUR 20m player?") could not
+be answered because `auction_outcomes.winning_bid` is empty on all 26 rows.
+
+The schema was mostly right and mostly unfilled. These tests pin the two
+additions that make next season answerable:
+
+* `record_buy_decision` — every candidate the bot evaluated and declined, with
+  the reason. Without it, "the bot bought nothing for weeks" cannot be
+  distinguished from "the bot saw nothing worth buying".
+* `resolve_auction_winners` — fills `winning_bid` / `winner_user_id` on lost
+  auctions from the transfer feed the session already ingests. Turns "we lost
+  at 1.0% overbid" into "we lost at 1.0% and it took 24%".
+"""
+
+import sqlite3
+
+import pytest
+
+from rehoboam.bid_learner import BidLearner
+
+
+@pytest.fixture
+def learner(tmp_path):
+    return BidLearner(db_path=tmp_path / "bid_learning.db")
+
+
+def _rows(learner, table):
+    with sqlite3.connect(learner.db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        return [dict(r) for r in conn.execute(f"SELECT * FROM {table}")]
+
+
+# --- declined candidates -------------------------------------------------
+
+
+def test_a_declined_candidate_is_recorded_with_its_reason(learner):
+    learner.record_buy_decision(
+        player_id="p1",
+        player_name="Declined Player",
+        decision="declined",
+        reason="below_ep_threshold",
+        marginal_ep_gain=12.5,
+        asking_price=5_000_000,
+        market_value=4_800_000,
+        budget_ceiling=90_000_000,
+        timestamp=1_000.0,
+    )
+    rows = _rows(learner, "buy_decisions")
+    assert len(rows) == 1
+    assert rows[0]["decision"] == "declined"
+    assert rows[0]["reason"] == "below_ep_threshold"
+    assert rows[0]["marginal_ep_gain"] == pytest.approx(12.5)
+
+
+def test_the_affordability_case_is_distinguishable_from_disinterest(learner):
+    """The distinction the Lukeba bid turns on: we wanted him and could not
+    afford him, which is a different failure from not wanting him."""
+    for pid, reason, gain, ceiling in (
+        ("cheap", "below_ep_threshold", 5.0, 90_000_000),
+        ("wanted", "unaffordable", 190.0, 4_687_915),
+    ):
+        learner.record_buy_decision(
+            player_id=pid,
+            player_name=pid,
+            decision="declined",
+            reason=reason,
+            marginal_ep_gain=gain,
+            asking_price=21_000_000,
+            market_value=21_000_000,
+            budget_ceiling=ceiling,
+            timestamp=1_000.0,
+        )
+    by_reason = {r["reason"]: r for r in _rows(learner, "buy_decisions")}
+    assert by_reason["unaffordable"]["marginal_ep_gain"] == pytest.approx(190.0)
+    assert by_reason["unaffordable"]["budget_ceiling"] == 4_687_915
+
+
+def test_recording_a_decision_never_raises_on_a_missing_optional(learner):
+    """Learning writes must never break the trading path."""
+    learner.record_buy_decision(
+        player_id="p2",
+        player_name="Sparse",
+        decision="declined",
+        reason="contested_skip",
+        marginal_ep_gain=None,
+        asking_price=None,
+        market_value=None,
+        budget_ceiling=None,
+        timestamp=1_000.0,
+    )
+    assert len(_rows(learner, "buy_decisions")) == 1
+
+
+# --- who actually won the auction ---------------------------------------
+
+
+AUCTION_TS = 1777888800.0  # 2026-05-04T10:00Z, one day before the fixture transfer
+
+
+def _lost_auction(learner, player_id="p9", our_bid=21_338_887, ts=AUCTION_TS):
+    from rehoboam.bid_learner import AuctionOutcome
+
+    learner.record_outcome(
+        AuctionOutcome(
+            player_id=player_id,
+            player_name="Lukeba",
+            our_bid=our_bid,
+            asking_price=21_127_611,
+            our_overbid_pct=1.0,
+            won=False,
+            timestamp=ts,
+        )
+    )
+
+
+def _transfer(learner, player_id, manager_id, price, dt):
+    learner.record_manager_transfers(
+        [
+            {
+                "league_id": "L1",
+                "manager_id": manager_id,
+                "transfer_dt": dt,
+                "player_id": player_id,
+                "player_name": "Lukeba",
+                "transfer_type": 1,
+                "transfer_price": price,
+            }
+        ]
+    )
+
+
+def test_a_lost_auction_learns_what_the_winner_paid(learner):
+    _lost_auction(learner)
+    _transfer(learner, "p9", "rival-1", 26_200_000, "2026-05-05T10:00:00Z")
+
+    filled = learner.resolve_auction_winners(window_days=3.0)
+
+    assert filled == 1
+    row = _rows(learner, "auction_outcomes")[0]
+    assert row["winning_bid"] == 26_200_000
+    assert row["winner_user_id"] == "rival-1"
+
+
+def test_a_transfer_outside_the_window_is_not_attributed(learner):
+    """A player traded weeks later says nothing about our auction. Refusing to
+    match is the safe direction: a wrong winning_bid would corrupt the exact
+    distribution this exists to measure."""
+    _lost_auction(learner)
+    _transfer(learner, "p9", "rival-1", 26_200_000, "2026-09-01T10:00:00Z")
+
+    assert learner.resolve_auction_winners(window_days=3.0) == 0
+    assert _rows(learner, "auction_outcomes")[0]["winning_bid"] is None
+
+
+def test_already_resolved_rows_are_not_rewritten(learner):
+    _lost_auction(learner)
+    _transfer(learner, "p9", "rival-1", 26_200_000, "2026-05-05T10:00:00Z")
+    assert learner.resolve_auction_winners(window_days=3.0) == 1
+    assert learner.resolve_auction_winners(window_days=3.0) == 0
+
+
+def test_won_auctions_are_left_alone(learner):
+    """We already know what the winning bid was: ours."""
+    from rehoboam.bid_learner import AuctionOutcome
+
+    learner.record_outcome(
+        AuctionOutcome(
+            player_id="p8",
+            player_name="Won",
+            our_bid=1_000_000,
+            asking_price=900_000,
+            our_overbid_pct=11.1,
+            won=True,
+            timestamp=AUCTION_TS,
+        )
+    )
+    _transfer(learner, "p8", "someone", 999, "2026-05-05T10:00:00Z")
+    assert learner.resolve_auction_winners(window_days=3.0) == 0

--- a/tests/test_decline_recording_wiring.py
+++ b/tests/test_decline_recording_wiring.py
@@ -1,0 +1,118 @@
+"""REH-86: the decline recorder must actually FIRE, not merely exist.
+
+This ticket's whole subject is instrumentation that was wired but never
+populated — `auction_outcomes.winning_bid` is NULL on all 26 production rows
+because nothing ever filled it. Shipping a decline writer without proving the
+call site reaches it would repeat exactly that.
+
+A live smoke test cannot prove it right now: the pre-season market has no
+listings, so `buy_recs` is empty and the branch never runs. This exercises the
+branch directly instead.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from types import SimpleNamespace
+
+import pytest
+
+from rehoboam.auto_trader import AutoTrader, EPSessionContext, MatchdayPhase
+from rehoboam.bid_learner import BidLearner
+
+
+class _Api:
+    def get_squad(self, league):
+        return []
+
+    def get_my_bids(self, league):
+        return []
+
+    def get_team_info(self, league):
+        return {"budget": 90_000_000, "teamValue": 100_000_000}
+
+    def buy_player(self, *a, **k):
+        return {"ok": True}
+
+
+def _rec(pid: str, bid, gain: float, reason: str):
+    """A BuyRecommendation-shaped object; only the fields the loop reads."""
+    player = SimpleNamespace(
+        id=pid,
+        first_name="F",
+        last_name=pid,
+        position="Midfielder",
+        price=5_000_000,
+        market_value=4_800_000,
+    )
+    return SimpleNamespace(
+        player=player,
+        recommended_bid=bid,
+        marginal_ep_gain=gain,
+        reason=reason,
+        sell_plan=None,
+    )
+
+
+@pytest.fixture
+def trader(tmp_path, monkeypatch):
+    monkeypatch.setenv("KICKBASE_EMAIL", "test@example.com")
+    monkeypatch.setenv("KICKBASE_PASSWORD", "x")
+    from rehoboam.config import Settings
+
+    t = AutoTrader(api=_Api(), settings=Settings(), dry_run=True)
+    t.learner = BidLearner(db_path=tmp_path / "bid_learning.db")
+    return t
+
+
+def _ctx(buy_recs):
+    return EPSessionContext(
+        ep_result={"buy_recs": buy_recs, "trade_pairs": [], "sell_recs": []},
+        matchday_phase=MatchdayPhase(
+            days_until_match=5, phase="aggressive", max_trades=5, allow_flips=True, reason="test"
+        ),
+        my_bids=[],
+        my_bid_amounts={},
+        squad=[],
+        current_budget=90_000_000,
+        team_value=100_000_000,
+        flip_budget=0,
+    )
+
+
+def _declines(trader):
+    with sqlite3.connect(trader.learner.db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        return [dict(r) for r in conn.execute("SELECT * FROM buy_decisions")]
+
+
+def test_a_candidate_the_bot_does_not_bid_on_is_recorded(trader):
+    """The silent drop this ticket exists to make visible."""
+    trader.run_unified_trade_phase(None, _ctx([_rec("p1", 0, 12.0, "below_ep_threshold")]))
+
+    rows = _declines(trader)
+    assert len(rows) == 1
+    assert rows[0]["player_id"] == "p1"
+    assert rows[0]["reason"] == "below_ep_threshold"
+    assert rows[0]["decision"] == "declined"
+    assert rows[0]["marginal_ep_gain"] == pytest.approx(12.0)
+
+
+def test_a_candidate_the_bot_does_bid_on_is_not_recorded_as_declined(trader):
+    trader.run_unified_trade_phase(None, _ctx([_rec("p2", 4_000_000, 80.0, "must_have")]))
+    assert [r for r in _declines(trader) if r["player_id"] == "p2"] == []
+
+
+def test_the_budget_ceiling_is_captured_so_affordability_is_diagnosable(trader):
+    """Distinguishing "did not want him" from "could not afford him" is the
+    entire point — REH-85 turns on a EUR 21.3m listing bid at 1.0% over asking."""
+    trader.run_unified_trade_phase(None, _ctx([_rec("p3", None, 190.0, "unaffordable")]))
+    row = _declines(trader)[0]
+    assert row["budget_ceiling"] == 90_000_000
+    assert row["marginal_ep_gain"] == pytest.approx(190.0)
+
+
+def test_a_learning_failure_never_blocks_the_trade_phase(trader):
+    """Instrumentation must not be able to stop a trade."""
+    trader.learner = None
+    trader.run_unified_trade_phase(None, _ctx([_rec("p4", 0, 1.0, "x")]))  # must not raise


### PR DESCRIPTION
Four analyses in one day stalled on the same gap. The schema was mostly right and mostly **unfilled**.

| blocked question | why |
| -- | -- |
| REH-75: were our flips profitable? | `flip_outcomes` records no motive |
| REH-72: did the *bot* cause the capital collapse? | `manager_transfers` records no actor |
| REH-85: how hard must we bid to win a €20M player? | `auction_outcomes.winning_bid` NULL on all 26 rows |
| "why did the bot buy nothing for weeks?" | declines were never recorded |

## Two additions

**`record_buy_decision`** — every candidate the bot evaluated and declined, with a stable reason slug. `run_unified_trade_phase` silently dropped any candidate whose `recommended_bid` was ≤ 0. That drop is a decision, and it's the one that makes a buy-less session ambiguous between *"saw nothing worth buying"* and *"wanted a player and couldn't afford him"* — the distinction REH-85 turns on.

**`resolve_auction_winners`** — fills `winning_bid` / `winner_user_id` / `winning_overbid_pct` on lost auctions by joining to the transfer feed the session **already ingests**. `_record_outcome` marks a bid lost by *elimination* and never asks who took the player.

## What it found immediately

Run against a copy of production it resolved **12 of 13** lost auctions:

| player | our overbid | **winner's overbid** |
| -- | --: | --: |
| Lukeba Castello Jr. | 1.0% | **184%** (€60.0M vs our €21.3M) |
| Samuele Inácio | 7.6% | **385%** |
| Grønbæk | 8.2% | **331%** |
| Zivzivadze | 9.6% | 185% |
| Kade | 9.7% | 102% |
| Honorat / Lemperle / Bitshiabu | ~9% / 8% / 28% | 34% / 33% / 32% |

**Median winning bid needed ~33% over asking. Our cap is 20%, or 30% for a must-have.** Contested auctions are unwinnable by construction — not a tuning error inside the range, a range that ends too low. That reframes REH-85 and is measured rather than inferred.

## Deliberately conservative

A transfer outside the window is **not** attributed. A wrong `winning_bid` would corrupt the exact distribution this exists to measure; an unfilled row is honestly unknown, where a wrong one is silently misleading.

**One of the 12 looks wrong and is flagged rather than hidden:** Skhiri shows the winner paying *less* than us (−39.7% vs our +28.2%), which cannot be a competitive loss — likely a later onward sale matched instead of the auction. The window wants tightening before these figures are quoted as precise.

## On proving the wiring

Shipping writers that nothing calls would repeat this ticket's own subject. A live smoke test can't prove it now — the pre-season market has no listings, so `buy_recs` is empty and the branch never runs. `status` against production created the table and recorded zero rows, which is correct and proves nothing. Four tests exercise the branch directly, including one asserting a learning failure can never block a trade.

810 passed / 1 skipped, ruff clean, black clean.

## Not included

`flip_outcomes.trend_at_buy` (0/151) and the motive column are still unfilled — REH-75 §11's first ask. Worth a follow-up, but the auction-winner data is the piece that unblocks the live strategy question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)