### PR TITLE
fix(scoring): correct the inverted buy ranking — availability recency + top-flight quality

### DIFF
--- a/docs/superpowers/plans/2026-08-22-ep-targeting-and-quality-bar.md
+++ b/docs/superpowers/plans/2026-08-22-ep-targeting-and-quality-bar.md
@@ -1,0 +1,1011 @@
+# EP Targeting and Quality Bar Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the bot ranking a second-division defender above a Bayern
+midfielder, and give it a defensible notion of a target worth waiting for.
+
+**Architecture:** Four changes, ordered so each is independently testable.
+First close a replay/live parity leak by extracting the prev-status traversal
+both currently implement separately. Then bound that traversal by recency, so a
+three-month-old bench appearance stops driving availability. Then stop applying
+a fitted quality coefficient to players whose fitted history is second-division.
+Finally add an absolute target bar and a computed hold state on top of the
+now-trustworthy EP.
+
+**Tech Stack:** Python 3.12, pytest, pydantic-settings, SQLite.
+
+**Spec:** `docs/superpowers/specs/2026-08-22-ep-targeting-and-quality-bar-design.md`
+
+## Global Constraints
+
+- Real Kickbase points everywhere. Never reintroduce a 0-100 index constant.
+  See `scoring/v2/thresholds.py`.
+- Every tunable threshold is a `Settings` field so it can change from `.env`
+  without a deploy. No inline magic numbers.
+- Never add a second implementation of a scoring path. `scoring/v2/thresholds.py`
+  states the rule; REH-84 records what it cost last time.
+- Do not override `P(status)` at serving time. `rate.py`'s module docstring
+  explains that quality is pooled across statuses and a direct override
+  reintroduces a ~24% starter bias. Changing the *input* to
+  `availability.predict` is fine; replacing its *output* is not.
+- Run `uv run pytest -q -m "not slow"` before every commit. 839 tests pass at
+  the start of this plan.
+- `uv run ruff check rehoboam/ tests/` must pass. Do not run `black` manually on
+  existing files — pre-commit pins black 25.1.0 at `--line-length=100`; a local
+  black may differ and cause collateral reformatting.
+
+______________________________________________________________________
+
+### Task 1: Extract the prev-status traversal so replay and live share one implementation
+
+The live scorer derives "most recent played status" in
+`adapter.last_played_status`. The replay derives the same thing with its own
+inline loop at `replay/driver.py:145-149`. That is the exact second
+implementation REH-84's comment in that file warns against — it is why a
+scoring change once left the replay printing an identical 26,960.
+
+This task is a pure refactor. Behaviour must not change.
+
+**Files:**
+
+- Modify: `rehoboam/scoring/v2/adapter.py` (add `prev_status_from_history`, make
+  `last_played_status` delegate to it)
+- Modify: `rehoboam/replay/driver.py:141-166` (delegate to the same function)
+- Test: `tests/test_scoring_v2/test_adapter.py`
+
+**Interfaces:**
+
+- Consumes: `PLAYED_STATUSES` from `rehoboam.scoring.v2.features`
+
+- Produces: `prev_status_from_history(history: Sequence[tuple[str | None, int | None]]) -> int | None`
+  where each tuple is `(iso_match_date, status)` and the sequence is ordered
+  oldest-first. Tasks 2 extends this signature.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_scoring_v2/test_adapter.py`:
+
+```python
+from rehoboam.scoring.v2.adapter import prev_status_from_history
+
+
+class TestPrevStatusFromHistory:
+    def test_returns_the_latest_played_status(self):
+        history = [
+            ("2026-05-01T13:30:00Z", 5),
+            ("2026-05-09T16:30:00Z", 4),
+        ]
+        assert prev_status_from_history(history) == 4
+
+    def test_skips_unplayed_fixtures(self):
+        history = [
+            ("2026-05-01T13:30:00Z", 5),
+            ("2026-08-29T13:30:00Z", 0),
+            ("2026-09-05T13:30:00Z", None),
+        ]
+        assert prev_status_from_history(history) == 5
+
+    def test_no_played_history_returns_none(self):
+        assert prev_status_from_history([("2026-08-29T13:30:00Z", 0)]) is None
+
+    def test_empty_history_returns_none(self):
+        assert prev_status_from_history([]) is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_scoring_v2/test_adapter.py::TestPrevStatusFromHistory -v`
+Expected: FAIL with `ImportError: cannot import name 'prev_status_from_history'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `rehoboam/scoring/v2/adapter.py`, add above `last_played_status`:
+
+```python
+def prev_status_from_history(
+    history: Sequence[tuple[str | None, int | None]],
+) -> int | None:
+    """Most recent *played* status from ``(match_date, status)`` pairs.
+
+    Input is ordered oldest-first. Unplayed fixtures (status 0 or absent)
+    describe a match that has not happened, not a state the player was in, so
+    they are skipped.
+
+    This is the single implementation of that rule. The live scorer and the
+    season replay both call it. They previously derived it separately, which is
+    the drift `scoring/v2/thresholds.py` forbids and REH-84 records the cost of.
+    """
+    latest: int | None = None
+    for _match_date, status in history:
+        if status in PLAYED_STATUSES:
+            latest = int(status)
+    return latest
+```
+
+Add `from collections.abc import Sequence` to the imports.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_scoring_v2/test_adapter.py::TestPrevStatusFromHistory -v`
+Expected: PASS (4 passed)
+
+- [ ] **Step 5: Make `last_played_status` delegate**
+
+Replace the body of `last_played_status` in `rehoboam/scoring/v2/adapter.py`.
+The existing version sorts by `(season_title, day)` because the API does not
+guarantee order; preserve that, then delegate:
+
+```python
+def last_played_status(performance: dict | None) -> int | None:
+    """The player's status in his most recent *played* match.
+
+    Returns None when there is no played history, which the availability model
+    handles by falling back to its marginal prior.
+    """
+    if not performance:
+        return None
+
+    ordered: list[tuple[tuple[str, int], str | None, int | None]] = []
+    for season in performance.get("it") or []:
+        title = season.get("ti") or ""
+        for match in season.get("ph") or []:
+            day = match.get("day")
+            if day is None:
+                continue
+            ordered.append(((title, int(day)), match.get("md"), match.get("st")))
+    ordered.sort(key=lambda row: row[0])
+    return prev_status_from_history([(md, st) for _key, md, st in ordered])
+```
+
+- [ ] **Step 6: Run the existing adapter tests to prove no behaviour change**
+
+Run: `uv run pytest tests/test_scoring_v2/ -q`
+Expected: PASS, same count as before this task.
+
+- [ ] **Step 7: Make the replay delegate to the same function**
+
+In `rehoboam/replay/driver.py`, replace the inline loop (currently lines
+145-149):
+
+```python
+        prev_status = None
+        for match in reversed(history):
+            if match.get("status") in PLAYED_STATUSES:
+                prev_status = int(match["status"])
+                break
+```
+
+with:
+
+```python
+        # REH-84's rule applies to this traversal too, not just to `compose_ep`:
+        # deriving "most recent played status" here separately is a second
+        # implementation that would drift from the live scorer.
+        prev_status = prev_status_from_history(
+            [(m.get("match_date"), m.get("status")) for m in history]
+        )
+```
+
+Update the import at the top of the file to include `prev_status_from_history`
+alongside `compose_ep`. `PLAYED_STATUSES` may become unused in this file — if
+ruff reports it, remove that import.
+
+- [ ] **Step 8: Verify the replay is unchanged**
+
+Run: `uv run rehoboam replay-season 2>&1 | grep -iE "simulated|actual total|FINISHING"`
+Expected: `Simulated total: 26,960` / `Actual total: 26,172` / `FINISHING POSITION: 9 of 14`
+
+This is a pure refactor. **If the number moves, stop** — the two
+implementations were not equivalent, and that difference is a finding worth
+reporting before going further.
+
+- [ ] **Step 9: Full suite and lint**
+
+Run: `uv run pytest -q -m "not slow" && uv run ruff check rehoboam/ tests/`
+Expected: 843 passed, ruff clean.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add rehoboam/scoring/v2/adapter.py rehoboam/replay/driver.py tests/test_scoring_v2/test_adapter.py
+git commit -m "refactor(scoring): one implementation of prev-played-status for live and replay"
+```
+
+______________________________________________________________________
+
+### Task 2: Bound the prev-status traversal by recency
+
+Pavlović's most recent played match is 2025/26 matchday 34, played 2026-05-16 —
+an end-of-season unused-sub appearance in a dead rubber. Three months later that
+single observation still yields `P(start) = 17%` against a fitted rate of 131
+points if started, which is what puts him under the buy floor.
+
+**Files:**
+
+- Modify: `rehoboam/scoring/v2/adapter.py` (`prev_status_from_history`,
+  `last_played_status`, `score_player_v2`)
+- Modify: `rehoboam/config.py` (new `Settings` field)
+- Modify: `rehoboam/trader.py:459,496` (pass the setting)
+- Modify: `rehoboam/replay/driver.py` (pass the same bound)
+- Test: `tests/test_scoring_v2/test_adapter.py`
+
+**Interfaces:**
+
+- Consumes: `prev_status_from_history` from Task 1
+
+- Produces: `prev_status_from_history(history, *, now: datetime | None = None, max_age_days: float | None = None) -> int | None`;
+  `last_played_status(performance, *, now=None, max_age_days=None)`;
+  `score_player_v2(data, *, max_status_age_days: float | None = None)`;
+  `Settings.max_status_age_days: float`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_scoring_v2/test_adapter.py`:
+
+```python
+from datetime import datetime, timedelta, timezone
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class TestPrevStatusRecency:
+    def test_stale_status_is_discarded(self):
+        """The live Pavlovic case: an unused-sub appearance from 3 months ago."""
+        now = datetime(2026, 8, 22, tzinfo=timezone.utc)
+        history = [("2026-05-16T13:30:00Z", 4)]
+        assert prev_status_from_history(history, now=now, max_age_days=60.0) is None
+
+    def test_recent_status_is_kept(self):
+        now = datetime(2026, 8, 22, tzinfo=timezone.utc)
+        history = [(_iso(now - timedelta(days=7)), 4)]
+        assert prev_status_from_history(history, now=now, max_age_days=60.0) == 4
+
+    def test_no_bound_keeps_current_behaviour(self):
+        now = datetime(2026, 8, 22, tzinfo=timezone.utc)
+        history = [("2026-05-16T13:30:00Z", 4)]
+        assert prev_status_from_history(history, now=now) == 4
+
+    def test_unparseable_date_is_treated_as_stale(self):
+        """Fail closed: an unknown date cannot be shown to be recent."""
+        now = datetime(2026, 8, 22, tzinfo=timezone.utc)
+        assert (
+            prev_status_from_history([("not-a-date", 5)], now=now, max_age_days=60.0)
+            is None
+        )
+
+    def test_missing_date_is_treated_as_stale(self):
+        now = datetime(2026, 8, 22, tzinfo=timezone.utc)
+        assert prev_status_from_history([(None, 5)], now=now, max_age_days=60.0) is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_scoring_v2/test_adapter.py::TestPrevStatusRecency -v`
+Expected: FAIL with `TypeError: prev_status_from_history() got an unexpected keyword argument 'now'`
+
+- [ ] **Step 3: Implement the bound**
+
+Replace `prev_status_from_history` in `rehoboam/scoring/v2/adapter.py`:
+
+```python
+def prev_status_from_history(
+    history: Sequence[tuple[str | None, int | None]],
+    *,
+    now: datetime | None = None,
+    max_age_days: float | None = None,
+) -> int | None:
+    """Most recent *played* status from ``(match_date, status)`` pairs.
+
+    Input is ordered oldest-first. Unplayed fixtures (status 0 or absent)
+    describe a match that has not happened, not a state the player was in, so
+    they are skipped.
+
+    When ``max_age_days`` is set, a status older than that is discarded and
+    None is returned instead. The availability model treats None as "no
+    evidence" and falls back to its marginal prior, which is a weaker claim
+    than a stale transition rather than a stronger one.
+
+    Why this matters: without a bound, the last matchday of the previous season
+    drives availability for the whole of the next one. End-of-season status is
+    a bad prior -- squads rotate through dead rubbers -- and it persists for the
+    entire off-season.
+
+    A date that is missing or unparseable is treated as stale. This guard
+    exists for the case we cannot see, so it fails closed.
+
+    This is the single implementation of that rule. The live scorer and the
+    season replay both call it.
+    """
+    latest: int | None = None
+    for match_date, status in history:
+        if status not in PLAYED_STATUSES:
+            continue
+        if max_age_days is not None:
+            parsed = _parse_iso(match_date)
+            reference = now or datetime.now(tz=timezone.utc)
+            if (
+                parsed is None
+                or (reference - parsed).total_seconds() > max_age_days * 86400
+            ):
+                continue
+        latest = int(status)
+    return latest
+
+
+def _parse_iso(value: str | None) -> datetime | None:
+    """Parse a Kickbase ISO match date, or None if it cannot be read."""
+    if not value or not isinstance(value, str):
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+```
+
+Add `from datetime import datetime, timezone` to the imports.
+
+Note the loop `continue`s on a stale row rather than breaking, so a recent
+match earlier in the list is still found if a later one is unreadable.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_scoring_v2/test_adapter.py::TestPrevStatusRecency -v`
+Expected: PASS (5 passed)
+
+- [ ] **Step 5: Thread the bound through `last_played_status` and `score_player_v2`**
+
+In `rehoboam/scoring/v2/adapter.py`, change the signatures:
+
+```python
+def last_played_status(
+    performance: dict | None,
+    *,
+    now: datetime | None = None,
+    max_age_days: float | None = None,
+) -> int | None:
+```
+
+and pass them through on the final line:
+
+```python
+return prev_status_from_history(
+    [(md, st) for _key, md, st in ordered], now=now, max_age_days=max_age_days
+)
+```
+
+Then in `score_player_v2`:
+
+```python
+def score_player_v2(
+    data: PlayerData, *, max_status_age_days: float | None = None
+) -> PlayerScore:
+```
+
+and its call:
+
+```python
+prev_status = last_played_status(data.performance, max_age_days=max_status_age_days)
+```
+
+The scorer keeps taking this as a parameter rather than reading `Settings`
+itself: constructing `Settings` requires credentials, and `score_player_v2` is
+a pure function used in tests that have none.
+
+- [ ] **Step 6: Add the Settings field**
+
+In `rehoboam/config.py`, next to the other scoring thresholds:
+
+```python
+max_status_age_days: float = Field(
+    default=60.0,
+    description=(
+        "Discard a player's last-played availability status when it is older "
+        "than this many days, falling back to the availability model's "
+        "marginal prior. Must exceed the longest in-season gap (the winter "
+        "break, roughly 30 days) and fall below the off-season gap (roughly "
+        "90). Without it, the final matchday of the previous season drives "
+        "availability for the whole of the next: on 2026-08-22 Pavlovic was "
+        "scored P(start)=17% off an unused-sub appearance played 2026-05-16."
+    ),
+)
+```
+
+- [ ] **Step 7: Pass it at the live call sites**
+
+In `rehoboam/trader.py`, at both `score_player_v2(data)` call sites (currently
+lines 459 and 496), pass the setting:
+
+```python
+market_scores.append(
+    score_player_v2(data, max_status_age_days=self.settings.max_status_age_days)
+)
+```
+
+```python
+squad_scores.append(
+    score_player_v2(data, max_status_age_days=self.settings.max_status_age_days)
+)
+```
+
+- [ ] **Step 8: Pass it in the replay**
+
+In `rehoboam/replay/driver.py`, inside `score`, apply the same bound so the
+harness measures the same rule. The replay scores at a simulated instant, so
+pass that instant as `now` rather than wall-clock time:
+
+```python
+prev_status = prev_status_from_history(
+    [(m.get("match_date"), m.get("status")) for m in history],
+    now=datetime.fromtimestamp(at, tz=timezone.utc),
+    max_age_days=float(Settings.model_fields["max_status_age_days"].default),
+)
+```
+
+`Settings` and `_default` are already imported in this module for the bid
+tiers; reuse the same pattern. Add `from datetime import datetime, timezone`
+if not present.
+
+- [ ] **Step 9: Run the replay — this one is expected to move**
+
+Run: `uv run rehoboam replay-season 2>&1 | grep -iE "simulated|actual total|FINISHING|Total buys"`
+Baseline: 26,960 simulated / 26,172 actual / +788 / 9th of 14.
+
+Unlike Task 1, a change here is expected and is the point. Record the new
+number. If it drops materially, that is a real signal — report it rather than
+tuning `max_status_age_days` until the number improves.
+
+- [ ] **Step 10: Full suite, lint, live smoke**
+
+```bash
+uv run pytest -q -m "not slow" && uv run ruff check rehoboam/ tests/
+uv run rehoboam -v status 2>&1 | grep -iE "pavlovi|buy-skip Pavl|  BUY "
+```
+
+Expected: tests pass; Pavlović's EP is materially above 29.1 and he is no
+longer skipped for `EP < min 35.0`.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add rehoboam/scoring/v2/adapter.py rehoboam/config.py rehoboam/trader.py rehoboam/replay/driver.py tests/test_scoring_v2/test_adapter.py
+git commit -m "fix(scoring): discard availability status older than the off-season gap"
+```
+
+______________________________________________________________________
+
+### Task 3: Do not apply a fitted quality coefficient to non-top-flight history
+
+`rate.quality` is a baked lookup of 389 `player_id → multiplier` values. Seven
+of the 22 Kickbase-sold listings on 2026-08-22 have no `ap`/`tp` field at all on
+`get_player_details` — no Bundesliga history — yet carry fitted multipliers
+derived from 2. Bundesliga matches, and a data-quality grade of **A**.
+
+`rate.predict` already falls back to `position_prior` when a player_id is absent
+from `quality`. So the fix is to withhold the key, not to refit or discount.
+
+**Replay note:** this task is **not** measurable by `replay-season`. The corpus
+records no competition marker, so the harness cannot tell top-flight history
+from second-division history. Do not expect the replay number to move, and do
+not treat an unchanged number as evidence the change is safe. The unit tests and
+the live dry-run are the evidence here.
+
+**Files:**
+
+- Modify: `rehoboam/scoring/v2/adapter.py` (`score_player_v2`, new helper)
+- Test: `tests/test_scoring_v2/test_adapter.py`
+
+**Interfaces:**
+
+- Consumes: `PlayerData.player_details` (already carried by `DataCollector`)
+
+- Produces: `has_top_flight_history(player_details: dict | None) -> bool`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_scoring_v2/test_adapter.py`:
+
+```python
+from rehoboam.scoring.v2.adapter import has_top_flight_history
+
+
+class TestTopFlightHistory:
+    def test_player_with_average_points_has_top_flight_history(self):
+        assert has_top_flight_history({"ap": 119, "tp": 2844}) is True
+
+    def test_missing_ap_means_no_top_flight_history(self):
+        """The live Elversberg case: full 2. Bundesliga record, no `ap` field."""
+        assert has_top_flight_history({"fn": "Maximilian", "ln": "Rohr"}) is False
+
+    def test_zero_ap_means_no_top_flight_history(self):
+        assert has_top_flight_history({"ap": 0, "tp": 0}) is False
+
+    def test_missing_details_is_not_a_claim_of_history(self):
+        assert has_top_flight_history(None) is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_scoring_v2/test_adapter.py::TestTopFlightHistory -v`
+Expected: FAIL with `ImportError: cannot import name 'has_top_flight_history'`
+
+- [ ] **Step 3: Implement the helper**
+
+In `rehoboam/scoring/v2/adapter.py`:
+
+```python
+def has_top_flight_history(player_details: dict | None) -> bool:
+    """Has this player ever recorded Bundesliga scoring?
+
+    Kickbase omits ``ap``/``tp`` entirely for players with no top-flight
+    appearances. On 2026-08-22 that was true of seven of 22 buyable listings —
+    six from newly promoted clubs (Elversberg, Schalke, Paderborn) and one
+    Mainz backup keeper. The keeper is why the signal is "no top-flight
+    history" rather than "promoted club": it is broader, and it needs no
+    annually-maintained list of who came up.
+    """
+    if not player_details:
+        return False
+    return bool(player_details.get("ap") or player_details.get("tp"))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_scoring_v2/test_adapter.py::TestTopFlightHistory -v`
+Expected: PASS (4 passed)
+
+- [ ] **Step 5: Write the failing scorer test**
+
+Add to `tests/test_scoring_v2/test_adapter.py`. Reuse the module's existing
+`_player` and `_perf` helpers:
+
+```python
+class TestNonTopFlightUsesPositionPrior:
+    def test_fitted_quality_is_withheld_without_top_flight_history(self):
+        """A 2. Bundesliga record must not buy a confident Bundesliga rate."""
+        from rehoboam.scoring.models import PlayerData
+
+        player = _player("3284")  # Rohr, present in the fitted quality table
+        matches = [
+            {"day": d, "st": 5, "p": 100, "md": "2026-05-16T13:30:00Z"}
+            for d in range(1, 35)
+        ]
+        with_history = PlayerData(
+            player=player,
+            performance=_perf(matches),
+            player_details={"ap": 74, "tp": 1251},
+            team_strength=None,
+            opponent_strength=None,
+            is_dgw=False,
+        )
+        without_history = PlayerData(
+            player=player,
+            performance=_perf(matches),
+            player_details={"fn": "Maximilian", "ln": "Rohr"},
+            team_strength=None,
+            opponent_strength=None,
+            is_dgw=False,
+        )
+
+        scored_with = score_player_v2(with_history)
+        scored_without = score_player_v2(without_history)
+
+        assert scored_without.expected_points < scored_with.expected_points
+        assert scored_without.data_quality.grade != "A"
+        assert any("position prior" in n for n in scored_without.notes)
+```
+
+- [ ] **Step 6: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_scoring_v2/test_adapter.py::TestNonTopFlightUsesPositionPrior -v`
+Expected: FAIL — both scores are currently identical, so the first assert fails.
+
+- [ ] **Step 7: Withhold the quality key in `score_player_v2`**
+
+In `rehoboam/scoring/v2/adapter.py`, inside `score_player_v2`, compute a
+quality key once and use it everywhere the player id currently feeds the rate
+model. Replace the scoring block:
+
+```python
+    prev_status = last_played_status(data.performance, max_age_days=max_status_age_days)
+
+    # Withhold the fitted quality coefficient from players whose fitted record
+    # is not top-flight: `rate.predict` then falls back to the position prior,
+    # which is exactly the cold-start path an unfitted player already takes.
+    # This is NOT a discount multiplier — REH-80's blanket cold-start discount
+    # was reverted for costing 782 points. It declines to apply a coefficient
+    # fitted on inapplicable data.
+    quality_key = player.id if has_top_flight_history(data.player_details) else None
+
+    ep = compose_ep(quality_key, prev_status, position, availability, rate)
+
+    dgw_multiplier = DGW_MULTIPLIER if data.is_dgw else 1.0
+    ep *= dgw_multiplier
+
+    probs = availability.predict(prev_status)
+    notes = [
+        f"v2: availability P(start)={probs[5]:.0%} "
+        f"(prev status {prev_status if prev_status is not None else 'unknown'}), "
+        f"rate={rate.predict(quality_key, 5, position):.0f} pts if started"
+    ]
+    if quality_key not in rate.quality:
+        notes.append("No fitted quality — using position prior (cold start)")
+```
+
+and change the grade line in the `DataQuality` construction from
+`grade="A" if player.id in rate.quality else "C"` to
+`grade="A" if quality_key in rate.quality else "C"`.
+
+Widen `compose_ep`'s first parameter annotation to `player_id: str | None` and
+`rate.predict`'s to `player_id: str | None`. Both already behave correctly with
+None — `dict.get(None)` returns None and triggers the position-prior fallback —
+this only makes the type honest.
+
+- [ ] **Step 8: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_scoring_v2/test_adapter.py -v`
+Expected: PASS, all classes.
+
+- [ ] **Step 9: Full suite, lint, live smoke**
+
+```bash
+uv run pytest -q -m "not slow" && uv run ruff check rehoboam/ tests/
+uv run rehoboam -v status 2>&1 | grep -E "  BUY |buy-skip Rohr|buy-skip Gyamerah"
+```
+
+Expected: Rohr's EP has fallen from 89.1 (roughly −16%, to about 80 before the
+Task 2 effect) and he no longer outranks Pavlović.
+
+- [ ] **Step 10: Run the replay and record it as uninformative**
+
+Run: `uv run rehoboam replay-season 2>&1 | grep -iE "simulated|FINISHING"`
+
+Record the number in the commit message **explicitly labelled as not
+measuring this change**, for the reason in the task header. Do not present an
+unchanged number as a pass.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add rehoboam/scoring/v2/adapter.py rehoboam/scoring/v2/rate.py tests/test_scoring_v2/test_adapter.py
+git commit -m "fix(scoring): withhold fitted quality from players with no top-flight history"
+```
+
+______________________________________________________________________
+
+### Task 4: Absolute target bar
+
+The bot ranks only by marginal gain against the current squad, so in a weak week
+it spends slots on the best of a poor market. A player is now a **target** only
+if his absolute expected points clear a league-elite bar; marginal gain still
+decides price and displacement.
+
+**Files:**
+
+- Modify: `rehoboam/config.py` (new `Settings` field)
+- Modify: `rehoboam/scoring/decision.py` (`DecisionEngine.__init__`, `recommend_buys`)
+- Test: `tests/test_scoring/test_target_bar.py` (create)
+
+**Interfaces:**
+
+- Consumes: `PlayerScore.expected_points`
+
+- Produces: `DecisionEngine(min_ep_to_buy, min_ep_upgrade, target_ep_bar: float = 0.0)`;
+  `Settings.target_ep_bar: float`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_scoring/test_target_bar.py`:
+
+```python
+"""The absolute target bar (2026-08-22 design).
+
+Marginal gain answers "is he worth today's price and who does he displace".
+It cannot answer "is this player worth a squad slot at all", because a large
+marginal gain against a weak squad still describes a mediocre player. The bar
+is that second, absolute question.
+"""
+
+from rehoboam.scoring.decision import DecisionEngine
+from tests.test_scoring.test_trade_pairs import _make_player, _make_score, _squad
+
+
+def _engine(bar):
+    return DecisionEngine(min_ep_to_buy=35.0, min_ep_upgrade=40.0, target_ep_bar=bar)
+
+
+def _recommend(engine, ep, *, is_emergency=False):
+    squad_players, squad_scores = _squad()
+    cand = _make_player("cand", "Midfielder", price=5_000_000)
+    return engine.recommend_buys(
+        market_scores=[_make_score("cand", ep, "Midfielder", price=5_000_000)],
+        squad_scores=squad_scores,
+        roster_context={},
+        budget=80_000_000,
+        market_players={"cand": cand},
+        squad_players=squad_players,
+        is_emergency=is_emergency,
+    )
+
+
+class TestTargetBar:
+    def test_player_below_the_bar_is_not_recommended(self):
+        """Large marginal gain against a weak squad is still a mediocre player."""
+        assert _recommend(_engine(100.0), 70.0) == []
+
+    def test_player_above_the_bar_is_recommended(self):
+        assert len(_recommend(_engine(100.0), 120.0)) == 1
+
+    def test_zero_bar_preserves_existing_behaviour(self):
+        assert len(_recommend(_engine(0.0), 70.0)) == 1
+
+    def test_the_bar_yields_in_an_emergency(self):
+        """-100 for an empty slot dwarfs the cost of a mediocre signing."""
+        assert len(_recommend(_engine(100.0), 70.0, is_emergency=True)) == 1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_scoring/test_target_bar.py -v`
+Expected: FAIL with `TypeError: __init__() got an unexpected keyword argument 'target_ep_bar'`
+
+- [ ] **Step 3: Add the constructor parameter**
+
+In `rehoboam/scoring/decision.py`, change `DecisionEngine.__init__`:
+
+```python
+def __init__(
+    self,
+    min_ep_to_buy: float = 35.0,
+    min_ep_upgrade: float = 40.0,
+    target_ep_bar: float = 0.0,
+) -> None:
+    self.min_ep_to_buy = min_ep_to_buy
+    self.min_ep_upgrade = min_ep_upgrade
+    self.target_ep_bar = target_ep_bar
+```
+
+- [ ] **Step 4: Apply the bar in `recommend_buys`**
+
+In `recommend_buys`, the existing minimum-EP skip block reads:
+
+```python
+            min_ep = 10.0 if is_emergency else self.min_ep_to_buy
+            if ps.expected_points < min_ep:
+```
+
+Immediately after that block's `continue`, add:
+
+```python
+            # The bar is a "worth a squad slot at all" test, so it yields in an
+            # emergency: an unfieldable squad needs bodies, and -100 for an
+            # empty slot dwarfs the cost of a mediocre signing.
+            if not is_emergency and ps.expected_points < self.target_ep_bar:
+                logger.debug(
+                    "buy-skip %s: EP %.1f below target bar %.1f — holding the slot",
+                    player.last_name,
+                    ps.expected_points,
+                    self.target_ep_bar,
+                )
+                continue
+```
+
+The loop binds the market player as `player` (from
+`market_players.get(ps.player_id)`), matching the neighbouring skip blocks.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_scoring/test_target_bar.py -v`
+Expected: PASS (3 passed)
+
+- [ ] **Step 6: Add the Settings field and wire it**
+
+In `rehoboam/config.py`:
+
+```python
+target_ep_bar: float = Field(
+    default=0.0,
+    description=(
+        "Absolute expected points a market player must reach to count as a "
+        "target worth a squad slot, independent of marginal gain against the "
+        "current squad. 0.0 disables the bar and preserves pre-2026-08-22 "
+        "behaviour. Derive this from the measured marginal-gain and EP "
+        "distributions via `rehoboam derive-thresholds` once the market has "
+        "repopulated — it reported n=0 on 2026-07-31 and n=9 on 2026-08-22, "
+        "neither of which is enough to set it from."
+    ),
+)
+```
+
+In `rehoboam/trader.py`, where `DecisionEngine` is constructed, pass
+`target_ep_bar=self.settings.target_ep_bar`.
+
+**Ship the default at 0.0.** Setting a real bar is a separate, measured
+decision — see the plan's closing note.
+
+- [ ] **Step 7: Full suite, lint, replay**
+
+```bash
+uv run pytest -q -m "not slow" && uv run ruff check rehoboam/ tests/
+uv run rehoboam replay-season 2>&1 | grep -iE "simulated|FINISHING"
+```
+
+Expected: tests pass; the replay is unchanged, because the shipped default of
+0.0 disables the bar.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add rehoboam/config.py rehoboam/scoring/decision.py rehoboam/trader.py tests/test_scoring/test_target_bar.py
+git commit -m "feat(scoring): absolute target bar, disabled by default pending measurement"
+```
+
+______________________________________________________________________
+
+### Task 5: Computed availability state and holding
+
+`competitor_player_ids` already rebuilds the set of every player in every
+opponent's squad each session (`trader.py:280`), and is currently used for
+nothing but an `uncontested` metadata flag. Make "no target available" a state
+the bot computes, logs, and acts on.
+
+**Files:**
+
+- Modify: `rehoboam/auto_trader.py` (`run_unified_trade_phase`)
+- Test: `tests/test_target_hold_state.py` (create)
+
+**Interfaces:**
+
+- Consumes: `ctx.ep_result["competitor_player_ids"]`, `Settings.target_ep_bar`
+
+- Produces: `_target_availability(buy_recs, competitor_ids, bar) -> dict` with
+  keys `listed`, `owned_by_opponents`, `bar`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_target_hold_state.py`:
+
+```python
+"""Target availability is a computed, logged state — not an accident.
+
+The bot holds slots when nothing worth having is listed. That is only
+defensible if it can say how many targets exist and where they are.
+"""
+
+from types import SimpleNamespace
+
+from rehoboam.auto_trader import _target_availability
+
+
+def _rec(pid, ep):
+    return SimpleNamespace(
+        player=SimpleNamespace(id=pid, last_name=pid),
+        score=SimpleNamespace(expected_points=ep),
+    )
+
+
+class TestTargetAvailability:
+    def test_counts_listed_targets_above_the_bar(self):
+        state = _target_availability(
+            [_rec("a", 120.0), _rec("b", 50.0)], competitor_ids=set(), bar=100.0
+        )
+        assert state["listed"] == 1
+
+    def test_targets_held_by_opponents_are_counted_separately(self):
+        state = _target_availability(
+            [_rec("a", 120.0)], competitor_ids={"a"}, bar=100.0
+        )
+        assert state["listed"] == 0
+        assert state["owned_by_opponents"] == 1
+
+    def test_no_bar_means_every_recommendation_is_a_target(self):
+        state = _target_availability(
+            [_rec("a", 120.0), _rec("b", 50.0)], competitor_ids=set(), bar=0.0
+        )
+        assert state["listed"] == 2
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_target_hold_state.py -v`
+Expected: FAIL with `ImportError: cannot import name '_target_availability'`
+
+- [ ] **Step 3: Implement the helper**
+
+In `rehoboam/auto_trader.py`, alongside the other module-level pure helpers
+(`_available_squad_slots`, `_emergency_slots_short`,
+`_starter_swap_has_recovery_time`):
+
+```python
+def _target_availability(buy_recs: list, competitor_ids: set, bar: float) -> dict:
+    """How many targets exist, and where they are.
+
+    A target is a player whose ABSOLUTE expected points clear the bar —
+    "is he worth a squad slot at all" — as distinct from marginal gain, which
+    answers "is he worth today's price and who does he displace".
+
+    Split by where they sit, because the two states call for different
+    behaviour: a target that is listed can be bid on now, while one sitting in
+    an opponent's squad is a reason to keep a slot free rather than to act.
+    """
+    listed = 0
+    owned = 0
+    for rec in buy_recs:
+        if rec.score.expected_points < bar:
+            continue
+        if rec.player.id in competitor_ids:
+            owned += 1
+        else:
+            listed += 1
+    return {"listed": listed, "owned_by_opponents": owned, "bar": bar}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_target_hold_state.py -v`
+Expected: PASS (3 passed)
+
+- [ ] **Step 5: Log the state each session**
+
+In `rehoboam/auto_trader.py`, inside `run_unified_trade_phase`, after
+`buy_recs` and `trade_pairs` are read from `ctx.ep_result` and before the
+candidate list is assembled, add:
+
+```python
+        target_state = _target_availability(
+            buy_recs,
+            ctx.ep_result.get("competitor_player_ids") or set(),
+            self.settings.target_ep_bar,
+        )
+        logger.info(
+            "target-availability listed=%d owned_by_opponents=%d bar=%.1f",
+            target_state["listed"],
+            target_state["owned_by_opponents"],
+            target_state["bar"],
+        )
+```
+
+Logging the state before acting on it is deliberate: with `target_ep_bar`
+shipped at 0.0 this records what the bar *would* do for several sessions before
+anything is gated on it, which is how the bar gets set from evidence rather
+than from a guess.
+
+- [ ] **Step 6: Full suite, lint, live smoke**
+
+```bash
+uv run pytest -q -m "not slow" && uv run ruff check rehoboam/ tests/
+uv run rehoboam -v status 2>&1 | grep "target-availability"
+```
+
+Expected: one `target-availability` line per session with real counts.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add rehoboam/auto_trader.py tests/test_target_hold_state.py
+git commit -m "feat(trade): compute and log target availability from competitor ownership"
+```
+
+______________________________________________________________________
+
+## Deliberately deferred
+
+**Turning the bar on.** Every task ships `target_ep_bar` at 0.0, so behaviour is
+unchanged until a value is chosen. Choosing it needs the distribution, and
+`derive-thresholds` reported n=0 on 2026-07-31 and n=9 on 2026-08-22 — neither
+is enough. Run it again once the market has repopulated, read the percentiles,
+set the bar from `.env`, and watch the `target-availability` log line. Setting
+it now would repeat the mistake that produced the current pre-season thresholds.
+
+**The hold behaviour itself.** With the bar at 0.0 there is nothing to hold for.
+Once the bar is live and the log shows the state behaving sensibly, gating buys
+on `target_state["listed"] > 0` is a small follow-up. The spec's two exceptions
+must be honoured when it lands: the emergency fieldability fill
+(`_emergency_slots_short`, REH-82) overrides the hold, and position minimums
+still bind. An unfieldable squad is never an acceptable state to hold in.
+
+**A rate-model refit excluding second-division matches.** Task 3 achieves the
+same outcome for affected players at serving time. A refit is larger work and
+would also let the replay measure it — see REH-88 and REH-90.

--- a/docs/superpowers/specs/2026-08-22-ep-targeting-and-quality-bar-design.md
+++ b/docs/superpowers/specs/2026-08-22-ep-targeting-and-quality-bar-design.md
@@ -1,0 +1,245 @@
+# EP targeting: availability recency, top-flight quality, and an absolute target bar
+
+Date: 2026-08-22
+Status: design, approved in conversation, not yet planned
+Related: REH-90, REH-52, REH-42, REH-41, REH-71
+
+## Why
+
+On the first matchweek of 2026/27 the bot's buy ranking was close to inverted at
+the top. Measured against the live market on 2026-08-22:
+
+| player       | club           | Kickbase avg | bot's EP | bot's verdict                         |
+| ------------ | -------------- | -----------: | -------: | ------------------------------------- |
+| Ulreich      | Bayern         |          125 |     11.6 | skipped                               |
+| **Pavlović** | **Bayern**     |      **119** | **29.1** | **skipped, below the 35.0 buy floor** |
+| Baumgartner  | Leipzig        |          117 |     68.5 | 6th                                   |
+| Burkardt     | Frankfurt      |           87 |     31.0 | skipped                               |
+| Gregoritsch  | Augsburg       |           74 |     69.8 | 3rd                                   |
+| El Mala      | Köln           |           71 |     69.5 | 4th                                   |
+| **Rohr**     | **Elversberg** |      **0.0** | **89.1** | **1st, bid €12.3M**                   |
+| **Gyamerah** | **Elversberg** |      **0.0** | **70.6** | **2nd, bid €8.6M**                    |
+
+Two independent defects produce this. Both were diagnosed against live data
+rather than inferred.
+
+### Defect A — availability rests on a single, possibly ancient, observation
+
+`scoring/v2/adapter.last_played_status` returns the status of the most recent
+*played* match, with no recency constraint. `compose_ep` then weights every
+status branch by `availability.predict(prev_status)`.
+
+Pavlović's most recent played match is **2025/26 matchday 34, played
+2026-05-16** — over three months old, the final matchday of last season, where
+he was an unused substitute (`st=4`) in a dead rubber. The 2026/27 block holds
+34 fixture rows and **zero** played ones.
+
+That single stale observation yields `P(start) = 17%`. His fitted rate is
+**131 points if started**, the highest in the market. `0.17 × 131` is what puts
+him under the buy floor.
+
+This is the dominant defect. Rohr's `P(start) = 85%` (previous status 5)
+against Pavlović's 17% accounts for essentially the entire ranking inversion:
+at Rohr's start probability Pavlović scores roughly 111, comfortably first.
+
+### Defect B — second-division form is fitted as if it were Bundesliga form
+
+`rate.quality` is a baked lookup of 389 `player_id → multiplier` values fitted
+offline. Seven of the 22 Kickbase-sold listings have **no `ap`/`tp` field at
+all** on `get_player_details` — no top-flight history, because they have never
+played in the Bundesliga:
+
+| player                 | club       |
+| ---------------------- | ---------- |
+| Rohr, Gyamerah, Petkov | Elversberg |
+| Karaman, Grüger        | Schalke    |
+| Gayret                 | Paderborn  |
+| Schwolow               | Mainz      |
+
+Six are from newly promoted clubs. `get_player_performance` still returns full
+34-match seasons for them — those are **2. Bundesliga** matches — and nothing in
+`scoring/v2/` records which competition a match belongs to. Rohr therefore
+carries a fitted `quality = 1.124` and a data-quality grade of **A**, higher
+confidence than El Mala, who is graded **C**.
+
+Schwolow is the instructive exception: Mainz, top flight, but no `ap` — a
+keeper with no Bundesliga appearances. The robust signal is "no top-flight
+history", which is broader and more durable than "promoted club" and needs no
+annually-maintained list.
+
+This defect is real but **smaller than it first appears**. Rohr's 1.124 is
+modest next to Pavlović's 1.432; the scorer does not believe Rohr is the better
+player. Correcting it moves Rohr's rate from ~95 to ~80, roughly −16%.
+
+### Missing capability — nothing defines a target worth waiting for
+
+The bot ranks only by marginal EP gain against the current squad, over whatever
+is listed today. There is no notion of absolute quality, so in a weak week it
+spends slots on the best of a poor market. The buyable pool is genuinely small
+— 22 of 51 listings on 2026-08-22 — and elite players rotate through it, so
+patience has real value.
+
+## Goals
+
+1. Availability reflects recent evidence, or admits it has none.
+1. A player with no top-flight history is not scored as a confident known
+   quantity.
+1. A player is only worth a squad slot if his **absolute** expected points
+   clear a league-elite bar; **marginal** gain then decides price and who he
+   displaces.
+1. "No target available" is a computed, logged state, not an accident.
+
+## Non-goals
+
+- **Profit trading of any kind.** Considered and dropped. Measured history:
+  151 flips, **−€55.3M realised**, driven by a +12.2% average entry premium
+  against a ~4%-per-fortnight drift, with only the 10 flips held over two
+  months profitable. Buying power is not the constraint: €92,047,144 cash plus
+  €88,854,939 of squad market value against a €32.2M target. REH-71 stays open
+  and `ENABLE_FLIP_BUYS` stays false.
+- **Player-to-player listings.** 27 of 51 listings, including Gnabry (avg 142)
+  and Ito (avg 103), are filtered out by `is_kickbase_seller()` at
+  `trader.py:225`. Marco confirmed that managers list players for fast sale and
+  do not complete trades, so these are not practically buyable. The filter
+  stays.
+- **A corpus-backed league-wide watchlist.** `training_corpus.db` holds 531
+  players and 75,924 match rows, but 2026/27 has **zero played rows**, so it
+  would rank on the same 2025/26 form the live pipeline already uses. It is
+  15 MB and absent from `azure_blob.DB_FILES`; syncing it is non-trivial given
+  that the 17.5 MB `player_history.db` push already times out. Revisit once
+  there is real season data to rank on.
+- **Refitting the rate model.** Serving-time exclusion achieves the same result
+  for the affected players; a refit is a separate, larger piece of work.
+
+## Design
+
+### 1. Recency-gated availability
+
+`last_played_status` gains an age bound. When the most recent played match is
+older than the bound, return `None` rather than a stale status.
+
+`None` is already a first-class input: the function's own docstring records
+that the availability model "handles \[it\] by falling back to its marginal
+prior". No new path is introduced and no renormalisation is required — the
+`rate.py` caveat about a ~24% starter bias applies only to overriding
+`P(status)` directly at serving time, which this does not do.
+
+The bound is a `Settings` field so it is tunable from `.env` without a deploy.
+It must exceed a normal in-season gap (including the winter break) and fall
+below the off-season gap.
+
+Expected effect: Pavlović stops being scored off a 2026-05-16 bench appearance
+and is weighted by the league-wide prior until 2026/27 produces evidence.
+
+### 2. Top-flight quality gate
+
+`rate.predict` already falls back to `position_prior` when a `player_id` is
+absent from `quality`:
+
+```python
+multiplier = self.quality.get(player_id)
+if multiplier is None:
+    multiplier = self.position_prior.get(position or "", 1.0)
+```
+
+So the fix is a serving-time exclusion, not a refit: when a player has no
+top-flight history, do not consult his fitted quality. Detection is the absence
+of `ap`/`tp` on `player_details`, which `PlayerData.player_details` already
+carries into the scorer.
+
+This is **not** a discount multiplier. REH-80's blanket cold-start discount was
+reverted for costing 782 points and a league place; this instead declines to
+apply a coefficient fitted on inapplicable data, and lets the existing
+shrinkage-to-prior mechanism do exactly what it was built for.
+
+Data quality must stop reporting grade **A** for a player with zero top-flight
+appearances.
+
+Expected effect: Rohr's multiplier moves from 1.124 to the 0.941 defender
+prior, rate ~95 → ~80.
+
+### 3. Absolute target bar
+
+A new gate, applied alongside the existing marginal-gain threshold: a market
+player is a **target** only if his absolute expected points clear an elite bar.
+
+Two-stage, as agreed:
+
+- **absolute EP** answers *is this player worth a squad slot at all* — stable
+  week to week, independent of my squad, and the thing the bot waits for;
+- **marginal EP gain** answers *is he worth today's price, and who does he
+  displace* — unchanged from today.
+
+The bar is a `Settings` field **derived from the measured distribution**, not
+chosen. `rehoboam derive-thresholds` already reports the percentiles. It must
+not be set from a pre-season measurement: the 2026-07-31 derivation ran at
+n=0 and n is only 9 as of 2026-08-22.
+
+### 4. Availability state and holding
+
+`competitor_player_ids` (`trader.py:280`) already rebuilds the set of every
+player in every opponent's squad each session, and is currently used for
+nothing but an `uncontested` metadata flag.
+
+Wire it into a logged state each run: how many targets exist, how many are held
+by opponents, how many are listed now. When none are listed, **hold** — set the
+lineup, buy nothing, and log the reason.
+
+Holding a slot is not the same as keeping dead weight. The sell path continues
+to run, so the bot still clears players like Klaas (avg 0.0) and Maksimovic
+(avg 18) while waiting.
+
+Two exceptions, stated so the implementation cannot read "buy nothing" too
+literally:
+
+- **The emergency fieldability fill still fires.** `_emergency_slots_short`
+  (REH-82) exists to prevent the −100 empty-slot penalty and must override the
+  hold, exactly as it already overrides the matchday-locked no-trade rule. An
+  unfieldable squad is never an acceptable state to hold in.
+- **Position minimums still bind.** If holding would leave the squad unable to
+  field a legal formation at kickoff, the hold yields.
+
+## Verification
+
+**This is the first change in this sequence the replay can actually measure.**
+Per REH-84 the replay calls the real scorer, so `rehoboam replay-season` is a
+genuine gate here against the **26,960 / 26,172 / +788 / 9th of 14** baseline.
+Three PRs merged on 2026-08-21/22 (#66, #67, #68) each left that number
+untouched because none of their code paths are exercised by the replay — see
+REH-88. That excuse does not apply to this work.
+
+Tests must pin the live cases that motivated the change:
+
+- Pavlović's availability must not rest on a match played 2026-05-16.
+- Rohr must not outrank Pavlović.
+- A player absent from `quality` must use the position prior (guards the
+  existing fallback against regression).
+- The hold state must produce no buys when no target is listed, and must not
+  suppress sells.
+
+Live `--dry-run` against production before merge, per the standing rule for
+changes that reinterpret API fields.
+
+## Risks
+
+- **The bar is set too high and the bot never buys.** Mitigated by deriving it
+  from the measured distribution, making it `.env`-tunable without a deploy,
+  and logging the target-count state every run.
+- **The recency bound is set too short**, discarding usable in-season evidence
+  after a winter break or an injury layoff. Mitigated by choosing it against
+  observed gap lengths rather than intuition.
+- **Correcting promoted-club quality tanks a player who is genuinely good.**
+  This is what the replay is for; the ~16% correction is modest by design.
+- **Fixing availability lifts players who genuinely will not start.** The
+  marginal prior is a weaker claim than a confident 85%, not a stronger one, so
+  the failure mode is under- rather than over-confidence.
+
+## Open questions
+
+1. The exact recency bound, and the exact absolute bar. Both to be derived from
+   data during implementation, not chosen here.
+1. Whether the data-quality grade should be capped for no-top-flight players or
+   given a distinct grade of its own.
+1. Whether the hold state should still permit an exceptional non-target buy —
+   deferred; the simplest version holds unconditionally and can be relaxed once
+   the state is observable in the logs.

--- a/rehoboam/auto_trader.py
+++ b/rehoboam/auto_trader.py
@@ -143,6 +143,29 @@ def _emergency_slots_short(squad: list) -> int:
     return max(FormationRequirements().starting_eleven_size - len(squad), 1)
 
 
+def _target_availability(buy_recs: list, competitor_ids: set, bar: float) -> dict:
+    """How many targets exist, and where they are.
+
+    A target is a player whose ABSOLUTE expected points clear the bar —
+    "is he worth a squad slot at all" — as distinct from marginal gain, which
+    answers "is he worth today's price and who does he displace".
+
+    Split by where they sit, because the two states call for different
+    behaviour: a target that is listed can be bid on now, while one sitting in
+    an opponent's squad is a reason to keep a slot free rather than to act.
+    """
+    listed = 0
+    owned = 0
+    for rec in buy_recs:
+        if rec.score.expected_points < bar:
+            continue
+        if rec.player.id in competitor_ids:
+            owned += 1
+        else:
+            listed += 1
+    return {"listed": listed, "owned_by_opponents": owned, "bar": bar}
+
+
 @dataclass
 class EPSessionContext:
     """Single-fetch context for the entire auto session."""
@@ -338,6 +361,18 @@ class AutoTrader:
         results: list[AutoTradeResult] = []
         buy_recs = ctx.ep_result.get("buy_recs", [])
         trade_pairs = ctx.ep_result.get("trade_pairs", [])
+
+        target_state = _target_availability(
+            buy_recs,
+            ctx.ep_result.get("competitor_player_ids") or set(),
+            self.settings.target_ep_bar,
+        )
+        logger.info(
+            "target-availability listed=%d owned_by_opponents=%d bar=%.1f",
+            target_state["listed"],
+            target_state["owned_by_opponents"],
+            target_state["bar"],
+        )
 
         effective_limit = min(
             self.max_trades_per_session,

--- a/rehoboam/auto_trader.py
+++ b/rehoboam/auto_trader.py
@@ -1488,8 +1488,11 @@ class AutoTrader:
 
             # Build ep_scores from the pipeline when available; fall back to a
             # per-player v2 score only for uncovered squad members or when the
-            # caller didn't provide scores. Both sides are real points, so they
-            # are safe to rank against each other below.
+            # caller didn't provide scores. Both sides are real points AND
+            # obey the same availability recency bound (REH-85), so they are
+            # safe to rank against each other below -- a mid-session signing
+            # landing in `missing` must not get a different availability rule
+            # than everyone the pipeline already scored.
             ep_scores: dict[str, float] = {}
             if squad_scores:
                 ep_scores = {s.player_id: s.expected_points for s in squad_scores}
@@ -1539,6 +1542,13 @@ class AutoTrader:
         ordering is deliberate: a 0.0 sorts a player to the bottom of
         ``select_best_eleven``, and benching someone we simply failed to fetch is
         how an avoidable empty slot turns into -100.
+
+        Applies the same ``max_status_age_days`` recency bound (REH-85) the
+        pipeline's own ``score_player_v2`` calls use, via ``last_played_status``.
+        Without it, this path -- which only fires for the highest-stakes case,
+        a player just bought mid-session -- would keep anchoring on a stale
+        end-of-last-season status forever, even after the pipeline everywhere
+        else was fixed.
         """
         from .scoring.v2.adapter import compose_ep, last_played_status
         from .scoring.v2.coefficients import load_coefficients
@@ -1563,7 +1573,7 @@ class AutoTrader:
             availability, rate, _meta = load_coefficients()
             return compose_ep(
                 str(player.id),
-                last_played_status(perf_data),
+                last_played_status(perf_data, max_age_days=self.settings.max_status_age_days),
                 player.position,
                 availability,
                 rate,

--- a/rehoboam/config.py
+++ b/rehoboam/config.py
@@ -194,6 +194,18 @@ class Settings(BaseSettings):
             "this gets harder to clear as the season goes well."
         ),
     )
+    target_ep_bar: float = Field(
+        default=0.0,
+        description=(
+            "Absolute expected points a market player must reach to count as a "
+            "target worth a squad slot, independent of marginal gain against the "
+            "current squad. 0.0 disables the bar and preserves pre-2026-08-22 "
+            "behaviour. Derive this from the measured marginal-gain and EP "
+            "distributions via `rehoboam derive-thresholds` once the market has "
+            "repopulated — it reported n=0 on 2026-07-31 and n=9 on 2026-08-22, "
+            "neither of which is enough to set it from."
+        ),
+    )
 
     max_status_age_days: float = Field(
         default=60.0,

--- a/rehoboam/config.py
+++ b/rehoboam/config.py
@@ -195,6 +195,19 @@ class Settings(BaseSettings):
         ),
     )
 
+    max_status_age_days: float = Field(
+        default=60.0,
+        description=(
+            "Discard a player's last-played availability status when it is older "
+            "than this many days, falling back to the availability model's "
+            "marginal prior. Must exceed the longest in-season gap (the winter "
+            "break, roughly 30 days) and fall below the off-season gap (roughly "
+            "90). Without it, the final matchday of the previous season drives "
+            "availability for the whole of the next: on 2026-08-22 Pavlovic was "
+            "scored P(start)=17% off an unused-sub appearance played 2026-05-16."
+        ),
+    )
+
     min_days_to_match_for_starter_swap: int = Field(
         default=3,
         description=(

--- a/rehoboam/replay/driver.py
+++ b/rehoboam/replay/driver.py
@@ -32,8 +32,6 @@ MANAGER_ID = "3616202"
 ASSIGNED_ON = 1754661947.0  # 2025-08-08T14:05:47Z, verified from /v4/leagues/{id}/overview
 STARTING_BUDGET = 80_000_000
 
-PLAYED_STATUSES = (1, 3, 4, 5)
-
 
 def _parse(dt: str) -> float:
     return datetime.strptime(dt, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc).timestamp()

--- a/rehoboam/replay/driver.py
+++ b/rehoboam/replay/driver.py
@@ -23,7 +23,7 @@ from rehoboam.replay.engine import (
 )
 from rehoboam.replay.market import ReplayMarket
 from rehoboam.replay.state import initial_state
-from rehoboam.scoring.v2.adapter import compose_ep
+from rehoboam.scoring.v2.adapter import compose_ep, prev_status_from_history
 from rehoboam.scoring.v2.coefficients import load_coefficients
 
 SEASON = "2025/2026"
@@ -143,11 +143,12 @@ def _make_score_fn(
         history = matches_before(
             corpus.matches_for_player(player_id), season=season, day_number=day
         )
-        prev_status = None
-        for match in reversed(history):
-            if match.get("status") in PLAYED_STATUSES:
-                prev_status = int(match["status"])
-                break
+        # REH-84's rule applies to this traversal too, not just to `compose_ep`:
+        # deriving "most recent played status" here separately is a second
+        # implementation that would drift from the live scorer.
+        prev_status = prev_status_from_history(
+            [(m.get("match_date"), m.get("status")) for m in history]
+        )
         if player_id not in positions:
             positions.update(corpus.positions_for([player_id]))
         position = positions.get(player_id)

--- a/rehoboam/replay/driver.py
+++ b/rehoboam/replay/driver.py
@@ -147,7 +147,9 @@ def _make_score_fn(
         # deriving "most recent played status" here separately is a second
         # implementation that would drift from the live scorer.
         prev_status = prev_status_from_history(
-            [(m.get("match_date"), m.get("status")) for m in history]
+            [(m.get("match_date"), m.get("status")) for m in history],
+            now=datetime.fromtimestamp(at, tz=timezone.utc),
+            max_age_days=_shipped_default("max_status_age_days"),
         )
         if player_id not in positions:
             positions.update(corpus.positions_for([player_id]))

--- a/rehoboam/replay/flip_buys.py
+++ b/rehoboam/replay/flip_buys.py
@@ -65,9 +65,9 @@ def history_at(corpus: TrainingCorpus, player_id: str, at: float) -> dict:
 
 
 # Statuses in which the player actually took the pitch: 3 = came on as a sub,
-# 5 = started. Deliberately NARROWER than `driver.PLAYED_STATUSES`, which is
-# (1, 3, 4, 5) because the availability model needs a fitted rate for every
-# state including "not in squad". Kickbase's own average points is per
+# 5 = started. Deliberately NARROWER than `scoring.v2.features.PLAYED_STATUSES`,
+# which is (1, 3, 4, 5) because the availability model needs a fitted rate for
+# every state including "not in squad". Kickbase's own average points is per
 # APPEARANCE, so counting non-appearances here would understate every player.
 APPEARANCE_STATUSES = (3, 5)
 

--- a/rehoboam/scoring/decision.py
+++ b/rehoboam/scoring/decision.py
@@ -299,6 +299,16 @@ class DecisionEngine:
         else:
             best_11_ids = set()
 
+        # Skip-reason tally for the INFO summary below — distinguishes "the bot
+        # correctly declined to buy anything" from "the pipeline is broken"
+        # without needing DEBUG. Counted, not restructured: each counter sits
+        # next to the `continue` it already accompanied.
+        skip_ep_floor = 0
+        skip_target_bar = 0
+        skip_lineup_prob = 0
+        skip_declining_minutes = 0
+        skip_marginal_gain = 0
+
         recs: list[BuyRecommendation] = []
         for ps in market_scores:
             player = market_players.get(ps.player_id)
@@ -308,6 +318,7 @@ class DecisionEngine:
             # Filter by minimum EP threshold
             min_ep = 10.0 if is_emergency else self.min_ep_to_buy
             if ps.expected_points < min_ep:
+                skip_ep_floor += 1
                 logger.debug(
                     "buy-skip %s: EP %.1f < min %.1f",
                     player.last_name,
@@ -320,6 +331,7 @@ class DecisionEngine:
             # emergency: an unfieldable squad needs bodies, and -100 for an
             # empty slot dwarfs the cost of a mediocre signing.
             if not is_emergency and ps.expected_points < self.target_ep_bar:
+                skip_target_bar += 1
                 logger.debug(
                     "buy-skip %s: EP %.1f below target bar %.1f — holding the slot",
                     player.last_name,
@@ -333,6 +345,7 @@ class DecisionEngine:
                 ps.lineup_probability is not None
                 and ps.lineup_probability > MAX_LINEUP_PROB_FOR_BUY
             ):
+                skip_lineup_prob += 1
                 logger.debug(
                     "buy-skip %s: lineup_probability=%s > %s (unlikely starter)",
                     player.last_name,
@@ -343,6 +356,7 @@ class DecisionEngine:
 
             # Hard-block players with severely declining minutes
             if ps.minutes_trend == "decreasing" and ps.minutes_bonus <= -15.0:
+                skip_declining_minutes += 1
                 logger.debug(
                     "buy-skip %s: minutes_trend=decreasing, bonus=%.1f",
                     player.last_name,
@@ -427,6 +441,7 @@ class DecisionEngine:
 
             # Only recommend if marginal gain meets threshold (or emergency)
             if not is_emergency and marginal < self.min_ep_upgrade and roster_impact != "fills_gap":
+                skip_marginal_gain += 1
                 logger.debug(
                     "buy-skip %s: marginal %.1f < threshold %.1f and not gap-fill",
                     player.last_name,
@@ -535,7 +550,9 @@ class DecisionEngine:
         top = final_recs[:top_n]
         logger.info(
             "recommend_buys: %d candidates considered, %d viable, returning top %d "
-            "(emergency=%s, budget=%d, min_ep=%.1f, min_upgrade=%.1f)",
+            "(emergency=%s, budget=%d, min_ep=%.1f, min_upgrade=%.1f) | "
+            "skipped: ep_floor=%d target_bar=%d lineup_prob=%d declining_minutes=%d "
+            "marginal_gain=%d",
             len(market_scores),
             len(final_recs),
             len(top),
@@ -543,6 +560,11 @@ class DecisionEngine:
             int(budget),
             self.min_ep_to_buy,
             self.min_ep_upgrade,
+            skip_ep_floor,
+            skip_target_bar,
+            skip_lineup_prob,
+            skip_declining_minutes,
+            skip_marginal_gain,
         )
         for rec in top:
             logger.info(

--- a/rehoboam/scoring/decision.py
+++ b/rehoboam/scoring/decision.py
@@ -30,11 +30,19 @@ class DecisionEngine:
     Args:
         min_ep_to_buy:  Minimum expected points for a player to be worth buying.
         min_ep_upgrade: Minimum marginal EP gain required to recommend a buy.
+        target_ep_bar:  Absolute EP a player must clear to count as a target
+            worth a squad slot, independent of marginal gain. 0.0 disables it.
     """
 
-    def __init__(self, min_ep_to_buy: float = 35.0, min_ep_upgrade: float = 40.0) -> None:
+    def __init__(
+        self,
+        min_ep_to_buy: float = 35.0,
+        min_ep_upgrade: float = 40.0,
+        target_ep_bar: float = 0.0,
+    ) -> None:
         self.min_ep_to_buy = min_ep_to_buy
         self.min_ep_upgrade = min_ep_upgrade
+        self.target_ep_bar = target_ep_bar
 
     # ------------------------------------------------------------------
     # Public helpers
@@ -305,6 +313,18 @@ class DecisionEngine:
                     player.last_name,
                     ps.expected_points,
                     min_ep,
+                )
+                continue
+
+            # The bar is a "worth a squad slot at all" test, so it yields in an
+            # emergency: an unfieldable squad needs bodies, and -100 for an
+            # empty slot dwarfs the cost of a mediocre signing.
+            if not is_emergency and ps.expected_points < self.target_ep_bar:
+                logger.debug(
+                    "buy-skip %s: EP %.1f below target bar %.1f — holding the slot",
+                    player.last_name,
+                    ps.expected_points,
+                    self.target_ep_bar,
                 )
                 continue
 

--- a/rehoboam/scoring/v2/adapter.py
+++ b/rehoboam/scoring/v2/adapter.py
@@ -134,9 +134,18 @@ def has_top_flight_history(player_details: dict | None) -> bool:
     Mainz backup keeper. The keeper is why the signal is "no top-flight
     history" rather than "promoted club": it is broader, and it needs no
     annually-maintained list of who came up.
+
+    ``player_details=None`` means "unknown", not "no top-flight history" —
+    it is the shape of a transient lookup failure (rate limit, timeout;
+    see ``Trader._fetch_player_data``), which can hit any player including
+    established regulars. This fails OPEN on that case: ``None`` returns
+    True, so the caller keeps the fitted quality coefficient instead of
+    withholding it on a data hiccup. Only a *present* ``player_details``
+    that actually lacks ``ap``/``tp`` (the real Elversberg case) returns
+    False.
     """
-    if not player_details:
-        return False
+    if player_details is None:
+        return True
     return bool(player_details.get("ap") or player_details.get("tp"))
 
 

--- a/rehoboam/scoring/v2/adapter.py
+++ b/rehoboam/scoring/v2/adapter.py
@@ -125,8 +125,23 @@ def last_played_status(
     )
 
 
+def has_top_flight_history(player_details: dict | None) -> bool:
+    """Has this player ever recorded Bundesliga scoring?
+
+    Kickbase omits ``ap``/``tp`` entirely for players with no top-flight
+    appearances. On 2026-08-22 that was true of seven of 22 buyable listings —
+    six from newly promoted clubs (Elversberg, Schalke, Paderborn) and one
+    Mainz backup keeper. The keeper is why the signal is "no top-flight
+    history" rather than "promoted club": it is broader, and it needs no
+    annually-maintained list of who came up.
+    """
+    if not player_details:
+        return False
+    return bool(player_details.get("ap") or player_details.get("tp"))
+
+
 def compose_ep(
-    player_id: str,
+    player_id: str | None,
     prev_status: int | None,
     position: str | None,
     availability: AvailabilityModel,
@@ -144,7 +159,16 @@ def score_player_v2(data: PlayerData, *, max_status_age_days: float | None = Non
     position = player.position or None
 
     prev_status = last_played_status(data.performance, max_age_days=max_status_age_days)
-    ep = compose_ep(player.id, prev_status, position, availability, rate)
+
+    # Withhold the fitted quality coefficient from players whose fitted record
+    # is not top-flight: `rate.predict` then falls back to the position prior,
+    # which is exactly the cold-start path an unfitted player already takes.
+    # This is NOT a discount multiplier — REH-80's blanket cold-start discount
+    # was reverted for costing 782 points. It declines to apply a coefficient
+    # fitted on inapplicable data.
+    quality_key = player.id if has_top_flight_history(data.player_details) else None
+
+    ep = compose_ep(quality_key, prev_status, position, availability, rate)
 
     dgw_multiplier = DGW_MULTIPLIER if data.is_dgw else 1.0
     ep *= dgw_multiplier
@@ -153,9 +177,9 @@ def score_player_v2(data: PlayerData, *, max_status_age_days: float | None = Non
     notes = [
         f"v2: availability P(start)={probs[5]:.0%} "
         f"(prev status {prev_status if prev_status is not None else 'unknown'}), "
-        f"rate={rate.predict(player.id, 5, position):.0f} pts if started"
+        f"rate={rate.predict(quality_key, 5, position):.0f} pts if started"
     ]
-    if player.id not in rate.quality:
+    if quality_key not in rate.quality:
         notes.append("No fitted quality — using position prior (cold start)")
     if data.is_dgw:
         notes.append("DOUBLE GAMEWEEK ×1.8")
@@ -164,7 +188,7 @@ def score_player_v2(data: PlayerData, *, max_status_age_days: float | None = Non
         player_id=player.id,
         expected_points=round(ep, 2),
         data_quality=DataQuality(
-            grade="A" if player.id in rate.quality else "C",
+            grade="A" if quality_key in rate.quality else "C",
             games_played=0,
             consistency=0.0,
             has_fixture_data=False,

--- a/rehoboam/scoring/v2/adapter.py
+++ b/rehoboam/scoring/v2/adapter.py
@@ -28,6 +28,7 @@ ticket notes before adding overrides.
 from __future__ import annotations
 
 from collections.abc import Sequence
+from datetime import datetime, timezone
 from functools import lru_cache
 
 from rehoboam.scoring.models import DataQuality, PlayerData, PlayerScore
@@ -47,6 +48,9 @@ def _models() -> tuple[AvailabilityModel, RateModel, dict]:
 
 def prev_status_from_history(
     history: Sequence[tuple[str | None, int | None]],
+    *,
+    now: datetime | None = None,
+    max_age_days: float | None = None,
 ) -> int | None:
     """Most recent *played* status from ``(match_date, status)`` pairs.
 
@@ -54,18 +58,51 @@ def prev_status_from_history(
     describe a match that has not happened, not a state the player was in, so
     they are skipped.
 
+    When ``max_age_days`` is set, a status older than that is discarded and
+    None is returned instead. The availability model treats None as "no
+    evidence" and falls back to its marginal prior, which is a weaker claim
+    than a stale transition rather than a stronger one.
+
+    Why this matters: without a bound, the last matchday of the previous season
+    drives availability for the whole of the next one. End-of-season status is
+    a bad prior -- squads rotate through dead rubbers -- and it persists for the
+    entire off-season.
+
+    A date that is missing or unparseable is treated as stale. This guard
+    exists for the case we cannot see, so it fails closed.
+
     This is the single implementation of that rule. The live scorer and the
-    season replay both call it. They previously derived it separately, which is
-    the drift `scoring/v2/thresholds.py` forbids and REH-84 records the cost of.
+    season replay both call it.
     """
     latest: int | None = None
-    for _match_date, status in history:
-        if status in PLAYED_STATUSES:
-            latest = int(status)
+    for match_date, status in history:
+        if status not in PLAYED_STATUSES:
+            continue
+        if max_age_days is not None:
+            parsed = _parse_iso(match_date)
+            reference = now or datetime.now(tz=timezone.utc)
+            if parsed is None or (reference - parsed).total_seconds() > max_age_days * 86400:
+                continue
+        latest = int(status)
     return latest
 
 
-def last_played_status(performance: dict | None) -> int | None:
+def _parse_iso(value: str | None) -> datetime | None:
+    """Parse a Kickbase ISO match date, or None if it cannot be read."""
+    if not value or not isinstance(value, str):
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def last_played_status(
+    performance: dict | None,
+    *,
+    now: datetime | None = None,
+    max_age_days: float | None = None,
+) -> int | None:
     """The player's status in his most recent *played* match.
 
     Returns None when there is no played history, which the availability model
@@ -83,7 +120,9 @@ def last_played_status(performance: dict | None) -> int | None:
                 continue
             ordered.append(((title, int(day)), match.get("md"), match.get("st")))
     ordered.sort(key=lambda row: row[0])
-    return prev_status_from_history([(md, st) for _key, md, st in ordered])
+    return prev_status_from_history(
+        [(md, st) for _key, md, st in ordered], now=now, max_age_days=max_age_days
+    )
 
 
 def compose_ep(
@@ -98,13 +137,13 @@ def compose_ep(
     return sum(probs[s] * rate.predict(player_id, s, position) for s in PLAYED_STATUSES)
 
 
-def score_player_v2(data: PlayerData) -> PlayerScore:
+def score_player_v2(data: PlayerData, *, max_status_age_days: float | None = None) -> PlayerScore:
     """Score a player with the fitted v2 models. Pure — no I/O beyond cached load."""
     availability, rate, _meta = _models()
     player = data.player
     position = player.position or None
 
-    prev_status = last_played_status(data.performance)
+    prev_status = last_played_status(data.performance, max_age_days=max_status_age_days)
     ep = compose_ep(player.id, prev_status, position, availability, rate)
 
     dgw_multiplier = DGW_MULTIPLIER if data.is_dgw else 1.0

--- a/rehoboam/scoring/v2/adapter.py
+++ b/rehoboam/scoring/v2/adapter.py
@@ -27,6 +27,7 @@ ticket notes before adding overrides.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from functools import lru_cache
 
 from rehoboam.scoring.models import DataQuality, PlayerData, PlayerScore
@@ -44,30 +45,45 @@ def _models() -> tuple[AvailabilityModel, RateModel, dict]:
     return load_coefficients()
 
 
+def prev_status_from_history(
+    history: Sequence[tuple[str | None, int | None]],
+) -> int | None:
+    """Most recent *played* status from ``(match_date, status)`` pairs.
+
+    Input is ordered oldest-first. Unplayed fixtures (status 0 or absent)
+    describe a match that has not happened, not a state the player was in, so
+    they are skipped.
+
+    This is the single implementation of that rule. The live scorer and the
+    season replay both call it. They previously derived it separately, which is
+    the drift `scoring/v2/thresholds.py` forbids and REH-84 records the cost of.
+    """
+    latest: int | None = None
+    for _match_date, status in history:
+        if status in PLAYED_STATUSES:
+            latest = int(status)
+    return latest
+
+
 def last_played_status(performance: dict | None) -> int | None:
     """The player's status in his most recent *played* match.
 
-    Unplayed fixtures (status 0 or absent) are skipped — they describe a match
-    that has not happened, not a state the player was in. Returns None when
-    there is no played history, which the availability model handles by falling
-    back to its marginal prior.
+    Returns None when there is no played history, which the availability model
+    handles by falling back to its marginal prior.
     """
     if not performance:
         return None
 
-    latest: tuple[str, int] | None = None
-    latest_status: int | None = None
+    ordered: list[tuple[tuple[str, int], str | None, int | None]] = []
     for season in performance.get("it") or []:
         title = season.get("ti") or ""
         for match in season.get("ph") or []:
-            status = match.get("st")
             day = match.get("day")
-            if status not in PLAYED_STATUSES or day is None:
+            if day is None:
                 continue
-            key = (title, int(day))
-            if latest is None or key > latest:
-                latest, latest_status = key, int(status)
-    return latest_status
+            ordered.append(((title, int(day)), match.get("md"), match.get("st")))
+    ordered.sort(key=lambda row: row[0])
+    return prev_status_from_history([(md, st) for _key, md, st in ordered])
 
 
 def compose_ep(

--- a/rehoboam/scoring/v2/rate.py
+++ b/rehoboam/scoring/v2/rate.py
@@ -58,7 +58,7 @@ class RateModel:
     position_prior: dict[str, float]
     shrinkage_k: float
 
-    def predict(self, player_id: str, status: int, position: str | None) -> float:
+    def predict(self, player_id: str | None, status: int, position: str | None) -> float:
         """Expected points for this player in this availability state.
 
         NOT a calibrated within-status expectation. ``quality`` is normalised

--- a/rehoboam/trader.py
+++ b/rehoboam/trader.py
@@ -456,7 +456,9 @@ class Trader:
                     player_details=details,
                     team_profiles=team_profiles,
                 )
-                market_scores.append(score_player_v2(data))
+                market_scores.append(
+                    score_player_v2(data, max_status_age_days=self.settings.max_status_age_days)
+                )
                 market_player_map[player.id] = player
 
                 try:
@@ -493,7 +495,9 @@ class Trader:
                     player_details=details,
                     team_profiles=team_profiles,
                 )
-                squad_scores.append(score_player_v2(data))
+                squad_scores.append(
+                    score_player_v2(data, max_status_age_days=self.settings.max_status_age_days)
+                )
                 squad_player_map[player.id] = player
 
                 try:

--- a/rehoboam/trader.py
+++ b/rehoboam/trader.py
@@ -540,6 +540,7 @@ class Trader:
             # both gates for any caller whose Settings lacks the fields.
             min_ep_to_buy=getattr(self.settings, "min_expected_points_to_buy", 35.0),
             min_ep_upgrade=getattr(self.settings, "min_ep_upgrade_threshold", 40.0),
+            target_ep_bar=getattr(self.settings, "target_ep_bar", 0.0),
         )
 
         # Always compute both buy recs and trade pairs so the unified trade

--- a/tests/test_auto_trader_flip_switches.py
+++ b/tests/test_auto_trader_flip_switches.py
@@ -178,6 +178,7 @@ class TestFlipBuyBlockGate:
             marginal_ep_gain=10.0,
             reason="test upgrade",
             sell_plan=None,
+            score=SimpleNamespace(expected_points=50.0),
         )
         phase = MatchdayPhase(
             days_until_match=5,

--- a/tests/test_decline_recording_wiring.py
+++ b/tests/test_decline_recording_wiring.py
@@ -51,6 +51,7 @@ def _rec(pid: str, bid, gain: float, reason: str):
         marginal_ep_gain=gain,
         reason=reason,
         sell_plan=None,
+        score=SimpleNamespace(expected_points=gain),
     )
 
 

--- a/tests/test_fallback_ep_recency.py
+++ b/tests/test_fallback_ep_recency.py
@@ -1,0 +1,85 @@
+"""REH-85 fix round 1: the lineup fallback path must obey the same
+availability recency bound as the pipeline's own ``score_player_v2`` calls.
+
+``AutoTrader._fallback_expected_points`` only fires for a mid-session
+purchase (or an upstream pipeline failure) -- the highest-stakes case, since
+a player who lands here just got bought for real money. Its result is merged
+into the same ``ep_scores`` dict the pipeline's bounded scores populate and
+ranked together by ``select_best_eleven``. If this path ignores
+``max_status_age_days`` while the pipeline honours it, a freshly bought
+player can still be scored off a stale end-of-last-season status and get
+benched despite the bug being "fixed" everywhere else.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from rehoboam.auto_trader import AutoTrader
+from rehoboam.config import Settings
+from rehoboam.scoring.v2.adapter import compose_ep
+from rehoboam.scoring.v2.coefficients import load_coefficients
+
+# Three months before any plausible test run date -- well past even a
+# generous max_status_age_days, so this fixture doesn't rot with the clock.
+STALE_MATCH_DATE = "2024-01-01T12:00:00Z"
+STALE_STATUS = 5  # started -- the strongest possible signal, chosen so an
+# unbounded read and a bounded read disagree as loudly as possible.
+
+
+def _perf(match_date: str, status: int) -> dict:
+    return {
+        "it": [
+            {
+                "ti": "2023/2024",
+                "ph": [{"day": 1, "md": match_date, "st": status}],
+            }
+        ]
+    }
+
+
+@pytest.fixture
+def settings(monkeypatch) -> Settings:
+    monkeypatch.setenv("KICKBASE_EMAIL", "test@example.com")
+    monkeypatch.setenv("KICKBASE_PASSWORD", "test")
+    return Settings()
+
+
+@pytest.fixture
+def trader(tmp_path, settings, monkeypatch) -> AutoTrader:
+    monkeypatch.chdir(tmp_path)  # ValueHistoryCache writes to ./logs -- isolate it
+    api = MagicMock()
+    api.client.get_player_performance.return_value = _perf(STALE_MATCH_DATE, STALE_STATUS)
+    return AutoTrader(api=api, settings=settings, dry_run=True)
+
+
+def test_fallback_ep_discards_stale_status(trader):
+    """Pins the REH-85 fix: without max_age_days threaded through, this
+    method returns the same value ``compose_ep`` would give for the stale
+    STALE_STATUS -- which is what this test would observe if the kwarg
+    threading regressed.
+    """
+    league = SimpleNamespace(id="1933872")
+    player = SimpleNamespace(id="6080", position="Midfielder")
+
+    assert trader.settings.max_status_age_days == 60.0, (
+        "fixture assumes the shipped default; update STALE_MATCH_DATE's margin " "if this changes"
+    )
+
+    result = trader._fallback_expected_points(league, player)
+
+    availability, rate, _meta = load_coefficients()
+    bounded_expected = compose_ep(str(player.id), None, player.position, availability, rate)
+    unbounded_regression = compose_ep(
+        str(player.id), STALE_STATUS, player.position, availability, rate
+    )
+
+    # The two must differ, or this test can't tell a fixed path from a
+    # regressed one.
+    assert bounded_expected != unbounded_regression
+
+    assert result == bounded_expected
+    assert result != unbounded_regression

--- a/tests/test_replay/test_scorer_parity.py
+++ b/tests/test_replay/test_scorer_parity.py
@@ -14,6 +14,7 @@ for every scorer bug ever shipped.
 from __future__ import annotations
 
 import sqlite3
+from datetime import datetime, timezone
 
 from rehoboam.enrichment.corpus import TrainingCorpus
 from rehoboam.replay.driver import SEASON, _make_score_fn
@@ -25,14 +26,21 @@ UNFITTED = "no-such-player-in-coefficients"
 DAY0 = 1_700_000_000.0
 
 
+def _iso(epoch: float) -> str:
+    return datetime.fromtimestamp(epoch, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
 def _corpus(tmp_path) -> TrainingCorpus:
     corpus = TrainingCorpus(tmp_path / "corpus.db")
+    # match_date must be within `max_status_age_days` of the decision instant
+    # (kickoffs[3]) or REH-85's recency bound discards these rows as stale.
+    kickoffs = {1: DAY0, 2: DAY0 + 7 * 86400, 3: DAY0 + 14 * 86400}
     with sqlite3.connect(corpus.db_path) as conn:
         conn.executemany(
             "INSERT OR REPLACE INTO player_match_history "
-            "(player_id, season, day_number, points, minutes, is_home, status) "
-            "VALUES (?, ?, ?, ?, 90, 1, ?)",
-            [(UNFITTED, SEASON, day, 60, 5) for day in (1, 2)],
+            "(player_id, season, day_number, match_date, points, minutes, is_home, status) "
+            "VALUES (?, ?, ?, ?, ?, 90, 1, ?)",
+            [(UNFITTED, SEASON, day, _iso(kickoffs[day]), 60, 5) for day in (1, 2)],
         )
         conn.commit()
     return corpus
@@ -62,16 +70,16 @@ def test_the_replay_scores_a_fitted_player_exactly_as_the_live_bot_does(tmp_path
     fitted = next(iter(rate.quality))
 
     corpus = TrainingCorpus(tmp_path / "corpus.db")
+    kickoffs = {1: DAY0, 2: DAY0 + 7 * 86400, 3: DAY0 + 14 * 86400}
     with sqlite3.connect(corpus.db_path) as conn:
         conn.executemany(
             "INSERT OR REPLACE INTO player_match_history "
-            "(player_id, season, day_number, points, minutes, is_home, status) "
-            "VALUES (?, ?, ?, ?, 90, 1, ?)",
-            [(fitted, SEASON, day, 60, 5) for day in (1, 2)],
+            "(player_id, season, day_number, match_date, points, minutes, is_home, status) "
+            "VALUES (?, ?, ?, ?, ?, 90, 1, ?)",
+            [(fitted, SEASON, day, _iso(kickoffs[day]), 60, 5) for day in (1, 2)],
         )
         conn.commit()
 
-    kickoffs = {1: DAY0, 2: DAY0 + 7 * 86400, 3: DAY0 + 14 * 86400}
     score = _make_score_fn(corpus, SEASON, kickoffs)
 
     position = corpus.positions_for([fitted]).get(fitted)

--- a/tests/test_scoring/test_target_bar.py
+++ b/tests/test_scoring/test_target_bar.py
@@ -1,0 +1,44 @@
+"""The absolute target bar (2026-08-22 design).
+
+Marginal gain answers "is he worth today's price and who does he displace".
+It cannot answer "is this player worth a squad slot at all", because a large
+marginal gain against a weak squad still describes a mediocre player. The bar
+is that second, absolute question.
+"""
+
+from rehoboam.scoring.decision import DecisionEngine
+from tests.test_scoring.test_trade_pairs import _make_player, _make_score, _squad
+
+
+def _engine(bar):
+    return DecisionEngine(min_ep_to_buy=35.0, min_ep_upgrade=40.0, target_ep_bar=bar)
+
+
+def _recommend(engine, ep, *, is_emergency=False):
+    squad_players, squad_scores = _squad()
+    cand = _make_player("cand", "Midfielder", price=5_000_000)
+    return engine.recommend_buys(
+        market_scores=[_make_score("cand", ep, "Midfielder", price=5_000_000)],
+        squad_scores=squad_scores,
+        roster_context={},
+        budget=80_000_000,
+        market_players={"cand": cand},
+        squad_players=squad_players,
+        is_emergency=is_emergency,
+    )
+
+
+class TestTargetBar:
+    def test_player_below_the_bar_is_not_recommended(self):
+        """Large marginal gain against a weak squad is still a mediocre player."""
+        assert _recommend(_engine(100.0), 70.0) == []
+
+    def test_player_above_the_bar_is_recommended(self):
+        assert len(_recommend(_engine(100.0), 120.0)) == 1
+
+    def test_zero_bar_preserves_existing_behaviour(self):
+        assert len(_recommend(_engine(0.0), 70.0)) == 1
+
+    def test_the_bar_yields_in_an_emergency(self):
+        """-100 for an empty slot dwarfs the cost of a mediocre signing."""
+        assert len(_recommend(_engine(100.0), 70.0, is_emergency=True)) == 1

--- a/tests/test_scoring_v2/test_adapter.py
+++ b/tests/test_scoring_v2/test_adapter.py
@@ -9,6 +9,7 @@ from rehoboam.scoring.models import PlayerData
 from rehoboam.scoring.v2.adapter import (
     compose_ep,
     last_played_status,
+    prev_status_from_history,
     score_player_v2,
 )
 from rehoboam.scoring.v2.availability import fit_availability
@@ -58,6 +59,29 @@ def _row(pid: str, prev: int | None, status: int, points: int) -> FeatureRow:
         target_status=status,
         target_points=points,
     )
+
+
+class TestPrevStatusFromHistory:
+    def test_returns_the_latest_played_status(self):
+        history = [
+            ("2026-05-01T13:30:00Z", 5),
+            ("2026-05-09T16:30:00Z", 4),
+        ]
+        assert prev_status_from_history(history) == 4
+
+    def test_skips_unplayed_fixtures(self):
+        history = [
+            ("2026-05-01T13:30:00Z", 5),
+            ("2026-08-29T13:30:00Z", 0),
+            ("2026-09-05T13:30:00Z", None),
+        ]
+        assert prev_status_from_history(history) == 5
+
+    def test_no_played_history_returns_none(self):
+        assert prev_status_from_history([("2026-08-29T13:30:00Z", 0)]) is None
+
+    def test_empty_history_returns_none(self):
+        assert prev_status_from_history([]) is None
 
 
 def test_last_played_status_reads_the_most_recent_played_match():

--- a/tests/test_scoring_v2/test_adapter.py
+++ b/tests/test_scoring_v2/test_adapter.py
@@ -224,8 +224,10 @@ class TestTopFlightHistory:
     def test_zero_ap_means_no_top_flight_history(self):
         assert has_top_flight_history({"ap": 0, "tp": 0}) is False
 
-    def test_missing_details_is_not_a_claim_of_history(self):
-        assert has_top_flight_history(None) is False
+    def test_missing_details_fails_open(self):
+        """None means "unknown", not "no top-flight history" — a transient
+        get_player_details failure must not withhold a fitted quality coefficient."""
+        assert has_top_flight_history(None) is True
 
 
 class TestNonTopFlightUsesPositionPrior:
@@ -260,3 +262,37 @@ class TestNonTopFlightUsesPositionPrior:
         assert scored_without.expected_points < scored_with.expected_points
         assert scored_without.data_quality.grade != "A"
         assert any("position prior" in n for n in scored_without.notes)
+
+    def test_missing_player_details_keeps_fitted_quality(self):
+        """The transient-lookup-failure case (REH fail-open fix): a player who IS
+        in the fitted quality table, scored with player_details=None (e.g. a
+        get_player_details HTTP blip mid-session — see Trader._fetch_player_data),
+        must keep his fitted quality — same EP as when details are present —
+        not fall to the position prior. Fails without the fail-open fix."""
+        player = _player("3284")  # Rohr, present in the fitted quality table
+        matches = [
+            {"day": d, "st": 5, "p": 100, "md": "2026-05-16T13:30:00Z"} for d in range(1, 35)
+        ]
+        with_history = PlayerData(
+            player=player,
+            performance=_perf(matches),
+            player_details={"ap": 74, "tp": 1251},
+            team_strength=None,
+            opponent_strength=None,
+            is_dgw=False,
+        )
+        unknown_details = PlayerData(
+            player=player,
+            performance=_perf(matches),
+            player_details=None,
+            team_strength=None,
+            opponent_strength=None,
+            is_dgw=False,
+        )
+
+        scored_with = score_player_v2(with_history)
+        scored_unknown = score_player_v2(unknown_details)
+
+        assert scored_unknown.expected_points == scored_with.expected_points
+        assert scored_unknown.data_quality.grade == "A"
+        assert not any("position prior" in n for n in scored_unknown.notes)

--- a/tests/test_scoring_v2/test_adapter.py
+++ b/tests/test_scoring_v2/test_adapter.py
@@ -10,6 +10,7 @@ from rehoboam.kickbase_client import MarketPlayer
 from rehoboam.scoring.models import PlayerData
 from rehoboam.scoring.v2.adapter import (
     compose_ep,
+    has_top_flight_history,
     last_played_status,
     prev_status_from_history,
     score_player_v2,
@@ -210,3 +211,52 @@ class TestPrevStatusRecency:
     def test_missing_date_is_treated_as_stale(self):
         now = datetime(2026, 8, 22, tzinfo=timezone.utc)
         assert prev_status_from_history([(None, 5)], now=now, max_age_days=60.0) is None
+
+
+class TestTopFlightHistory:
+    def test_player_with_average_points_has_top_flight_history(self):
+        assert has_top_flight_history({"ap": 119, "tp": 2844}) is True
+
+    def test_missing_ap_means_no_top_flight_history(self):
+        """The live Elversberg case: full 2. Bundesliga record, no `ap` field."""
+        assert has_top_flight_history({"fn": "Maximilian", "ln": "Rohr"}) is False
+
+    def test_zero_ap_means_no_top_flight_history(self):
+        assert has_top_flight_history({"ap": 0, "tp": 0}) is False
+
+    def test_missing_details_is_not_a_claim_of_history(self):
+        assert has_top_flight_history(None) is False
+
+
+class TestNonTopFlightUsesPositionPrior:
+    def test_fitted_quality_is_withheld_without_top_flight_history(self):
+        """A 2. Bundesliga record must not buy a confident Bundesliga rate."""
+        from rehoboam.scoring.models import PlayerData
+
+        player = _player("3284")  # Rohr, present in the fitted quality table
+        matches = [
+            {"day": d, "st": 5, "p": 100, "md": "2026-05-16T13:30:00Z"} for d in range(1, 35)
+        ]
+        with_history = PlayerData(
+            player=player,
+            performance=_perf(matches),
+            player_details={"ap": 74, "tp": 1251},
+            team_strength=None,
+            opponent_strength=None,
+            is_dgw=False,
+        )
+        without_history = PlayerData(
+            player=player,
+            performance=_perf(matches),
+            player_details={"fn": "Maximilian", "ln": "Rohr"},
+            team_strength=None,
+            opponent_strength=None,
+            is_dgw=False,
+        )
+
+        scored_with = score_player_v2(with_history)
+        scored_without = score_player_v2(without_history)
+
+        assert scored_without.expected_points < scored_with.expected_points
+        assert scored_without.data_quality.grade != "A"
+        assert any("position prior" in n for n in scored_without.notes)

--- a/tests/test_scoring_v2/test_adapter.py
+++ b/tests/test_scoring_v2/test_adapter.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
+
 import pytest
 
 from rehoboam.kickbase_client import MarketPlayer
@@ -177,3 +179,34 @@ def test_dgw_multiplies_the_composed_score():
     doubled = score_player_v2(dgw_data)
     assert doubled.expected_points > single.expected_points
     assert doubled.is_dgw is True
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class TestPrevStatusRecency:
+    def test_stale_status_is_discarded(self):
+        """The live Pavlovic case: an unused-sub appearance from 3 months ago."""
+        now = datetime(2026, 8, 22, tzinfo=timezone.utc)
+        history = [("2026-05-16T13:30:00Z", 4)]
+        assert prev_status_from_history(history, now=now, max_age_days=60.0) is None
+
+    def test_recent_status_is_kept(self):
+        now = datetime(2026, 8, 22, tzinfo=timezone.utc)
+        history = [(_iso(now - timedelta(days=7)), 4)]
+        assert prev_status_from_history(history, now=now, max_age_days=60.0) == 4
+
+    def test_no_bound_keeps_current_behaviour(self):
+        now = datetime(2026, 8, 22, tzinfo=timezone.utc)
+        history = [("2026-05-16T13:30:00Z", 4)]
+        assert prev_status_from_history(history, now=now) == 4
+
+    def test_unparseable_date_is_treated_as_stale(self):
+        """Fail closed: an unknown date cannot be shown to be recent."""
+        now = datetime(2026, 8, 22, tzinfo=timezone.utc)
+        assert prev_status_from_history([("not-a-date", 5)], now=now, max_age_days=60.0) is None
+
+    def test_missing_date_is_treated_as_stale(self):
+        now = datetime(2026, 8, 22, tzinfo=timezone.utc)
+        assert prev_status_from_history([(None, 5)], now=now, max_age_days=60.0) is None

--- a/tests/test_target_hold_state.py
+++ b/tests/test_target_hold_state.py
@@ -1,0 +1,35 @@
+"""Target availability is a computed, logged state — not an accident.
+
+The bot holds slots when nothing worth having is listed. That is only
+defensible if it can say how many targets exist and where they are.
+"""
+
+from types import SimpleNamespace
+
+from rehoboam.auto_trader import _target_availability
+
+
+def _rec(pid, ep):
+    return SimpleNamespace(
+        player=SimpleNamespace(id=pid, last_name=pid),
+        score=SimpleNamespace(expected_points=ep),
+    )
+
+
+class TestTargetAvailability:
+    def test_counts_listed_targets_above_the_bar(self):
+        state = _target_availability(
+            [_rec("a", 120.0), _rec("b", 50.0)], competitor_ids=set(), bar=100.0
+        )
+        assert state["listed"] == 1
+
+    def test_targets_held_by_opponents_are_counted_separately(self):
+        state = _target_availability([_rec("a", 120.0)], competitor_ids={"a"}, bar=100.0)
+        assert state["listed"] == 0
+        assert state["owned_by_opponents"] == 1
+
+    def test_no_bar_means_every_recommendation_is_a_target(self):
+        state = _target_availability(
+            [_rec("a", 120.0), _rec("b", 50.0)], competitor_ids=set(), bar=0.0
+        )
+        assert state["listed"] == 2


### PR DESCRIPTION
Fixes the season-opening buy ranking, which was close to inverted at the top. Implements `docs/superpowers/specs/2026-08-22-ep-targeting-and-quality-bar-design.md` via `docs/superpowers/plans/2026-08-22-ep-targeting-and-quality-bar.md`.

## The problem

On matchweek 1 the bot ranked two players from a newly promoted club — **zero Bundesliga appearances between them** — 1st and 2nd, and bid €12.3M and €8.6M on them. Meanwhile the market's highest-rated player was skipped below the buy floor.

| player | club | Kickbase avg | before | after |
|---|---|---:|---|---|
| **Pavlović** | Bayern | 119 | EP 29.1 — *skipped* | **EP 82.6** |
| **Rohr** | Elversberg | 0.0 | EP 89.1 — *1st, €12.3M bid* | EP 54.31 — buy-skip |
| **Gyamerah** | Elversberg | 0.0 | EP 70.6 — *2nd, €8.6M bid* | buy-skip |

Two independent defects, fixed independently.

**A — availability rested on a single, arbitrarily old observation.** `last_played_status` had no recency bound. Pavlović's most recent played match was 2025/26 matchday 34, played **2026-05-16** — an unused-substitute appearance in an end-of-season dead rubber, three months stale. That yielded `P(start)=17%` against a fitted rate of 131 points if started. `0.17 × 131` is what put him under the floor.

**B — second-division form was fitted as Bundesliga form.** `rate.quality` carried multipliers fitted on 2. Bundesliga matches, because nothing in `scoring/v2/` records a match's competition. Seven of 22 buyable listings had no `ap`/`tp` field at all; six were from promoted clubs (Elversberg, Schalke, Paderborn).

**Diagnosis correction worth recording:** A is dominant, not B. The fitted table rates Pavlović 1.432 against Rohr's 1.124 — the scorer never thought Rohr was the better player. The inversion was availability, not quality.

## What changed

1. **`prev_status_from_history`** — one implementation of "most recent played status", shared by the live scorer and the replay. The replay previously re-implemented it inline, the exact drift REH-84's own comment in that file warns against.
2. **Recency bound** (`Settings.max_status_age_days`, default 60.0) — longer than a winter break, shorter than an off-season. Missing/unparseable dates fail closed.
3. **Top-flight gate** — withholds the fitted quality coefficient from players with no Bundesliga history, falling through to `rate.predict`'s pre-existing position-prior path. **Not a discount** — REH-80's blanket cold-start discount was reverted for costing 782 points and a league place. Independently corroborated: Gyamerah's EP *rose* 5.8% under this change, which a blanket penalty cannot produce.
4. **Absolute target bar** (`Settings.target_ep_bar`, **default 0.0 — inert**) — absolute EP decides whether a player is worth a squad slot; marginal gain still decides price and displacement. Yields in an emergency, because an empty slot costs −100.
5. **Target-availability logging** — computes and logs targets listed vs. held by opponents, from the existing `competitor_player_ids`.
6. **Fail-open on missing `player_details`** (from final review) — `trader.py:257` swallows every details-fetch failure into `None`, so failing *closed* meant a transient 429 silently cost a player 22% EP and benched him. Now unknown ≠ absent.
7. **INFO skip-reason histogram** — in prod, "declined correctly" and "pipeline broken" were previously indistinguishable.

## Verification

- **862 tests pass** (from 839), ruff clean throughout.
- **`replay-season` 26,960 → 27,025 (+65).** The gain is entirely the availability fix. Tasks 3–5 cannot move it and are labelled as such — the top-flight change is invisible to the replay because the corpus records no competition marker, so an unchanged number there is *not measured*, not *no regression*.
- Live dry-run against prod at each step.

## Known consequence — read before merging

After this branch the pipeline reports **`22 candidates considered, 0 viable`**. Pavlović's marginal gain is 32.1 against `min_ep_upgrade_threshold = 40.0` — a pre-existing threshold this branch does not touch, rounded from a p50 measured against a *synthetic* mid-table squad and never validated live.

That threshold was deliberately **not** tuned here: picking a number to improve an outcome, inside the branch gated by that number, is the failure this work exists to unwind. It is `.env`-tunable without a deploy. The squad remains fieldable, so there is no −100 penalty and no budget risk.

Worth weighing: the pre-branch pipeline was not buying *well* — it was buying Rohr and Gyamerah for €20.9M combined.

## Follow-ups filed as deferred

- `_fallback_expected_points` obeys the new recency bound but not the top-flight gate
- The target bar gates plain buys but not trade pairs — attach to the bar-enablement ticket
- The skip-reason histogram counts 5 of ~9 skip paths
- `test_scorer_parity.py` asserts against `compose_ep`, but the live scorer is now `score_player_v2` one level above it — REH-84's failure mode, recurring

🤖 Generated with [Claude Code](https://claude.com/claude-code)