### PR TITLE
fix(trade): don't break up the starting eleven for a bid that may not land (REH-87)

### DIFF
--- a/rehoboam/auto_trader.py
+++ b/rehoboam/auto_trader.py
@@ -89,6 +89,31 @@ def _available_squad_slots(squad_size: int, open_bid_count: int, cap: int = SQUA
     return cap - squad_size - open_bid_count
 
 
+def _starter_swap_has_recovery_time(days_until_match: int | None, min_days: int) -> bool:
+    """May a trade pair break up the best eleven for a bid that might not land?
+
+    A pair sells before it bids, and that ordering is forced rather than
+    careless: Kickbase counts open bids toward the 15-player cap, so at 15/15
+    the sell is what frees the slot the bid needs. The plain-buy path can defer
+    its sell until the auction resolves (`sell_plan_player_ids`); the pair path
+    has nothing to defer into.
+
+    So the sell is certain and the buy is only a bid. Lose the auction and the
+    squad is simply one player lighter until a later session replaces him --
+    which costs nothing on the pitch for a bench player, and real points every
+    matchday for a member of the best eleven.
+
+    The bot runs twice a day, so that risk is only material when there is no
+    time left to refill before kickoff. An unknown date counts as no time: this
+    guard's whole point is the case we cannot see, and `get_days_until_match`
+    returning None is exactly how the matchday phase silently degraded for
+    months (PR #66).
+    """
+    if days_until_match is None:
+        return False
+    return days_until_match >= min_days
+
+
 def _emergency_slots_short(squad: list) -> int:
     """How many players must be bought to make a legal eleven fieldable.
 
@@ -552,6 +577,29 @@ class AutoTrader:
                         f"[yellow]Cannot afford trade pair "
                         f"{obj.sell_player.last_name}→{obj.buy_player.last_name} "
                         f"(net €{net_cost:,} > €{ctx.flip_budget:,})[/yellow]"
+                    )
+                    continue
+
+                # The sell below is irreversible while the buy is only a bid,
+                # so refuse to open a hole in the starting eleven that we may
+                # not have time to close again. Bench sells pass freely.
+                if obj.sell_is_starter and not _starter_swap_has_recovery_time(
+                    ctx.matchday_phase.days_until_match,
+                    self.settings.min_days_to_match_for_starter_swap,
+                ):
+                    console.print(
+                        f"[yellow]Skip pair {obj.sell_player.last_name}→"
+                        f"{obj.buy_player.last_name} — would sell a starter with "
+                        f"{ctx.matchday_phase.days_until_match} day(s) to kickoff "
+                        f"(need {self.settings.min_days_to_match_for_starter_swap}+); "
+                        f"a lost auction would leave the eleven short[/yellow]"
+                    )
+                    logger.info(
+                        "trade-pair skip starter-swap sell=%s buy=%s days_to_match=%s min=%d",
+                        obj.sell_player.id,
+                        obj.buy_player.id,
+                        ctx.matchday_phase.days_until_match,
+                        self.settings.min_days_to_match_for_starter_swap,
                     )
                     continue
 

--- a/rehoboam/config.py
+++ b/rehoboam/config.py
@@ -195,6 +195,20 @@ class Settings(BaseSettings):
         ),
     )
 
+    min_days_to_match_for_starter_swap: int = Field(
+        default=3,
+        description=(
+            "Days before kickoff below which a trade pair may not sell a member "
+            "of the best eleven. A pair sells before it bids -- Kickbase counts "
+            "open bids toward the 15-player cap, so the sell is what frees the "
+            "slot -- which makes the sell certain and the buy only a bid. Losing "
+            "that auction leaves the starting eleven short until a later session "
+            "refills it, so the swap is only worth risking while sessions remain "
+            "before kickoff. Bench sells are unaffected: they cost nothing on the "
+            "pitch. An unknown match date counts as no time. See REH-87."
+        ),
+    )
+
     # Bid tiers — the marginal-gain bands SmartBidding uses to size an overbid.
     # Fields rather than module constants so they can be re-tuned from `.env`
     # mid-season without shipping a build.

--- a/rehoboam/scoring/decision.py
+++ b/rehoboam/scoring/decision.py
@@ -713,6 +713,7 @@ class DecisionEngine:
                     sell_score=best_sell.score,
                     net_cost=net_cost,
                     ep_gain=ep_gain,
+                    sell_is_starter=is_starter_sell,
                 )
             )
 

--- a/rehoboam/scoring/models.py
+++ b/rehoboam/scoring/models.py
@@ -97,6 +97,10 @@ class TradePair:
     sell_score: PlayerScore
     net_cost: int
     ep_gain: float
+    # True when the sell target is in the current best eleven. The execution
+    # path needs this: a trade pair sells before it bids, so losing the
+    # auction costs real matchday points only when a starter was the one sold.
+    sell_is_starter: bool = False
     recommended_bid: int | None = None
     metadata: dict | None = None
 

--- a/tests/test_starter_swap_recovery_time.py
+++ b/tests/test_starter_swap_recovery_time.py
@@ -1,0 +1,185 @@
+"""Tests for the recovery-time gate on starter trade-pair swaps (REH-87).
+
+A trade pair sells before it bids. That ordering is forced, not sloppy:
+Kickbase counts open bids toward the 15-player cap, so at 15/15 the sell is
+what frees the slot the bid needs. The plain-buy path can defer its sell
+until the auction resolves; the pair path cannot.
+
+So the sell is unconditional while the buy is only a bid. Losing the auction
+leaves the squad a player lighter until a later session replaces him:
+
+* a bench player was scoring nothing, so nothing is lost on the pitch
+* a member of the best eleven costs real points every matchday until refilled
+
+The bot runs twice a day, so the risk is only material when there is no time
+left to refill before kickoff.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, Mock, patch
+
+from rehoboam.auto_trader import (
+    AutoTrader,
+    EPSessionContext,
+    MatchdayPhase,
+    _starter_swap_has_recovery_time,
+)
+from rehoboam.config import Settings
+from rehoboam.scoring.decision import DecisionEngine
+from tests.test_scoring.test_trade_pairs import _make_player, _make_score, _squad
+
+
+class TestRecoveryTimeGate:
+    def test_unknown_match_date_is_treated_as_no_time(self):
+        """Fail closed. An unknown date is exactly how this bug hid for months."""
+        assert _starter_swap_has_recovery_time(None, min_days=3) is False
+
+    def test_plenty_of_time_allows_the_swap(self):
+        assert _starter_swap_has_recovery_time(6, min_days=3) is True
+
+    def test_too_close_to_kickoff_blocks_the_swap(self):
+        assert _starter_swap_has_recovery_time(2, min_days=3) is False
+
+    def test_threshold_is_inclusive(self):
+        assert _starter_swap_has_recovery_time(3, min_days=3) is True
+
+    def test_matchday_eve_blocks_the_swap(self):
+        assert _starter_swap_has_recovery_time(0, min_days=3) is False
+
+
+class TestTradePairCarriesStarterFlag:
+    """build_trade_pairs already knows whether it picked a starter; it must say so."""
+
+    def test_bench_sell_is_not_flagged_as_starter(self):
+        engine = DecisionEngine(min_ep_to_buy=35.0, min_ep_upgrade=40.0)
+        squad_players, squad_scores = _squad()
+        star = _make_player("mid_star", "Midfielder", price=20_000_000)
+        star_score = _make_score("mid_star", 120.0, "Midfielder", price=20_000_000)
+
+        pairs = engine.build_trade_pairs(
+            market_scores=[star_score],
+            squad_scores=squad_scores,
+            roster_context={},
+            budget=80_000_000,
+            market_players={"mid_star": star},
+            squad_players=squad_players,
+        )
+        assert len(pairs) == 1
+        assert pairs[0].sell_is_starter is False
+
+    def test_starter_sell_is_flagged(self):
+        engine = DecisionEngine(min_ep_to_buy=35.0, min_ep_upgrade=40.0)
+        squad_players, squad_scores = _squad()
+
+        # Four high-EP defenders claim the four bench targets; the fifth has
+        # only a starting defender left to sell.
+        scores, players = [], {}
+        for i, ep in enumerate([130.0, 130.0, 130.0, 130.0, 120.0]):
+            pid = f"buy{i}"
+            players[pid] = _make_player(pid, "Defender", price=5_000_000)
+            scores.append(_make_score(pid, ep, "Defender", price=5_000_000))
+
+        pairs = engine.build_trade_pairs(
+            market_scores=scores,
+            squad_scores=squad_scores,
+            roster_context={},
+            budget=80_000_000,
+            market_players=players,
+            squad_players=squad_players,
+        )
+        starter_swaps = [p for p in pairs if p.sell_player.id == "def5"]
+        assert len(starter_swaps) == 1
+        assert starter_swaps[0].sell_is_starter is True
+        assert all(p.sell_is_starter is False for p in pairs if p.sell_player.id != "def5")
+
+
+class TestGateBehaviourInTradePhase:
+    """Observe the gate through `run_unified_trade_phase`, not by inspecting it.
+
+    The sibling flip-switch tests record why: earlier gate tests there were
+    deleted because they passed on an inverted gate, on a gate that read the
+    setting and ignored it, and on a gate in unreachable code. What matters
+    here is whether the irreversible `instant_sell` actually happens.
+    """
+
+    @staticmethod
+    def _trader(tmp_path, monkeypatch):
+        monkeypatch.setenv("KICKBASE_EMAIL", "test@example.com")
+        monkeypatch.setenv("KICKBASE_PASSWORD", "test")
+        monkeypatch.chdir(tmp_path)
+        settings = Settings()
+        settings.enable_flip_buys = False  # keep the flip block out of the way
+        trader = AutoTrader(api=MagicMock(), settings=settings, dry_run=True)
+        # A full squad: 15 players + 0 bids means zero open slots, which is the
+        # only condition under which the pair branch runs at all.
+        trader.api.get_squad.return_value = [SimpleNamespace(id=f"s{i}") for i in range(15)]
+        trader.api.get_my_bids.return_value = []
+        trader.api.get_team_info.return_value = {
+            "budget": 50_000_000,
+            "team_value": 100_000_000,
+        }
+        trader.learner = Mock()
+        trader.learner.was_recently_sold.return_value = False
+        return trader
+
+    @staticmethod
+    def _ctx(days_until_match, sell_is_starter):
+        pair = SimpleNamespace(
+            buy_player=SimpleNamespace(id="b1", first_name="New", last_name="Buyer"),
+            sell_player=SimpleNamespace(
+                id="s1", first_name="Old", last_name="Seller", market_value=5_000_000
+            ),
+            ep_gain=90.0,
+            net_cost=1_000_000,
+            recommended_bid=6_000_000,
+            sell_is_starter=sell_is_starter,
+        )
+        phase = MatchdayPhase(
+            days_until_match=days_until_match,
+            phase="aggressive" if (days_until_match or 0) > 4 else "moderate",
+            max_trades=5,
+            allow_flips=False,
+            reason="test",
+        )
+        return EPSessionContext(
+            ep_result={"buy_recs": [], "trade_pairs": [pair]},
+            matchday_phase=phase,
+            my_bids=[],
+            my_bid_amounts={},
+            squad=[],
+            current_budget=50_000_000,
+            team_value=100_000_000,
+            flip_budget=50_000_000,
+        )
+
+    def _run(self, tmp_path, monkeypatch, days_until_match, sell_is_starter):
+        trader = self._trader(tmp_path, monkeypatch)
+        with (
+            patch.object(trader.execution, "instant_sell") as mock_sell,
+            patch.object(trader.execution, "buy") as mock_buy,
+        ):
+            mock_sell.return_value = SimpleNamespace(success=True, price=5_000_000)
+            mock_buy.return_value = SimpleNamespace(success=True)
+            trader.run_unified_trade_phase(
+                league=SimpleNamespace(id="L"),
+                ctx=self._ctx(days_until_match, sell_is_starter),
+            )
+        return mock_sell
+
+    def test_starter_is_not_sold_on_matchday_eve(self, tmp_path, monkeypatch):
+        """The whole point: no irreversible sell we cannot undo before kickoff."""
+        mock_sell = self._run(tmp_path, monkeypatch, days_until_match=1, sell_is_starter=True)
+        mock_sell.assert_not_called()
+
+    def test_starter_is_not_sold_when_the_match_date_is_unknown(self, tmp_path, monkeypatch):
+        mock_sell = self._run(tmp_path, monkeypatch, days_until_match=None, sell_is_starter=True)
+        mock_sell.assert_not_called()
+
+    def test_starter_is_sold_when_there_is_time_to_recover(self, tmp_path, monkeypatch):
+        mock_sell = self._run(tmp_path, monkeypatch, days_until_match=6, sell_is_starter=True)
+        mock_sell.assert_called_once()
+
+    def test_bench_sell_is_unaffected_on_matchday_eve(self, tmp_path, monkeypatch):
+        """Bench players cost nothing on the pitch — the gate must not touch them."""
+        mock_sell = self._run(tmp_path, monkeypatch, days_until_match=1, sell_is_starter=False)
+        mock_sell.assert_called_once()


### PR DESCRIPTION
Closes REH-87.

## The problem

`run_unified_trade_phase` instant-sells, then bids. `buy_result.success` means **a bid was placed**, not an auction won — so the sell is certain and the buy is not. Lose the auction and the squad is simply a player lighter.

Observed in the 2026-08-21 dry run: after three trades the squad had to field Klaas at 0.0 EP to fill the starting 11.

## Why this fixes the consequence, not the sequence

The obvious fix — defer the sell like the plain-buy path does via `sell_plan_player_ids` — is **infeasible here**. Kickbase counts open bids toward the 15-player cap ("15-player cap now counts open bids", v2 design spec §313), and the pair branch only runs at zero open slots. **The sell is the slot the bid needs.** A pair has nothing to defer into.

## What it does instead

The two failure severities differ sharply, and the code treated them alike:

| | auction lost | cost |
|---|---|---|
| **Bench sell** | squad 14/15 | nothing on the pitch — the player wasn't scoring |
| **Starter sell** | best 11 is short | real points every matchday until refilled |

So gate on **recovery time** rather than banning starter swaps outright. The bot runs twice daily, so the risk only bites when no sessions remain before kickoff.

`min_days_to_match_for_starter_swap` (default 3) is a `Settings` field — tunable from `.env` without a deploy, consistent with every other threshold in the project.

An unknown match date counts as no time. This guard's whole point is the case we can't see, and `get_days_until_match` returning `None` is exactly how the matchday phase silently degraded for months. That's also why this gate is only buildable now: **before PR #66 the date was always `None`**, so a recovery-time gate would have blocked every starter swap unconditionally.

`TradePair` gains `sell_is_starter` — `build_trade_pairs` already computed it as `is_starter_sell` and threw it away.

## Verification

- **834 tests pass** (from 830), 1 skipped. 11 new tests.
- **Behavioural, not source-inspecting.** `tests/test_auto_trader_flip_switches.py` records that earlier gate tests there were deleted because they passed on an inverted gate, on a gate that read its setting and ignored it, and on a gate in unreachable code. These observe whether `instant_sell` actually fires. I neutered the gate and confirmed the two "must not sell" tests **fail** — they test behaviour, not existence.
- `ruff` clean. All 5 touched files black-clean (the 6 dirty files under `rehoboam/` are pre-existing and untouched).
- **Live dry-run unchanged** — 6 days out with a bench sell, so the gate is correctly dormant. It changes nothing today; it is a guard for the case that hasn't happened yet.
- **`replay-season` unchanged at 26,960 — which is "not measured", not "no regression".** `rehoboam/replay/` doesn't call `build_trade_pairs` at all (REH-88).

## Note on the 2x starter premium

PR #66 kept `min_ep_upgrade * 2` for starter swaps, justified specifically by this ordering risk. This gate addresses the risk directly and time-bounds it, so the premium is now a candidate for re-tuning — but that's a behaviour change worth measuring on its own, and REH-88 must land first so the replay can actually see it. Left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)