### PR TITLE
fix(bidding): the EP overbid floor no longer overrides the falling-value guard (REH-89)

### DIFF
--- a/rehoboam/bid_learner.py
+++ b/rehoboam/bid_learner.py
@@ -77,6 +77,36 @@ class FlipOutcome:
     was_injured: bool = False
 
 
+# --- EP overbid recommender (REH-89) --------------------------------------
+#
+# Minimum auctions inside the window before the learner is allowed to move a
+# bid at all. Below this there is nothing measured, so it must defer to the
+# bid stack rather than substitute an assumption for evidence.
+MIN_AUCTIONS_FOR_LEARNED_OVERBID = 5
+
+# How far back auction outcomes stay relevant. Note the off-season is longer
+# than this, so at season start the window is legitimately empty -- which is
+# precisely when the bot spends most.
+AUCTION_HISTORY_WINDOW_DAYS = 90
+
+# Overbid percentage contributed per point of marginal EP gain.
+#
+# NOT re-derived for the real-points scale, and deliberately so: doing that
+# honestly needs auction outcomes measured against v2 gains, and there are
+# currently zero inside the window. It is named and greppable here so the
+# re-derivation is a one-line change once REH-68's replay can measure it.
+#
+# Scale history: on the 0-100 index a gain had to exceed ~27 to beat the
+# MIN_LEARNED_OVERBID_PCT floor below, so this was a rarely-triggered
+# backstop. On real points (p50 gain 43.1) it binds every time, which is how
+# a backstop became the primary driver of bid size. It now only applies when
+# there is auction evidence, which bounds the damage until it is re-derived.
+EP_FLOOR_PCT_PER_POINT = 0.3
+
+# Smallest overbid the learner will ever recommend once it does speak.
+MIN_LEARNED_OVERBID_PCT = 8.0
+
+
 class BidLearner:
     """Learn from auction outcomes to improve bidding strategy"""
 
@@ -1519,9 +1549,6 @@ class BidLearner:
             }
         max_overbid_pct = (max_extra / asking_price) * 100.0
 
-        # EP-gain-based minimum floor (each EP point of marginal gain is worth ~0.3% extra)
-        ep_floor_pct = marginal_ep_gain * 0.3
-
         # Win-rate adjustment from historical auction data
         with sqlite3.connect(self.db_path) as conn:
             cursor = conn.execute(
@@ -1530,7 +1557,7 @@ class BidLearner:
                 FROM auction_outcomes
                 WHERE timestamp > ?
                 """,
-                (datetime.now().timestamp() - (90 * 24 * 3600),),
+                (datetime.now().timestamp() - (AUCTION_HISTORY_WINDOW_DAYS * 24 * 3600),),
             )
             row = cursor.fetchone()
 
@@ -1538,26 +1565,42 @@ class BidLearner:
         total_auctions = total_auctions or 0
         total_wins = total_wins or 0
 
-        if total_auctions >= 5:
-            win_rate = total_wins / total_auctions
-            if win_rate < 0.30:
-                win_rate_adj = 1.20  # Losing too much — be more aggressive
-                rate_reason = f"low win rate ({win_rate:.0%})"
-            elif win_rate > 0.70:
-                win_rate_adj = 0.90  # Winning easily — can dial back slightly
-                rate_reason = f"high win rate ({win_rate:.0%})"
-            else:
-                win_rate_adj = 1.0
-                rate_reason = f"balanced win rate ({win_rate:.0%})"
+        # No evidence, no opinion. The caller treats any positive value as
+        # authoritative and lets it replace the whole bid stack -- including
+        # the reduction applied when a player's market value is falling. An
+        # EP-derived guess is not a good enough reason to overrule that, so
+        # say nothing and let the stack stand (REH-89).
+        if total_auctions < MIN_AUCTIONS_FOR_LEARNED_OVERBID:
+            return {
+                "recommended_overbid_pct": 0.0,
+                "reason": (
+                    f"only {total_auctions} auction(s) in the last "
+                    f"{AUCTION_HISTORY_WINDOW_DAYS}d "
+                    f"(need {MIN_AUCTIONS_FOR_LEARNED_OVERBID}) — "
+                    f"deferring to the bid stack"
+                ),
+            }
+
+        # EP-gain-based minimum floor.
+        ep_floor_pct = marginal_ep_gain * EP_FLOOR_PCT_PER_POINT
+
+        # Past the early return there is always enough history to divide by.
+        win_rate = total_wins / total_auctions
+        if win_rate < 0.30:
+            win_rate_adj = 1.20  # Losing too much — be more aggressive
+            rate_reason = f"low win rate ({win_rate:.0%})"
+        elif win_rate > 0.70:
+            win_rate_adj = 0.90  # Winning easily — can dial back slightly
+            rate_reason = f"high win rate ({win_rate:.0%})"
         else:
             win_rate_adj = 1.0
-            rate_reason = "insufficient auction history"
+            rate_reason = f"balanced win rate ({win_rate:.0%})"
 
         # Outcome quality adjustment
         outcome_quality = self._get_won_player_outcome_quality()
 
         # Base overbid: use ep floor as the starting point, then scale
-        base_overbid = max(ep_floor_pct, 8.0)  # minimum sensible overbid
+        base_overbid = max(ep_floor_pct, MIN_LEARNED_OVERBID_PCT)
         recommended = base_overbid * win_rate_adj * outcome_quality
 
         # Cap to budget ceiling

--- a/tests/test_matchday_outcomes.py
+++ b/tests/test_matchday_outcomes.py
@@ -468,6 +468,28 @@ class TestWonPlayerOutcomeQuality:
             assert 0.5 <= quality < 1.0
 
 
+def _seed_recent_auctions(learner, n=10, won=False):
+    """Give the learner enough recent evidence to be allowed an opinion.
+
+    Since REH-89 `get_ep_recommended_overbid` returns 0.0 when there are fewer
+    than MIN_AUCTIONS_FOR_LEARNED_OVERBID outcomes inside its window, so that
+    an unmeasured EP floor cannot override the bid stack. Without this seeding
+    the tests below would pass vacuously on 0.0 and stop testing anything.
+    """
+    import sqlite3
+    import time
+
+    ts = time.time() - 24 * 3600
+    with sqlite3.connect(learner.db_path) as conn:
+        for i in range(n):
+            conn.execute(
+                "INSERT INTO auction_outcomes "
+                "(player_id, player_name, our_bid, asking_price, our_overbid_pct, "
+                " won, timestamp) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (f"seed{i}", f"Seed{i}", 1_100_000, 1_000_000, 10.0, 1 if won else 0, ts),
+            )
+
+
 class TestEPRecommendedOverbid:
     def test_returns_dict_with_required_keys(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -487,6 +509,7 @@ class TestEPRecommendedOverbid:
         """High marginal EP gain should produce higher overbid than low EP gain."""
         with tempfile.TemporaryDirectory() as tmpdir:
             learner = BidLearner(db_path=Path(tmpdir) / "test.db")
+            _seed_recent_auctions(learner)
             low_ep = learner.get_ep_recommended_overbid(
                 asking_price=10_000_000,
                 marginal_ep_gain=5.0,
@@ -505,6 +528,7 @@ class TestEPRecommendedOverbid:
         """Budget ceiling must constrain the overbid so we don't exceed budget."""
         with tempfile.TemporaryDirectory() as tmpdir:
             learner = BidLearner(db_path=Path(tmpdir) / "test.db")
+            _seed_recent_auctions(learner)
             # Tight budget ceiling: only 1M above asking price on a 10M player = 10% max
             result = learner.get_ep_recommended_overbid(
                 asking_price=10_000_000,
@@ -517,6 +541,7 @@ class TestEPRecommendedOverbid:
     def test_overbid_pct_is_non_negative(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             learner = BidLearner(db_path=Path(tmpdir) / "test.db")
+            _seed_recent_auctions(learner)
             result = learner.get_ep_recommended_overbid(
                 asking_price=10_000_000,
                 marginal_ep_gain=0.0,

--- a/tests/test_overbid_floor_precedence.py
+++ b/tests/test_overbid_floor_precedence.py
@@ -1,0 +1,140 @@
+"""REH-89: the EP overbid floor must not override a deliberate risk reduction.
+
+`SmartBidding.calculate_ep_bid` builds an overbid from a stack of signals, one
+of which cuts the bid hard when the player's market value is falling
+(`bidding_strategy.py`, trend-based reduction). Immediately afterwards the
+"learned override" replaced that stack outright:
+
+    overbid_pct = min(learned_pct, max_overbid)   # not min(learned_pct, stack)
+
+The overriding value came from `BidLearner.get_ep_recommended_overbid`, whose
+floor is `marginal_ep_gain * EP_FLOOR_PCT_PER_POINT`. That coefficient was
+calibrated on the 0-100 index, where `max(floor, 8.0)` meant it only bound for
+gains above ~27 and was therefore a rarely-triggered backstop. On the real
+points scale of v2 every gain binds, so the backstop quietly became the
+primary driver of bid size.
+
+Observed live 2026-08-21/22 on Maximilian Rohr:
+
+    stack=11.5% learned=21.1% applied=21.1%
+      | EP-gain=70.5pts -> floor 21.1% | insufficient auction history
+
+The trend logic saw -9.16 and cut to 11.5%; the floor pushed it back to 21.1%
+and the bot bid EUR 11,587,747 against a EUR 9,567,747 market value that had
+fallen 2.3% overnight.
+
+Crucially the reason was "insufficient auction history": the learner had 26
+auction outcomes but all from 2026-05-01..05-15, outside its 90-day window.
+Off-season leaves that window empty, so season start -- when the bot spends
+most -- is exactly when an unmeasured floor takes over.
+"""
+
+import sqlite3
+import time
+
+import pytest
+
+from rehoboam.bid_learner import BidLearner
+from rehoboam.bidding_strategy import SmartBidding
+
+
+@pytest.fixture
+def learner(tmp_path):
+    return BidLearner(db_path=tmp_path / "bids.db")
+
+
+def _seed_auctions(learner, n, won=True, age_days=1):
+    ts = time.time() - age_days * 24 * 3600
+    with sqlite3.connect(learner.db_path) as conn:
+        for i in range(n):
+            conn.execute(
+                "INSERT INTO auction_outcomes "
+                "(player_id, player_name, our_bid, asking_price, our_overbid_pct, "
+                " won, timestamp) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (f"p{i}", f"P{i}", 1_100_000, 1_000_000, 10.0, 1 if won else 0, ts),
+            )
+
+
+class TestFloorDefersWithoutEvidence:
+    def test_no_recent_auctions_returns_zero_not_a_floor(self, learner):
+        """With nothing measured, recommend nothing and let the stack stand."""
+        out = learner.get_ep_recommended_overbid(
+            asking_price=9_567_747,
+            marginal_ep_gain=70.5,
+            market_value=9_567_747,
+            budget_ceiling=85_000_000,
+        )
+        assert out["recommended_overbid_pct"] == 0.0, out
+        assert "defer" in out["reason"].lower(), out["reason"]
+
+    def test_stale_auctions_outside_the_window_do_not_count(self, learner):
+        """The live failure: 26 outcomes, all ~100 days old, window empty."""
+        _seed_auctions(learner, 26, age_days=100)
+        out = learner.get_ep_recommended_overbid(
+            asking_price=9_567_747,
+            marginal_ep_gain=70.5,
+            market_value=9_567_747,
+            budget_ceiling=85_000_000,
+        )
+        assert out["recommended_overbid_pct"] == 0.0, out
+
+    def test_recent_auctions_do_produce_a_recommendation(self, learner):
+        """Once there IS evidence, the learner is allowed to speak again."""
+        _seed_auctions(learner, 10, won=False, age_days=5)
+        out = learner.get_ep_recommended_overbid(
+            asking_price=9_567_747,
+            marginal_ep_gain=70.5,
+            market_value=9_567_747,
+            budget_ceiling=85_000_000,
+        )
+        assert out["recommended_overbid_pct"] > 0.0, out
+        assert "insufficient" not in out["reason"].lower()
+
+
+class TestFallingValueGuardSurvives:
+    def test_falling_market_value_reduction_is_not_overridden(self, learner):
+        """The Rohr case, end to end through the real bidding path."""
+        bidding = SmartBidding(bid_learner=learner)
+
+        falling = bidding.calculate_ep_bid(
+            asking_price=9_567_747,
+            market_value=9_567_747,
+            expected_points=89.1,
+            marginal_ep_gain=70.5,
+            confidence=0.7,
+            current_budget=85_162_497,
+            player_id="3284",
+            trend_change_pct=-11.27,
+        )
+        flat = bidding.calculate_ep_bid(
+            asking_price=9_567_747,
+            market_value=9_567_747,
+            expected_points=89.1,
+            marginal_ep_gain=70.5,
+            confidence=0.7,
+            current_budget=85_162_497,
+            player_id="3284",
+            trend_change_pct=0.0,
+        )
+
+        assert falling.recommended_bid < flat.recommended_bid, (
+            "a player whose market value is falling 11% must be bid on more "
+            f"cautiously, got falling={falling.recommended_bid:,} "
+            f"flat={flat.recommended_bid:,}"
+        )
+
+    def test_bid_stays_under_the_observed_live_overbid(self, learner):
+        """21.1% on a falling value was the defect; the stack alone gives ~11.5%."""
+        bidding = SmartBidding(bid_learner=learner)
+        rec = bidding.calculate_ep_bid(
+            asking_price=9_567_747,
+            market_value=9_567_747,
+            expected_points=89.1,
+            marginal_ep_gain=70.5,
+            confidence=0.7,
+            current_budget=85_162_497,
+            player_id="3284",
+            trend_change_pct=-11.27,
+        )
+        overbid_pct = (rec.recommended_bid / 9_567_747 - 1) * 100
+        assert overbid_pct < 20.0, f"overbid {overbid_pct:.1f}% still above the stack"


### PR DESCRIPTION
Closes REH-89. Found on day 1 of 2026/27, asking why the bot was bidding 21% over market value on a player whose market value was falling.

## The defect

`calculate_ep_bid` cuts the overbid to 30% of its value when a player's market value is falling more than 10%. The "learned override" right after it then **replaced** the whole stack instead of bounding it:

```python
overbid_pct = min(learned_pct, max_overbid)   # not min(learned_pct, stack_pct)
```

Two things made that overriding number wrong.

**1. It's a v1-scale constant.** `ep_floor_pct = marginal_ep_gain * 0.3`, calibrated on the 0–100 index. With `max(floor, 8.0)` it only bound above a gain of ~27 — a rarely-triggered backstop. On v2's real-points scale (p50 gain 43.1) it binds every time, so the backstop quietly became the *primary* driver of bid size. Fourth instance of the class REH-69 flagged, after tier thresholds, the 0.95 sell rate, and REH-69 itself.

**2. It isn't learned.** The reason string on every observed application was `insufficient auction history`. The table holds 26 outcomes — all from 2026-05-01..05-15, outside the 90-day window. **The off-season is longer than the window**, so season start, when the bot spends most, is precisely when an unmeasured floor takes over a deliberate risk reduction.

Observed live on Rohr:

```
stack=11.5% learned=21.1% applied=21.1% | EP-gain=70.5pts → floor 21.1% | insufficient auction history
```

The trend logic worked — saw −9.16, cut to 11.5%. The floor pushed it back to 21.1% and the bot bid €11,587,747 against a €9,567,747 value that fell 2.3% overnight.

## The fix

No evidence, no opinion. Below `MIN_AUCTIONS_FOR_LEARNED_OVERBID` in-window, return `0.0` and let the stack stand. Once there *is* evidence the learner can still raise a bid — that's the point of the win-rate adjustment, and it's preserved.

The coefficient is now named and documented but **deliberately not re-derived**. Doing that honestly needs auction outcomes measured against v2 gains, and there are zero in-window. Inventing a replacement number here would repeat the original mistake; it's greppable and inert until the data exists.

## Result — live dry-run, same market

| player | trend | before | after |
|---|---|---|---|
| Rohr | −11.27 (falling) | 21.1% | **6.9%** |
| Rohr | unknown | 21.1% | 13.8% |
| Gyamerah | +23.55 (rising) | ~21% | 16.0% |

Falling now bids less than unknown, which bids less than rising. Before, all three were flattened to ~21%. On Rohr that's €11,587,747 → €10,227,747, **€1,360,000 less**. Zero `learned-override` lines remain in the session log.

## Test coverage note

Three of the five existing `TestEPRecommendedOverbid` tests would have started passing **vacuously** on the `0.0` return (`0.0 >= 0.0` etc.) and stopped testing anything. They're seeded with recent auctions and assert a real gradient again — 9.6% / 14.4% / 25.4% across gains 5 / 40 / 70.5.

839 tests pass, ruff clean.

## `replay-season` unchanged at 26,960 — again NOT MEASURED

`rehoboam/replay/driver.py:423` constructs `SmartBidding(...)` **without a `bid_learner`**, so the override block is skipped entirely and the replay has never exercised this path. That's the third blind spot in three PRs (REH-88 covers the trade-pair one). The live dry-run above is the actual evidence here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)