### PR TITLE
fix(scoring): apply Kickbase injury status at serving time (REH-52)

### DIFF
--- a/rehoboam/config.py
+++ b/rehoboam/config.py
@@ -207,6 +207,20 @@ class Settings(BaseSettings):
         ),
     )
 
+    uncertain_start_multiplier: float = Field(
+        default=0.5,
+        description=(
+            "How much of a player's start probability survives a Kickbase "
+            "'uncertain' flag (status 2). 1.0 ignores the flag, 0.0 treats it as "
+            "a hard block. Deliberately a haircut rather than a verdict: status 2 "
+            "covers both a player returning to fitness and one falling out of "
+            "favour. On 2026-08-22 it covered Fuehrich (market value +15.7% over "
+            "30d, returning) and Stark (-36.0%, fading) simultaneously — the code "
+            "alone cannot tell them apart. Injuries (status 4/256) are handled "
+            "separately and are not affected by this knob."
+        ),
+    )
+
     max_status_age_days: float = Field(
         default=60.0,
         description=(

--- a/rehoboam/scoring/v2/adapter.py
+++ b/rehoboam/scoring/v2/adapter.py
@@ -32,7 +32,13 @@ from datetime import datetime, timezone
 from functools import lru_cache
 
 from rehoboam.scoring.models import DataQuality, PlayerData, PlayerScore
-from rehoboam.scoring.v2.availability import AvailabilityModel
+from rehoboam.scoring.v2.availability import (
+    DEFAULT_UNCERTAIN_START_MULTIPLIER,
+    OUT_STATUSES,
+    UNCERTAIN_STATUSES,
+    AvailabilityModel,
+    apply_availability_override,
+)
 from rehoboam.scoring.v2.coefficients import load_coefficients
 from rehoboam.scoring.v2.features import PLAYED_STATUSES
 from rehoboam.scoring.v2.rate import RateModel
@@ -149,19 +155,56 @@ def has_top_flight_history(player_details: dict | None) -> bool:
     return bool(player_details.get("ap") or player_details.get("tp"))
 
 
+def availability_probs(
+    prev_status: int | None,
+    availability: AvailabilityModel,
+    *,
+    live_status: int | None = None,
+    uncertain_start_multiplier: float = DEFAULT_UNCERTAIN_START_MULTIPLIER,
+) -> dict[int, float]:
+    """Fitted transition probabilities with any serving-time override applied.
+
+    One implementation, so the composed EP and the note reporting P(start) can
+    never disagree about what the model believes.
+    """
+    probs = availability.predict(prev_status)
+    return apply_availability_override(
+        probs, live_status, uncertain_start_multiplier=uncertain_start_multiplier
+    )
+
+
 def compose_ep(
     player_id: str | None,
     prev_status: int | None,
     position: str | None,
     availability: AvailabilityModel,
     rate: RateModel,
+    *,
+    live_status: int | None = None,
+    uncertain_start_multiplier: float = DEFAULT_UNCERTAIN_START_MULTIPLIER,
 ) -> float:
-    """Probability-weighted expected points, in real Kickbase points."""
-    probs = availability.predict(prev_status)
+    """Probability-weighted expected points, in real Kickbase points.
+
+    ``live_status`` is Kickbase's current injury flag. It defaults to None so
+    the season replay -- which has per-match history but no historical injury
+    flags -- keeps its existing behaviour and does not silently acquire a
+    signal it cannot evaluate.
+    """
+    probs = availability_probs(
+        prev_status,
+        availability,
+        live_status=live_status,
+        uncertain_start_multiplier=uncertain_start_multiplier,
+    )
     return sum(probs[s] * rate.predict(player_id, s, position) for s in PLAYED_STATUSES)
 
 
-def score_player_v2(data: PlayerData, *, max_status_age_days: float | None = None) -> PlayerScore:
+def score_player_v2(
+    data: PlayerData,
+    *,
+    max_status_age_days: float | None = None,
+    uncertain_start_multiplier: float = DEFAULT_UNCERTAIN_START_MULTIPLIER,
+) -> PlayerScore:
     """Score a player with the fitted v2 models. Pure — no I/O beyond cached load."""
     availability, rate, _meta = _models()
     player = data.player
@@ -177,12 +220,29 @@ def score_player_v2(data: PlayerData, *, max_status_age_days: float | None = Non
     # fitted on inapplicable data.
     quality_key = player.id if has_top_flight_history(data.player_details) else None
 
-    ep = compose_ep(quality_key, prev_status, position, availability, rate)
+    # Kickbase's live injury flag: unfitted, applied at serving time.
+    # Downward-only — see apply_availability_override for why that matters.
+    live_status = (data.player_details or {}).get("st")
+
+    ep = compose_ep(
+        quality_key,
+        prev_status,
+        position,
+        availability,
+        rate,
+        live_status=live_status,
+        uncertain_start_multiplier=uncertain_start_multiplier,
+    )
 
     dgw_multiplier = DGW_MULTIPLIER if data.is_dgw else 1.0
     ep *= dgw_multiplier
 
-    probs = availability.predict(prev_status)
+    probs = availability_probs(
+        prev_status,
+        availability,
+        live_status=live_status,
+        uncertain_start_multiplier=uncertain_start_multiplier,
+    )
     notes = [
         f"v2: availability P(start)={probs[5]:.0%} "
         f"(prev status {prev_status if prev_status is not None else 'unknown'}), "
@@ -190,6 +250,10 @@ def score_player_v2(data: PlayerData, *, max_status_age_days: float | None = Non
     ]
     if quality_key not in rate.quality:
         notes.append("No fitted quality — using position prior (cold start)")
+    if live_status in OUT_STATUSES:
+        notes.append(f"UNAVAILABLE — Kickbase status {live_status} (injured)")
+    elif live_status in UNCERTAIN_STATUSES:
+        notes.append(f"Status uncertain ({live_status}) — start probability reduced")
     if data.is_dgw:
         notes.append("DOUBLE GAMEWEEK ×1.8")
 

--- a/rehoboam/scoring/v2/availability.py
+++ b/rehoboam/scoring/v2/availability.py
@@ -30,6 +30,22 @@ from rehoboam.scoring.v2.features import PLAYED_STATUSES, FeatureRow
 
 DEFAULT_SHRINKAGE_K = 20.0
 
+# --- Serving-time availability overrides (REH-52 item 4) ------------------
+#
+# Kickbase's live status flag has no historical counterpart -- it does not
+# publish what a player's status was on matchday 12 of 2023/24 -- so it cannot
+# be fitted alongside the transitions above. It is applied here at serving
+# time, explicitly unfitted, and kept separate from the fitted model.
+#
+# 0 = healthy, 2 = uncertain, 4 = short-term injury, 256 = long-term injury
+# (kickbase_client.py:488, scorer.py:424). v1 applied -30/-20/-10 point
+# penalties for these; the v2 migration dropped the signal entirely, which is
+# how a long-term-injured player came to be scored 47.2 EP and named in the
+# starting eleven on 2026-08-22.
+OUT_STATUSES: frozenset[int] = frozenset({4, 256})
+UNCERTAIN_STATUSES: frozenset[int] = frozenset({2})
+DEFAULT_UNCERTAIN_START_MULTIPLIER = 0.5
+
 
 @dataclass(frozen=True)
 class AvailabilityModel:
@@ -69,6 +85,46 @@ class AvailabilityModel:
             prior={int(s): float(p) for s, p in data["prior"].items()},
             shrinkage_k=float(data["shrinkage_k"]),
         )
+
+
+def apply_availability_override(
+    probs: dict[int, float],
+    live_status: int | None,
+    *,
+    uncertain_start_multiplier: float = DEFAULT_UNCERTAIN_START_MULTIPLIER,
+) -> dict[int, float]:
+    """Shift probability mass toward "not in squad" from a live status flag.
+
+    **Downward only, by construction.** ``rate.py`` records that quality is
+    pooled across statuses, so ``rate(5)`` overstates a true starter's mean by
+    ~24% and stays calibrated only because ``P(5)`` is the fitted ~82% rather
+    than 100%. Forcing probability *up* would expose that overshoot; forcing it
+    *down* drives EP toward zero and cannot inflate anything. That asymmetry is
+    why this function can exist without renormalising quality within-status.
+
+    An injury (4, 256) moves all mass to "not in squad". An uncertain flag (2)
+    is a haircut, never a block: the same code covers a player returning to
+    fitness and one falling out of favour -- on 2026-08-22 it covered Fuehrich,
+    whose market value was rising 15.7% over 30 days, and Stark, whose was down
+    36% -- so it must not be treated as a verdict.
+
+    Anything else, including an unknown status, is returned unchanged: a details
+    fetch that failed is not evidence of injury.
+    """
+    multiplier = min(max(uncertain_start_multiplier, 0.0), 1.0)
+
+    if live_status in OUT_STATUSES:
+        return {status: (1.0 if status == 1 else 0.0) for status in probs}
+
+    if live_status in UNCERTAIN_STATUSES:
+        adjusted = dict(probs)
+        for status in (3, 5):
+            if status in adjusted:
+                adjusted[status] *= multiplier
+        adjusted[1] = adjusted.get(1, 0.0) + (1.0 - sum(adjusted.values()))
+        return adjusted
+
+    return dict(probs)
 
 
 def fit_availability(

--- a/rehoboam/trader.py
+++ b/rehoboam/trader.py
@@ -457,7 +457,13 @@ class Trader:
                     team_profiles=team_profiles,
                 )
                 market_scores.append(
-                    score_player_v2(data, max_status_age_days=self.settings.max_status_age_days)
+                    score_player_v2(
+                        data,
+                        max_status_age_days=self.settings.max_status_age_days,
+                        uncertain_start_multiplier=getattr(
+                            self.settings, "uncertain_start_multiplier", 0.5
+                        ),
+                    )
                 )
                 market_player_map[player.id] = player
 
@@ -496,7 +502,13 @@ class Trader:
                     team_profiles=team_profiles,
                 )
                 squad_scores.append(
-                    score_player_v2(data, max_status_age_days=self.settings.max_status_age_days)
+                    score_player_v2(
+                        data,
+                        max_status_age_days=self.settings.max_status_age_days,
+                        uncertain_start_multiplier=getattr(
+                            self.settings, "uncertain_start_multiplier", 0.5
+                        ),
+                    )
                 )
                 squad_player_map[player.id] = player
 

--- a/tests/test_scoring_v2/test_adapter.py
+++ b/tests/test_scoring_v2/test_adapter.py
@@ -296,3 +296,59 @@ class TestNonTopFlightUsesPositionPrior:
         assert scored_unknown.expected_points == scored_with.expected_points
         assert scored_unknown.data_quality.grade == "A"
         assert not any("position prior" in n for n in scored_unknown.notes)
+
+
+class TestLiveInjuryStatusReachesTheScore:
+    """The serving-time override must actually reach EP, not just exist.
+
+    On 2026-08-22 Hoeler carried status 256 (long-term injury), scored 47.2 EP,
+    and was named in the bot's starting eleven. Nothing in scoring/v2 read the
+    flag. These pin that it is now read.
+    """
+
+    @staticmethod
+    def _data(status_code):
+        from rehoboam.scoring.models import PlayerData
+
+        matches = [{"day": d, "st": 5, "p": 90, "md": "2026-05-16T13:30:00Z"} for d in range(1, 35)]
+        return PlayerData(
+            player=_player("1856"),
+            performance=_perf(matches),
+            player_details={"ap": 83, "tp": 2000, "st": status_code},
+            team_strength=None,
+            opponent_strength=None,
+            is_dgw=False,
+        )
+
+    def test_long_term_injury_collapses_expected_points(self):
+        healthy = score_player_v2(self._data(0))
+        injured = score_player_v2(self._data(256))
+
+        assert healthy.expected_points > 10.0, "baseline must be non-trivial"
+        assert (
+            injured.expected_points < 1.0
+        ), f"a long-term-injured player must not score {injured.expected_points}"
+
+    def test_short_term_injury_collapses_expected_points(self):
+        assert score_player_v2(self._data(4)).expected_points < 1.0
+
+    def test_uncertain_reduces_but_does_not_erase(self):
+        """Fuehrich's case: status 2 is a haircut, not a verdict."""
+        healthy = score_player_v2(self._data(0))
+        uncertain = score_player_v2(self._data(2))
+
+        assert 0.0 < uncertain.expected_points < healthy.expected_points
+
+    def test_missing_status_scores_as_healthy(self):
+        from rehoboam.scoring.models import PlayerData
+
+        healthy = score_player_v2(self._data(0))
+        no_details = PlayerData(
+            player=_player("1856"),
+            performance=self._data(0).performance,
+            player_details=None,
+            team_strength=None,
+            opponent_strength=None,
+            is_dgw=False,
+        )
+        assert score_player_v2(no_details).expected_points == pytest.approx(healthy.expected_points)

--- a/tests/test_scoring_v2/test_availability_override.py
+++ b/tests/test_scoring_v2/test_availability_override.py
@@ -1,0 +1,109 @@
+"""Serving-time availability overrides (REH-52 item 4).
+
+The fitted availability model predicts P(status | previous status) from history
+alone. Kickbase's live injury flag has no historical counterpart -- it does not
+publish what a player's status was on matchday 12 of 2023/24 -- so it cannot be
+fitted. It enters here, at serving time, explicitly unfitted.
+
+Direction matters. `rate.py` warns that overriding P(status) upward exposes a
+~24% starter overshoot that the paired availability+rate models currently
+cancel: quality is pooled across statuses, so rate(5) overstates a true
+starter's mean and only stays calibrated because P(5) is the fitted ~82%
+rather than 100%. Forcing probability DOWNWARD drives EP toward zero and
+cannot inflate anything, so these overrides are downward-only by construction.
+
+Status codes (kickbase_client.py:488, scorer.py:424):
+    0 = healthy, 2 = uncertain, 4 = short-term injury, 256 = long-term injury
+
+The v1 scorer applied -30/-20/-10 point penalties for these. v2 dropped the
+signal entirely, which is how a long-term-injured player came to be scored 47.2
+EP and named in the starting eleven on 2026-08-22.
+"""
+
+import pytest
+
+from rehoboam.scoring.v2.availability import apply_availability_override
+
+
+def _even_probs() -> dict[int, float]:
+    """A starter-ish distribution, roughly what the fitted model returns."""
+    return {1: 0.05, 3: 0.10, 4: 0.05, 5: 0.80}
+
+
+class TestInjuryForcesDidNotPlay:
+    def test_long_term_injury_removes_the_start_probability(self):
+        """Hoeler: status 256, scored 47.2 EP, named in the starting eleven."""
+        out = apply_availability_override(_even_probs(), live_status=256)
+        assert out[5] == pytest.approx(0.0)
+        assert out[1] == pytest.approx(1.0)
+
+    def test_short_term_injury_removes_it_too(self):
+        out = apply_availability_override(_even_probs(), live_status=4)
+        assert out[5] == pytest.approx(0.0)
+
+
+class TestUncertainIsReducedNotBlocked:
+    def test_uncertain_reduces_the_start_probability(self):
+        """Fuehrich: status 2, market value rising 15.7% over 30d.
+
+        Same code as a collapsing player, opposite meaning -- so status 2 is a
+        haircut, never a block.
+        """
+        out = apply_availability_override(
+            _even_probs(), live_status=2, uncertain_start_multiplier=0.5
+        )
+        assert out[5] == pytest.approx(0.40)
+
+    def test_uncertain_does_not_zero_the_player(self):
+        out = apply_availability_override(
+            _even_probs(), live_status=2, uncertain_start_multiplier=0.5
+        )
+        assert out[5] > 0.0
+
+
+class TestHealthyAndUnknownAreUntouched:
+    def test_healthy_is_unchanged(self):
+        probs = _even_probs()
+        assert apply_availability_override(probs, live_status=0) == probs
+
+    def test_unknown_status_is_unchanged(self):
+        """Fail open. A details fetch that failed is not evidence of injury."""
+        probs = _even_probs()
+        assert apply_availability_override(probs, live_status=None) == probs
+
+    def test_unrecognised_status_is_unchanged(self):
+        probs = _even_probs()
+        assert apply_availability_override(probs, live_status=9999) == probs
+
+
+class TestInvariants:
+    @pytest.mark.parametrize("status", [None, 0, 2, 4, 256, 9999])
+    def test_the_override_never_raises_the_start_probability(self, status):
+        """Downward-only. Raising P(start) would expose rate.py's ~24% overshoot."""
+        before = _even_probs()
+        after = apply_availability_override(before, live_status=status)
+        assert after[5] <= before[5] + 1e-9
+
+    @pytest.mark.parametrize("status", [None, 0, 2, 4, 256, 9999])
+    def test_probabilities_still_sum_to_one(self, status):
+        after = apply_availability_override(_even_probs(), live_status=status)
+        assert sum(after.values()) == pytest.approx(1.0)
+
+
+class TestMultiplierIsClamped:
+    def test_a_multiplier_above_one_cannot_raise_the_start_probability(self):
+        """The knob is .env-tunable, so it must not be able to invert the rule.
+
+        A multiplier > 1 would turn an uncertain flag into a promotion and
+        reintroduce exactly the upward override rate.py warns about.
+        """
+        before = _even_probs()
+        after = apply_availability_override(before, live_status=2, uncertain_start_multiplier=1.5)
+        assert after[5] <= before[5] + 1e-9
+
+    def test_a_negative_multiplier_does_not_produce_negative_probability(self):
+        after = apply_availability_override(
+            _even_probs(), live_status=2, uncertain_start_multiplier=-2.0
+        )
+        assert all(p >= 0.0 for p in after.values())
+        assert sum(after.values()) == pytest.approx(1.0)


### PR DESCRIPTION
Closes REH-52.

## The bug

The bot named a **long-term-injured player in its starting eleven.** On 2026-08-22, Höler carried Kickbase status 256, was scored **47.2 EP**, and was selected. Four of twelve squad players were flagged unavailable and all four were scored as fully fit.

Nothing in `scoring/v2/` read the flag. The only `status` references there are *match* status (did he start/sub), never *is he fit*.

**This is a regression, not a gap.** v1's scorer applied −30/−20/−10 penalties for status 256/4/2 (`scorer.py:418`). The v2 migration dropped the signal entirely.

## Scope

REH-52's first three items were already built — per-match `st` is stored in the corpus, the transition model is fitted and shrunk toward the marginal prior, it ships as coefficients. Item 4, *"apply serving-time `prob`/`st` as documented overrides"*, was not. **This is item 4.**

## Downward-only, and that asymmetry is the whole design

`rate.py`'s module docstring warns:

> Anyone overriding `P(status)` at serving time MUST renormalise quality within-status first, or this ~24% starter bias — currently cancelled by the paired availability model — will leak straight into the output.

Quality is pooled across statuses, so `rate(5)` overstates a true starter's mean and stays calibrated only because `P(5)` is the fitted ~82% rather than 100%.

Forcing probability **up** exposes that overshoot. Forcing it **down** drives EP toward zero and cannot inflate anything. So these overrides are downward-only by construction, and need no renormalisation:

| status | meaning | effect |
|---|---|---|
| 4, 256 | short-/long-term injury | all mass to "not in squad" → EP ≈ 0 |
| 2 | uncertain | haircut via `Settings.uncertain_start_multiplier` (default 0.5) |
| 0, unknown | healthy / no data | untouched — a failed details fetch is not evidence of injury |

**Status 2 is deliberately a haircut, never a block.** The same code covered Führich (market value **+15.7%** over 30d, returning) and Stark (**−36.0%**, fading) on the same day. The code alone cannot distinguish them, so it must not try.

## Live result

| player | status | before | after | outcome |
|---|---|---|---|---|
| **Höler** | 256 | 47.2 | **0.0** | dropped from the eleven |
| **Führich** | 2 | 66.8 | **33.6** | halved, still starts |
| Klaas | 2 | 50.6 | 25.5 | reduced |
| Stark | 2 | — | 26.7 | reduced |
| Sabitzer, Mohya, Flekken… | 0 | — | unchanged | untouched |

Lineup went `3-5-2 | …Höler` → `4-5-1` without him. That slot held a player who cannot play and would have scored **0**; it now holds one worth ~39.6 EP.

**Second-order effect:** discounting Führich raised every marginal gain computed against him. Pavlović moved **+32.1 → +57.2** and became the session's single viable buy, clearing a threshold he previously missed — without touching that threshold.

## Verification

- **887 tests pass** (from 862), ruff clean. 25 new tests, each watched fail first.
- The multiplier is clamped to [0, 1] with a test proving it fails unclamped — it's `.env`-tunable, so it must not be able to invert the downward-only rule.
- **`replay-season` unchanged at 27,025, and that is NOT measurement.** The corpus carries per-match status but no historical injury flags, so the harness cannot see this change. `compose_ep`'s `live_status` defaults to `None` precisely so the replay does not silently acquire a signal it cannot evaluate. The live before/after above is the evidence.

## Deliberately not included

Using **market-value direction** to distinguish a rising status-2 player from a falling one — the Führich/Stark problem. It's the right next signal, but folding it in here would mean neither piece could be measured alone.

`lineup_probability` is `None` for every player pre-season; when Kickbase publishes it, it plugs into this same override with no new machinery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)