### PR TITLE
fix: two live-money bugs found dry-running the new season

### DIFF
--- a/rehoboam/scoring/decision.py
+++ b/rehoboam/scoring/decision.py
@@ -545,6 +545,42 @@ class DecisionEngine:
                     )
         return top
 
+    def trade_ep_gain(
+        self,
+        buy_score: PlayerScore,
+        buy_player: MarketPlayer,
+        sell_player_id: str,
+        squad: list[MarketPlayer],
+        squad_scores: list[PlayerScore],
+    ) -> float:
+        """Best-11 EP delta of swapping *sell_player_id* out for *buy_player*.
+
+        This is the trade-pair analogue of :meth:`calculate_marginal_ep`: both
+        answer "how much better is the starting 11 afterwards?", the only
+        difference being that a trade also *removes* a player.
+
+        Measured against the squad we would keep by doing nothing, so selling
+        a contributor is charged for the hole it leaves. Deliberately not
+        clamped at zero — a negative result means the swap actively hurts the
+        best 11, and the caller's threshold check needs to see that.
+
+        Using the raw ``buy.ep - sell.ep`` difference instead credits the full
+        EP of a player who was contributing nothing (a bench player scores no
+        matchday points) and ignores whether the incoming player can even
+        enter the best 11 — only one goalkeeper ever starts.
+        """
+        score_map = self.select_lineup(squad_scores)
+        current_best = select_best_eleven(squad, score_map)
+        current_total = sum(score_map.get(p.id, 0.0) for p in current_best)
+
+        new_squad = [p for p in squad if p.id != sell_player_id] + [buy_player]
+        new_score_map = dict(score_map)
+        new_score_map[buy_score.player_id] = buy_score.expected_points
+        new_best = select_best_eleven(new_squad, new_score_map)
+        new_total = sum(new_score_map.get(p.id, 0.0) for p in new_best)
+
+        return new_total - current_total
+
     def build_trade_pairs(
         self,
         market_scores: list[PlayerScore],
@@ -637,10 +673,28 @@ class DecisionEngine:
             sell_mp = best_sell.player
             sell_value = int(sell_mp.market_value * INSTANT_SELL_PCT)
             net_cost = buy_player.price - sell_value
-            ep_gain = ps.expected_points - best_sell.score.expected_points
+            ep_gain = self.trade_ep_gain(
+                buy_score=ps,
+                buy_player=buy_player,
+                sell_player_id=best_sell.score.player_id,
+                squad=squad_list,
+                squad_scores=squad_scores,
+            )
 
-            # Starter swaps churn team value — require a significant EP boost
-            # (2x the normal threshold) to justify the cost.
+            # Starter swaps must clear 2x the normal threshold.
+            #
+            # This multiplier predates formation-aware ep_gain, where it was a
+            # blunt correction for arithmetic that overstated every swap. It is
+            # kept deliberately, for a different reason: trade_ep_gain now
+            # prices the starter's lost EP correctly, but three costs of the
+            # swap still sit outside that delta --
+            #   1. instant sell takes the INSTANT_SELL_PCT haircut
+            #   2. the sell executes immediately while the buy is only a BID
+            #      (auto_trader.run_unified_trade_phase), so a lost auction on a
+            #      starter swap leaves a hole in the real starting 11
+            #   3. week-to-week lineup churn
+            # (2) is the binding one. Revisit this premium when the trade phase
+            # defers the sell until the auction resolves.
             min_gain = self.min_ep_upgrade * 2 if is_starter_sell else self.min_ep_upgrade
             if ep_gain < min_gain:
                 continue

--- a/rehoboam/trader.py
+++ b/rehoboam/trader.py
@@ -134,7 +134,8 @@ class Trader:
         Kickbase has moved this value between aliases across seasons. Up to
         2025/26 it was a single ``nm``/``nextMatch``; as of 2026/27 the
         /myeleven response carries no such key and the fixture date is
-        instead attached per player under ``nlp[].md``. Both shapes are read,
+        instead attached per player under ``md``, split across ``lp`` (the
+        set lineup) and ``nlp`` (everyone else). Both shapes are read,
         newest first, and a shape we cannot read at all is logged rather than
         swallowed -- returning None here disables both the matchday "locked"
         phase and the budget-at-kickoff guard, so a silent None is expensive.
@@ -161,12 +162,17 @@ class Trader:
         if parsed is not None:
             candidates.append(parsed)
 
-        # 2026/27 shape: one fixture date per player in the next lineup.
-        for entry in starting_eleven.get("nlp") or []:
-            if isinstance(entry, dict):
-                parsed = _parse_match_date(entry.get("md"))
-                if parsed is not None:
-                    candidates.append(parsed)
+        # 2026/27 shape: one fixture date per player, under "md".
+        # lp[] is the set lineup, nlp[] the players outside it -- read BOTH.
+        # Before a lineup is set lp[] is empty and nlp[] holds the whole squad;
+        # afterwards the starters move to lp[], and reading only nlp[] would
+        # time the guard off the bench's fixtures.
+        for key in ("lp", "nlp"):
+            for entry in starting_eleven.get(key) or []:
+                if isinstance(entry, dict):
+                    parsed = _parse_match_date(entry.get("md"))
+                    if parsed is not None:
+                        candidates.append(parsed)
 
         upcoming = [d for d in candidates if d >= now]
         if not upcoming:

--- a/rehoboam/trader.py
+++ b/rehoboam/trader.py
@@ -15,6 +15,7 @@ Everything else from the old trader.py (legacy analyze/trade/display logic)
 has been removed.
 """
 
+import logging
 from datetime import datetime, timezone
 
 from rich.console import Console
@@ -33,6 +34,8 @@ from .kickbase_client import League
 from .matchup_analyzer import MatchupAnalyzer
 from .services.trend_service import TrendService
 from .value_history import ValueHistoryCache
+
+logger = logging.getLogger(__name__)
 
 console = Console()
 
@@ -67,6 +70,24 @@ def _determine_emergency(squad: list) -> tuple[bool, str]:
     if fieldability["ok"]:
         return False, ""
     return True, fieldability["reason"]
+
+
+def _parse_match_date(value) -> datetime | None:
+    """Parse a Kickbase match date from either an epoch number or an ISO string.
+
+    Returns None for anything unparseable so callers can keep collecting
+    candidates instead of aborting on one bad entry.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        if isinstance(value, int | float):
+            return datetime.fromtimestamp(value, tz=timezone.utc)
+        if isinstance(value, str):
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (ValueError, OSError, OverflowError):
+        return None
+    return None
 
 
 class Trader:
@@ -104,28 +125,69 @@ class Trader:
     # ------------------------------------------------------------------
 
     def get_days_until_match(self, league) -> int | None:
-        """Return days until the next match, or None if unknown.
+        """Return days until the next match, or None if genuinely unknown.
 
         Uses timezone-aware datetime comparison to avoid the naive/aware
         TypeError that silently broke matchday-phase detection in early
         revisions of this code.
+
+        Kickbase has moved this value between aliases across seasons. Up to
+        2025/26 it was a single ``nm``/``nextMatch``; as of 2026/27 the
+        /myeleven response carries no such key and the fixture date is
+        instead attached per player under ``nlp[].md``. Both shapes are read,
+        newest first, and a shape we cannot read at all is logged rather than
+        swallowed -- returning None here disables both the matchday "locked"
+        phase and the budget-at-kickoff guard, so a silent None is expensive.
         """
         try:
             starting_eleven = self.api.get_starting_eleven(league)
-            next_match = starting_eleven.get("nm") or starting_eleven.get("nextMatch")
-            if not next_match:
-                return None
-            if isinstance(next_match, int | float):
-                next_match_date = datetime.fromtimestamp(next_match, tz=timezone.utc)
-            elif isinstance(next_match, str):
-                next_match_date = datetime.fromisoformat(next_match.replace("Z", "+00:00"))
-            else:
-                return None
-            now = datetime.now(tz=timezone.utc)
-            days = (next_match_date - now).days
-            return max(days, 0)
         except Exception:
+            logger.warning("next-match: /myeleven fetch failed", exc_info=True)
             return None
+
+        if not isinstance(starting_eleven, dict):
+            logger.warning(
+                "next-match: unexpected /myeleven payload type=%s",
+                type(starting_eleven).__name__,
+            )
+            return None
+
+        now = datetime.now(tz=timezone.utc)
+        candidates: list[datetime] = []
+
+        # Legacy single-value aliases (pre-2026/27).
+        legacy = starting_eleven.get("nm") or starting_eleven.get("nextMatch")
+        parsed = _parse_match_date(legacy)
+        if parsed is not None:
+            candidates.append(parsed)
+
+        # 2026/27 shape: one fixture date per player in the next lineup.
+        for entry in starting_eleven.get("nlp") or []:
+            if isinstance(entry, dict):
+                parsed = _parse_match_date(entry.get("md"))
+                if parsed is not None:
+                    candidates.append(parsed)
+
+        upcoming = [d for d in candidates if d >= now]
+        if not upcoming:
+            logger.warning(
+                "next-match: no upcoming fixture found in /myeleven "
+                "(keys=%s, parsed=%d date(s)) - matchday phase detection and "
+                "the budget-at-kickoff guard are both disabled",
+                sorted(starting_eleven.keys()),
+                len(candidates),
+            )
+            return None
+
+        # Budget must be non-negative at the FIRST kickoff among our players,
+        # so the earliest upcoming fixture is the one that binds.
+        next_match_date = min(upcoming)
+        logger.debug(
+            "next-match: %s (from %d candidate date(s))",
+            next_match_date.isoformat(),
+            len(candidates),
+        )
+        return max((next_match_date - now).days, 0)
 
     # ------------------------------------------------------------------
     # EP pipeline

--- a/tests/test_next_match_detection.py
+++ b/tests/test_next_match_detection.py
@@ -96,3 +96,34 @@ class TestNextMatchDetection:
         with caplog.at_level(logging.WARNING):
             assert trader.get_days_until_match(MagicMock()) is None
         assert caplog.records, "schema miss must be logged, not swallowed"
+
+
+class TestLineupSplit:
+    """lp[] holds the set lineup, nlp[] everyone else -- both carry fixtures.
+
+    Before a lineup is set lp[] is empty and nlp[] holds the whole squad,
+    which is the state the fix was first probed in. Once a lineup exists the
+    starters move into lp[], and reading only nlp[] would time the
+    budget-at-kickoff guard off the bench's fixtures instead of the squad's.
+    """
+
+    def test_reads_fixtures_from_the_set_lineup_too(self):
+        now = datetime.now(tz=timezone.utc)
+        trader = _trader(
+            {
+                # Starters play first -- this is the kickoff that binds.
+                "lp": [{"md": _iso(now + timedelta(days=2, hours=1))}],
+                "nlp": [{"md": _iso(now + timedelta(days=7, hours=1))}],
+            }
+        )
+        assert trader.get_days_until_match(MagicMock()) == 2
+
+    def test_bench_fixture_still_counts_when_it_is_earlier(self):
+        now = datetime.now(tz=timezone.utc)
+        trader = _trader(
+            {
+                "lp": [{"md": _iso(now + timedelta(days=6, hours=1))}],
+                "nlp": [{"md": _iso(now + timedelta(days=3, hours=1))}],
+            }
+        )
+        assert trader.get_days_until_match(MagicMock()) == 3

--- a/tests/test_next_match_detection.py
+++ b/tests/test_next_match_detection.py
@@ -1,0 +1,98 @@
+"""Tests for Trader.get_days_until_match.
+
+This is the input to the matchday phase machine (auto_trader._get_matchday_phase)
+and to the budget-at-kickoff guard in ExecutionService.buy. When it returns
+None, the phase falls back to "moderate" and the 0-1 day "locked" phase can
+never trigger -- the bot keeps trading into kickoff.
+
+On 2026-08-21 the live /myeleven response for the new season carried none of
+the aliases this function looked for. Its response keys were:
+    clpc, cpte, lp, lpc, mu, nlp, p, pa
+The match date had moved into ``nlp``, a list of the squad's players for the
+next lineup, each entry carrying its own fixture date under ``md``.
+"""
+
+import logging
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+from rehoboam.config import Settings
+from rehoboam.trader import Trader
+
+
+def _trader(starting_eleven):
+    api = MagicMock()
+    api.get_starting_eleven.return_value = starting_eleven
+    return Trader(api=api, settings=Settings())
+
+
+def _iso(dt):
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class TestNextMatchDetection:
+    def test_reads_match_date_from_nlp_entries(self):
+        """The live 2026/27 shape: date lives in nlp[].md, not nm/nextMatch."""
+        now = datetime.now(tz=timezone.utc)
+        trader = _trader(
+            {
+                "clpc": 11,
+                "cpte": False,
+                "lp": [],
+                "lpc": 0,
+                "p": [],
+                "pa": True,
+                "nlp": [
+                    {"i": "72", "n": "Flekken", "md": _iso(now + timedelta(days=6, hours=2))},
+                    {"i": "157", "n": "Stark", "md": _iso(now + timedelta(days=7, hours=1))},
+                    {"i": "999", "n": "Other", "md": _iso(now + timedelta(days=8, hours=3))},
+                ],
+            }
+        )
+        assert trader.get_days_until_match(MagicMock()) == 6
+
+    def test_picks_the_earliest_upcoming_fixture(self):
+        """Budget must be non-negative at the FIRST kickoff, so take the min."""
+        now = datetime.now(tz=timezone.utc)
+        trader = _trader(
+            {
+                "nlp": [
+                    {"md": _iso(now + timedelta(days=9, hours=1))},
+                    {"md": _iso(now + timedelta(days=2, hours=1))},
+                    {"md": _iso(now + timedelta(days=5, hours=1))},
+                ]
+            }
+        )
+        assert trader.get_days_until_match(MagicMock()) == 2
+
+    def test_imminent_match_reports_zero_not_none(self):
+        """A match hours away must reach the 'locked' phase, not 'moderate'."""
+        now = datetime.now(tz=timezone.utc)
+        trader = _trader({"nlp": [{"md": _iso(now + timedelta(hours=5))}]})
+        assert trader.get_days_until_match(MagicMock()) == 0
+
+    def test_ignores_fixtures_already_played(self):
+        """Past dates in nlp must not be read as an imminent match."""
+        now = datetime.now(tz=timezone.utc)
+        trader = _trader(
+            {
+                "nlp": [
+                    {"md": _iso(now - timedelta(days=3))},
+                    {"md": _iso(now + timedelta(days=4, hours=2))},
+                ]
+            }
+        )
+        assert trader.get_days_until_match(MagicMock()) == 4
+
+    def test_legacy_nm_field_still_honoured(self):
+        """Back-compat: if nm returns, keep using it."""
+        now = datetime.now(tz=timezone.utc)
+        trader = _trader({"nm": _iso(now + timedelta(days=3, hours=1))})
+        assert trader.get_days_until_match(MagicMock()) == 3
+
+    def test_unrecognised_shape_warns_instead_of_failing_silently(self, caplog):
+        """A schema change must be loud -- this guard is worth ~1,100 points."""
+        trader = _trader({"clpc": 11, "cpte": False, "pa": True})
+        with caplog.at_level(logging.WARNING):
+            assert trader.get_days_until_match(MagicMock()) is None
+        assert caplog.records, "schema miss must be logged, not swallowed"

--- a/tests/test_scoring/test_trade_pairs.py
+++ b/tests/test_scoring/test_trade_pairs.py
@@ -1,0 +1,266 @@
+"""Tests for DecisionEngine.build_trade_pairs.
+
+Trade pairs must be valued the same way plain buys are: by how much the
+sell->buy swap moves the *best-11 total*, not by the two players' raw EP
+difference. A raw difference credits the full EP of a bench player who was
+contributing nothing, which is how a backup-keeper-for-backup-keeper swap
+came to be scored +52 EP against a squad that already had a 93 EP starter.
+"""
+
+from rehoboam.kickbase_client import MarketPlayer
+from rehoboam.scoring.decision import DecisionEngine
+from rehoboam.scoring.models import DataQuality, PlayerScore
+
+
+def _make_score(player_id, ep, position="Midfielder", price=5_000_000):
+    dq = DataQuality(
+        grade="A",
+        games_played=15,
+        consistency=0.8,
+        has_fixture_data=True,
+        has_lineup_data=True,
+        warnings=[],
+    )
+    return PlayerScore(
+        player_id=player_id,
+        expected_points=ep,
+        data_quality=dq,
+        base_points=ep * 0.5,
+        consistency_bonus=0.0,
+        lineup_bonus=0.0,
+        fixture_bonus=0.0,
+        form_bonus=0.0,
+        minutes_bonus=0.0,
+        dgw_multiplier=1.0,
+        is_dgw=False,
+        next_opponent=None,
+        notes=[],
+        current_price=price,
+        market_value=price,
+        position=position,
+    )
+
+
+def _make_player(player_id, position, price=5_000_000):
+    return MarketPlayer(
+        id=player_id,
+        first_name="Test",
+        last_name=player_id,
+        position=position,
+        team_id="t1",
+        team_name="Test FC",
+        price=price,
+        market_value=price,
+        points=100,
+        average_points=12.0,
+        status=0,
+    )
+
+
+def _squad():
+    """A realistic 15-man squad: 2 GK, 5 DEF, 5 MID, 3 FW.
+
+    Mirrors the live 2026-08-21 squad shape — one strong keeper plus a
+    worthless backup, which is the configuration that exposed the bug.
+    """
+    spec = [
+        ("gk_star", "Goalkeeper", 93.0),
+        ("gk_bench", "Goalkeeper", 0.0),
+        ("def1", "Defender", 73.0),
+        ("def2", "Defender", 69.0),
+        ("def3", "Defender", 36.0),
+        ("def4", "Defender", 31.0),
+        ("def5", "Defender", 26.0),
+        ("mid1", "Midfielder", 101.0),
+        ("mid2", "Midfielder", 83.0),
+        ("mid3", "Midfielder", 58.0),
+        ("mid4", "Midfielder", 34.0),
+        ("mid5", "Midfielder", 5.0),
+        ("fw1", "Forward", 46.0),
+        ("fw2", "Forward", 23.0),
+        ("fw3", "Forward", 4.0),
+    ]
+    players = {pid: _make_player(pid, pos) for pid, pos, _ in spec}
+    scores = [_make_score(pid, ep, pos) for pid, pos, ep in spec]
+    return players, scores
+
+
+def _best_11_total(engine, players, scores):
+    from rehoboam.formation import select_best_eleven
+
+    score_map = {s.player_id: s.expected_points for s in scores}
+    best = select_best_eleven(list(players.values()), score_map)
+    return sum(score_map.get(p.id, 0.0) for p in best)
+
+
+class TestTradePairMarginalEP:
+    def test_backup_keeper_swap_is_not_a_52_point_upgrade(self):
+        """A bench GK swap cannot improve the best 11 — only one GK ever starts.
+
+        This is the live 2026-08-21 regression: the plain-buy ranker scored
+        this same player at marginal 4.6 and skipped him, while the trade
+        path scored him +52.2 and bought him for EUR 6,631,597.
+        """
+        engine = DecisionEngine(min_ep_to_buy=35.0, min_ep_upgrade=40.0)
+        squad_players, squad_scores = _squad()
+
+        new_gk = _make_player("gk_new", "Goalkeeper", price=6_000_000)
+        new_gk_score = _make_score("gk_new", 52.0, "Goalkeeper", price=6_000_000)
+
+        pairs = engine.build_trade_pairs(
+            market_scores=[new_gk_score],
+            squad_scores=squad_scores,
+            roster_context={},
+            budget=80_000_000,
+            market_players={"gk_new": new_gk},
+            squad_players=squad_players,
+        )
+
+        assert pairs == [], (
+            "a second keeper cannot enter the best 11, so this swap is worth "
+            f"~0 EP, but build_trade_pairs produced: "
+            f"{[(p.sell_player.id, p.buy_player.id, p.ep_gain) for p in pairs]}"
+        )
+
+    def test_genuine_upgrade_still_produces_a_pair(self):
+        """Guard against over-correcting: real upgrades must survive."""
+        engine = DecisionEngine(min_ep_to_buy=35.0, min_ep_upgrade=40.0)
+        squad_players, squad_scores = _squad()
+
+        star = _make_player("mid_star", "Midfielder", price=20_000_000)
+        star_score = _make_score("mid_star", 120.0, "Midfielder", price=20_000_000)
+
+        pairs = engine.build_trade_pairs(
+            market_scores=[star_score],
+            squad_scores=squad_scores,
+            roster_context={},
+            budget=80_000_000,
+            market_players={"mid_star": star},
+            squad_players=squad_players,
+        )
+
+        assert len(pairs) == 1, "a 120 EP midfielder is a real upgrade"
+        pair = pairs[0]
+
+        # The gain must equal the actual best-11 delta of the whole swap.
+        before = _best_11_total(engine, squad_players, squad_scores)
+        after_players = {k: v for k, v in squad_players.items() if k != pair.sell_player.id}
+        after_players["mid_star"] = star
+        after_scores = [s for s in squad_scores if s.player_id != pair.sell_player.id] + [
+            star_score
+        ]
+        after = _best_11_total(engine, after_players, after_scores)
+
+        assert (
+            pair.ep_gain == round(after - before, 4) or abs(pair.ep_gain - (after - before)) < 0.01
+        ), f"ep_gain {pair.ep_gain} != best-11 delta {after - before}"
+
+    def test_selling_a_starter_charges_for_the_hole_it_leaves(self):
+        """Selling a starter must be measured against the squad that keeps him."""
+        engine = DecisionEngine(min_ep_to_buy=35.0, min_ep_upgrade=40.0)
+        squad_players, squad_scores = _squad()
+
+        # A forward-only squad slice: every bench player is already used up,
+        # so the only sell target for a forward is the starting fw1 (46.0).
+        buy = _make_player("fw_new", "Forward", price=9_000_000)
+        buy_score = _make_score("fw_new", 95.0, "Forward", price=9_000_000)
+
+        pairs = engine.build_trade_pairs(
+            market_scores=[buy_score],
+            squad_scores=squad_scores,
+            roster_context={},
+            budget=80_000_000,
+            market_players={"fw_new": buy},
+            squad_players=squad_players,
+        )
+
+        for pair in pairs:
+            before = _best_11_total(engine, squad_players, squad_scores)
+            after_players = {k: v for k, v in squad_players.items() if k != pair.sell_player.id}
+            after_players[pair.buy_player.id] = pair.buy_player
+            after_scores = [s for s in squad_scores if s.player_id != pair.sell_player.id] + [
+                buy_score
+            ]
+            after = _best_11_total(engine, after_players, after_scores)
+            assert (
+                abs(pair.ep_gain - (after - before)) < 0.01
+            ), f"ep_gain {pair.ep_gain} != best-11 delta {after - before}"
+
+
+class TestStarterSellPremium:
+    """Selling a starter must clear 2x the normal EP threshold.
+
+    Not because the EP math needs correcting -- trade_ep_gain prices the
+    starter's lost contribution properly -- but because the sell executes
+    immediately while the buy is only a bid, so a lost auction on a starter
+    swap leaves a hole in the real starting 11. See the rationale comment in
+    DecisionEngine.build_trade_pairs.
+
+    The squad below has no bench defenders, so once the four bench players
+    (gk_bench, fw3, mid5, fw2) are consumed by earlier candidates, a fifth
+    defender candidate has only a starting defender left to sell.
+    """
+
+    @staticmethod
+    def _defender_market(eps):
+        scores, players = [], {}
+        for i, ep in enumerate(eps):
+            pid = f"buy{i}"
+            players[pid] = _make_player(pid, "Defender", price=5_000_000)
+            scores.append(_make_score(pid, ep, "Defender", price=5_000_000))
+        return scores, players
+
+    def test_starter_swap_below_2x_is_rejected(self):
+        """+49 EP clears the normal 40 threshold but not the 80 starter bar."""
+        engine = DecisionEngine(min_ep_to_buy=35.0, min_ep_upgrade=40.0)
+        squad_players, squad_scores = _squad()
+        market_scores, market_players = self._defender_market([75.0] * 5)
+
+        pairs = engine.build_trade_pairs(
+            market_scores=market_scores,
+            squad_scores=squad_scores,
+            roster_context={},
+            budget=80_000_000,
+            market_players=market_players,
+            squad_players=squad_players,
+        )
+
+        # Four bench targets exist; the fifth candidate would have to sell a
+        # starter for +49, which is under the 2x bar.
+        assert len(pairs) == 4, [(p.sell_player.id, p.buy_player.id, p.ep_gain) for p in pairs]
+        best_11_ids = {
+            "gk_star",
+            "def1",
+            "def2",
+            "def3",
+            "def4",
+            "def5",
+            "mid1",
+            "mid2",
+            "mid3",
+            "mid4",
+            "fw1",
+        }
+        assert all(p.sell_player.id not in best_11_ids for p in pairs)
+
+    def test_starter_swap_above_2x_is_allowed(self):
+        """A big enough upgrade still justifies breaking up the starting 11."""
+        engine = DecisionEngine(min_ep_to_buy=35.0, min_ep_upgrade=40.0)
+        squad_players, squad_scores = _squad()
+        # First four outrank the fifth, so they claim the bench targets and
+        # the fifth (+94) falls through to the starter branch.
+        market_scores, market_players = self._defender_market([130.0, 130.0, 130.0, 130.0, 120.0])
+
+        pairs = engine.build_trade_pairs(
+            market_scores=market_scores,
+            squad_scores=squad_scores,
+            roster_context={},
+            budget=80_000_000,
+            market_players=market_players,
+            squad_players=squad_players,
+        )
+
+        assert len(pairs) == 5, [(p.sell_player.id, p.buy_player.id, p.ep_gain) for p in pairs]
+        starter_swaps = [p for p in pairs if p.sell_player.id == "def5"]
+        assert len(starter_swaps) == 1, "the fifth candidate should sell a starter"
+        assert starter_swaps[0].ep_gain >= 80.0


### PR DESCRIPTION
Found by running `rehoboam status` against the live 2026/27 league on 2026-08-21. Both are live-money bugs; neither is caught by CI.

## 1. Trade pairs were valued with the wrong EP math

`build_trade_pairs` scored a swap as `buy.ep - sell.ep`, while the plain-buy ranker used the formation-aware `calculate_marginal_ep`. Two numbers for the same decision, and the trade path was the optimistic one.

The bias is systematic, not incidental: the function prefers bench players as sell targets *by design*, and a bench player contributes exactly 0 to the best 11 — so the most-preferred path is the most-inflated.

The same player, scored twice in one session:

```
buy-skip Schwolow: marginal 4.6 < threshold 40.0 and not gap-fill
TRADE Kolke -> Schwolow | net EUR 5,231,597 | EP +52.2
```

A backup keeper swapped for a backup keeper behind a 93 EP starter, valued at +52 EP and bought for €6,631,597. `formation._POSITION_MAX_STARTERS["Goalkeeper"] == 1` — a second keeper can never enter the best 11, so the swap is worth ~0.

`trade_ep_gain` now mirrors `calculate_marginal_ep`, additionally removing the sold player so a starter sale is charged for the hole it leaves. Both paths now agree exactly on the live squad:

| Player | plain-buy marginal | trade pair (after) | trade pair (before) |
|---|---|---|---|
| Rohr | +70.5 | **+70.5** | +85.4 |
| Gregoritsch | +51.1 | **+51.1** | +52.0 |
| El Mala | +50.9 | **+50.9** | +51.7 |
| Baumgartner | +49.8 | **+49.8** | — |

The 2x starter-sell premium is **kept**, with its rationale rewritten. It's no longer compensating for broken arithmetic — that's fixed — but for the sell-executes-now / buy-is-only-a-bid ordering in `run_unified_trade_phase`. Filed as REH-87; revisit the premium once that lands.

`build_trade_pairs` had no test coverage at all. It does now.

## 2. The matchday lock was disarmed

`get_days_until_match` looked for `nm`/`nextMatch` on `/myeleven`. The new season's response carries neither — probed live, its keys are `clpc, cpte, lp, lpc, mu, nlp, p, pa`.

The date is still there, moved to a per-player `md` field (ISO string) split across **`lp`** (the set lineup) and **`nlp`** (everyone outside it). Both are read: before a lineup is set `lp` is empty and `nlp` holds the whole squad, but once one exists the starters move to `lp`, so reading only `nlp` would time the guard off the *bench's* fixtures rather than the squad's. That correction is commit 3 — the first pass had this wrong and the initial probe couldn't reveal it, because no lineup was set.

A bare `except Exception: return None` turned the schema change into a silent shrug. `None` is expensive here: it feeds both the matchday phase machine and the budget-at-kickoff guard, so every session ran as `moderate` regardless of the real fixture and the 0–1 day `locked` phase could never fire. Negative budget at kickoff scores **zero for the entire matchday**.

`tests/test_budget_kickoff_guardrail.py:169` already documented this as a hypothetical "ordinary API hiccup". It isn't hypothetical — the field is gone, so the guard was disabled permanently rather than intermittently.

## Verification

- **823 tests pass** (from 813), 1 skipped. 13 new tests across two new files.
- `ruff` clean. `mypy` unchanged (1 pre-existing error at `trader.py:479`, identical on `main`).
- **Live dry-run against prod**, per the API-touching-PR rule:

| | before | after |
|---|---|---|
| `days_to_match` | `None` | `6` |
| phase | `moderate` | `aggressive` (Match in 6d — full trading) |
| trades | 4 (incl. the keeper) | 3 |
| spend | €60,022,782 | €51,775,801 |

- **`replay-season` is silent on this change, not passing it.** It holds at 26,960 / 26,172 / +788 / 9th — but `rehoboam/replay/` never calls `build_trade_pairs`, so the gate doesn't exercise either fix. The unchanged number confirms only that I didn't break the scoring path it *does* cover. Filed as REH-88, because a silent gate produces false confidence.

## Follow-ups filed

- **REH-87** (High) — trade phase sells before the bid resolves; the dry-run lineup had to field a 0.0 EP player. Blocks re-tuning the 2x premium.
- **REH-88** (Medium) — `replay-season` blind to the trade-pair path.

## Not addressed here

The Best-11 table's "Value Score" / "Avg Points" columns show average points, not the EP driving decisions — the v1 display remnants CLAUDE.md already flags. Malatini reads 26.0 there but scores EP 3.7, which is why selling him is correct. Display-only, left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)