### PR TITLE
Deploy plumbing for approval notifications, and send the daily summary over Telegram

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,3 +51,21 @@ API_FOOTBALL_KEY=your-api-football-key
 # `push-azure-state` and the deployed Azure Function. Leave unset for local-only dev.
 # AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=https;AccountName=...
 # BLOB_CONTAINER=rehoboam-data
+
+# --- Trade-approval notifications (REH-97) ---------------------------------
+# All optional. Leave empty and the bot keeps trading autonomously on profit
+# and lineup; it simply records improvement-buy proposals without delivering
+# them. deploy.sh passes these to Bicep, which stores the secret ones in Key
+# Vault and surfaces them as app settings — nothing secret is committed.
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_CHAT_ID=
+# Any random string; Telegram echoes it back in a header so the public
+# money-spending webhook can reject forged callbacks. `openssl rand -hex 32`.
+TELEGRAM_WEBHOOK_SECRET=
+
+SMTP_HOST=
+SMTP_PORT=587
+# Also used as the From address.
+SMTP_USER=
+SMTP_PASSWORD=
+ALERT_EMAIL_TO=

--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,8 @@ TELEGRAM_CHAT_ID=
 # money-spending webhook can reject forged callbacks. `openssl rand -hex 32`.
 TELEGRAM_WEBHOOK_SECRET=
 
+# Optional and secondary: the daily summary goes over Telegram, which needs no
+# mail provider. Set these only if you also want it by email.
 SMTP_HOST=
 SMTP_PORT=587
 # Also used as the From address.

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ deploy/bicep/**/*.json
 
 # SDD workspace (scratch — git history is the record)
 .superpowers/
+deploy/bicep/main.json

--- a/deploy/azure_function/function_app.py
+++ b/deploy/azure_function/function_app.py
@@ -89,6 +89,7 @@ def _send_daily_summary(api, league, settings, session):
     from rehoboam.bid_learner import BidLearner
     from rehoboam.notify.email import send_email
     from rehoboam.notify.render import render_daily_summary
+    from rehoboam.notify.telegram import send_message
 
     squad = api.get_squad(league)
     budget = int(api.get_team_info(league).get("budget", 0))
@@ -137,6 +138,17 @@ def _send_daily_summary(api, league, settings, session):
         executed=executed,
         rejections=blocked,
     )
+    header = f"REHOBOAM DAILY — {len(pending)} awaiting approval\n\n"
+
+    # Telegram is the primary channel: it is already configured for approvals,
+    # costs nothing, and needs no mail provider. Proton — the alternative that
+    # was considered — requires a paid plan plus a custom domain, and Proton
+    # Bridge binds to localhost, which an Azure Function can never reach.
+    if not send_message(settings.telegram_bot_token, settings.telegram_chat_id, header + body):
+        logging.warning("daily summary: telegram delivery failed or not configured")
+
+    # Email stays available for anyone who configures SMTP; absent config makes
+    # this a no-op rather than an error.
     send_email(
         host=settings.smtp_host,
         port=settings.smtp_port,

--- a/deploy/bicep/main.bicep
+++ b/deploy/bicep/main.bicep
@@ -34,6 +34,35 @@ param kickbaseEmail string
 @secure()
 param kickbasePassword string
 
+@description('Telegram bot token for trade-approval messages. Empty disables Telegram entirely.')
+@secure()
+param telegramBotToken string = ''
+
+@description('Telegram chat to send trade proposals to.')
+@secure()
+param telegramChatId string = ''
+
+@description('Shared secret Telegram echoes in X-Telegram-Bot-Api-Secret-Token. The approval webhook is a public endpoint that spends money, so a callback without this header is rejected before anything is read from it.')
+@secure()
+param telegramWebhookSecret string = ''
+
+@description('SMTP host for the daily summary email. Empty disables email.')
+param smtpHost string = ''
+
+@description('SMTP port; 587 for STARTTLS.')
+param smtpPort string = '587'
+
+@description('SMTP username. Also used as the From address.')
+@secure()
+param smtpUser string = ''
+
+@description('SMTP password or app password.')
+@secure()
+param smtpPassword string = ''
+
+@description('Recipient of the daily summary email.')
+param alertEmailTo string = ''
+
 @description('League index in the Kickbase leagues list.')
 param leagueIndex string = '0'
 
@@ -143,6 +172,58 @@ resource secretKickbasePassword 'Microsoft.KeyVault/vaults/secrets@2023-07-01' =
   properties: { value: kickbasePassword }
 }
 
+// Optional secrets: created only when supplied, because Key Vault rejects an
+// empty secret value. The matching app settings are added by the same
+// condition below, so an unconfigured channel is genuinely absent rather than
+// present-but-blank.
+resource secretTelegramBotToken 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = if (!empty(telegramBotToken)) {
+  parent: keyVault
+  name: 'telegram-bot-token'
+  properties: { value: telegramBotToken }
+}
+
+resource secretTelegramChatId 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = if (!empty(telegramChatId)) {
+  parent: keyVault
+  name: 'telegram-chat-id'
+  properties: { value: telegramChatId }
+}
+
+resource secretTelegramWebhookSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = if (!empty(telegramWebhookSecret)) {
+  parent: keyVault
+  name: 'telegram-webhook-secret'
+  properties: { value: telegramWebhookSecret }
+}
+
+resource secretSmtpUser 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = if (!empty(smtpUser)) {
+  parent: keyVault
+  name: 'smtp-user'
+  properties: { value: smtpUser }
+}
+
+resource secretSmtpPassword 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = if (!empty(smtpPassword)) {
+  parent: keyVault
+  name: 'smtp-password'
+  properties: { value: smtpPassword }
+}
+
+// Built from the vault URI rather than from the conditional resources above,
+// so referencing them is never evaluated when they were not created.
+var kvSecretPrefix = '${keyVault.properties.vaultUri}secrets/'
+
+var telegramSettings = empty(telegramBotToken) ? {} : {
+  TELEGRAM_BOT_TOKEN: '@Microsoft.KeyVault(SecretUri=${kvSecretPrefix}telegram-bot-token)'
+  TELEGRAM_CHAT_ID: '@Microsoft.KeyVault(SecretUri=${kvSecretPrefix}telegram-chat-id)'
+  TELEGRAM_WEBHOOK_SECRET: '@Microsoft.KeyVault(SecretUri=${kvSecretPrefix}telegram-webhook-secret)'
+}
+
+var smtpSettings = empty(smtpHost) ? {} : {
+  SMTP_HOST: smtpHost
+  SMTP_PORT: smtpPort
+  SMTP_USER: '@Microsoft.KeyVault(SecretUri=${kvSecretPrefix}smtp-user)'
+  SMTP_PASSWORD: '@Microsoft.KeyVault(SecretUri=${kvSecretPrefix}smtp-password)'
+  ALERT_EMAIL_TO: alertEmailTo
+}
+
 var storageConnectionString = 'DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};EndpointSuffix=${environment().suffixes.storage};AccountKey=${storageAccount.listKeys().keys[0].value}'
 
 resource secretStorageConn 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
@@ -202,7 +283,7 @@ resource tradingAppSettings 'Microsoft.Web/sites/config@2023-01-01' = {
   dependsOn: [
     tradingKvAccess
   ]
-  properties: {
+  properties: union({
     AzureWebJobsStorage: '@Microsoft.KeyVault(SecretUri=${secretStorageConn.properties.secretUri})'
     AZURE_STORAGE_CONNECTION_STRING: '@Microsoft.KeyVault(SecretUri=${secretStorageConn.properties.secretUri})'
     APPLICATIONINSIGHTS_CONNECTION_STRING: '@Microsoft.KeyVault(SecretUri=${secretAppInsightsConn.properties.secretUri})'
@@ -214,7 +295,7 @@ resource tradingAppSettings 'Microsoft.Web/sites/config@2023-01-01' = {
     DRY_RUN: dryRun
     AGGRESSIVE: aggressiveMode
     BLOB_CONTAINER: blobContainerName
-  }
+  }, telegramSettings, smtpSettings)
 }
 
 resource externalAppSettings 'Microsoft.Web/sites/config@2023-01-01' = {

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -42,6 +42,20 @@ source_env() {
   fi
 }
 
+# Optional notification channels. Absent means the channel stays disabled —
+# the bot keeps trading, it just cannot tell anyone about it. Passed through
+# to Bicep, which only creates a Key Vault secret when the value is non-empty.
+notify_params() {
+  echo "telegramBotToken=${TELEGRAM_BOT_TOKEN:-}" \
+       "telegramChatId=${TELEGRAM_CHAT_ID:-}" \
+       "telegramWebhookSecret=${TELEGRAM_WEBHOOK_SECRET:-}" \
+       "smtpHost=${SMTP_HOST:-}" \
+       "smtpPort=${SMTP_PORT:-587}" \
+       "smtpUser=${SMTP_USER:-}" \
+       "smtpPassword=${SMTP_PASSWORD:-}" \
+       "alertEmailTo=${ALERT_EMAIL_TO:-}"
+}
+
 deploy_infra() {
   source_env
   : "${KICKBASE_EMAIL:?must be set in .env}"
@@ -53,7 +67,8 @@ deploy_infra() {
       --resource-group "$RESOURCE_GROUP" \
       --template-file "$BICEP_TEMPLATE" \
       --parameters "$BICEP_PARAMS" \
-      --parameters kickbaseEmail="$KICKBASE_EMAIL" kickbasePassword="$KICKBASE_PASSWORD"
+      --parameters kickbaseEmail="$KICKBASE_EMAIL" kickbasePassword="$KICKBASE_PASSWORD" \
+      --parameters $(notify_params)
     return
   fi
 
@@ -66,6 +81,7 @@ deploy_infra() {
     --template-file "$BICEP_TEMPLATE" \
     --parameters "$BICEP_PARAMS" \
     --parameters kickbaseEmail="$KICKBASE_EMAIL" kickbasePassword="$KICKBASE_PASSWORD" \
+    --parameters $(notify_params) \
     --output table
 }
 

--- a/rehoboam/notify/telegram.py
+++ b/rehoboam/notify/telegram.py
@@ -15,6 +15,65 @@ logger = logging.getLogger(__name__)
 
 _API = "https://api.telegram.org/bot{token}/sendMessage"
 
+# Telegram rejects anything longer than this in a single message.
+MAX_MESSAGE_CHARS = 4096
+
+
+def _post(token: str, payload: dict, what: str, timeout: float) -> bool:
+    """One sendMessage call. False on any failure — never raises."""
+    try:
+        resp = requests.post(_API.format(token=token), json=payload, timeout=timeout)
+    except Exception as exc:
+        # NEVER log the exception object or a traceback here: requests embeds the
+        # full request URL in its message, and that URL contains the bot token.
+        logger.warning("telegram: send failed for %s (%s)", what, type(exc).__name__)
+        return False
+
+    if resp.status_code != 200:
+        logger.warning("telegram: send returned %s for %s", resp.status_code, what)
+        return False
+    return True
+
+
+def _chunks(text: str, limit: int = MAX_MESSAGE_CHARS) -> list[str]:
+    """Split on line boundaries so a figure is never torn in half."""
+    out: list[str] = []
+    current = ""
+    for line in text.split("\n"):
+        candidate = f"{current}\n{line}" if current else line
+        if len(candidate) <= limit:
+            current = candidate
+            continue
+        if current:
+            out.append(current)
+            current = ""
+        # A single line longer than the cap has to be cut somewhere.
+        while len(line) > limit:
+            out.append(line[:limit])
+            line = line[limit:]
+        current = line
+    if current:
+        out.append(current)
+    return out
+
+
+def send_message(token: str, chat_id: str, text: str, *, timeout: float = 10.0) -> bool:
+    """Send plain text with no buttons. True only if every part was accepted.
+
+    Carries the daily summary. That started as an SMTP email, but Proton needs
+    a paid plan plus a custom domain, and Proton Bridge binds to localhost so
+    an Azure Function can never reach it — the summary reuses the channel that
+    is already configured and verified.
+    """
+    if not token or not chat_id:
+        logger.info("telegram: no token or chat id configured — not sending")
+        return False
+
+    ok = True
+    for part in _chunks(text):
+        ok = _post(token, {"chat_id": chat_id, "text": part}, "daily summary", timeout) and ok
+    return ok
+
 
 def send_proposal(
     token: str,
@@ -45,19 +104,4 @@ def send_proposal(
             ]
         },
     }
-    try:
-        resp = requests.post(_API.format(token=token), json=payload, timeout=timeout)
-    except Exception as exc:
-        # NEVER log the exception object or a traceback here: requests embeds the
-        # full request URL in its message, and that URL contains the bot token.
-        logger.warning(
-            "telegram: send failed for proposal %s (%s)",
-            proposal_id,
-            type(exc).__name__,
-        )
-        return False
-
-    if resp.status_code != 200:
-        logger.warning("telegram: send returned %s for proposal %s", resp.status_code, proposal_id)
-        return False
-    return True
+    return _post(token, payload, f"proposal {proposal_id}", timeout)

--- a/tests/test_telegram_notifier.py
+++ b/tests/test_telegram_notifier.py
@@ -7,7 +7,7 @@ best-effort pattern. These tests pin that a dead Telegram is survivable.
 import logging
 from unittest.mock import MagicMock, patch
 
-from rehoboam.notify.telegram import send_proposal
+from rehoboam.notify.telegram import send_message, send_proposal
 
 
 class TestSuccess:
@@ -52,3 +52,60 @@ class TestFailuresAreSurvivable:
             with caplog.at_level(logging.WARNING):
                 assert send_proposal("SECRET123", "C", "p1", "hello") is False
         assert "SECRET123" not in caplog.text
+
+
+class TestPlainMessages:
+    """The daily summary goes over Telegram rather than SMTP.
+
+    Proton needs a paid plan plus a custom domain, and Proton Bridge only
+    binds to localhost so an Azure Function can never reach it. Telegram is
+    already configured and verified, so the summary reuses it.
+    """
+
+    def test_it_sends_a_plain_message_without_buttons(self):
+        with patch("rehoboam.notify.telegram.requests.post") as post:
+            post.return_value = MagicMock(status_code=200)
+            assert send_message("T", "C", "hello") is True
+        payload = post.call_args[1]["json"]
+        assert payload["text"] == "hello"
+        assert "reply_markup" not in payload
+
+    def test_missing_credentials_return_false_without_calling_out(self):
+        with patch("rehoboam.notify.telegram.requests.post") as post:
+            assert send_message("", "", "hello") is False
+            post.assert_not_called()
+
+    def test_a_failure_returns_false_and_does_not_raise(self):
+        with patch("rehoboam.notify.telegram.requests.post", side_effect=OSError("down")):
+            assert send_message("T", "C", "hello") is False
+
+
+class TestLongMessagesAreSplit:
+    """Telegram rejects anything over 4096 characters.
+
+    A summary that grew past the cap must not vanish, and must not be cut
+    through the middle of a number.
+    """
+
+    def test_a_long_message_is_split_on_line_boundaries(self):
+        text = "\n".join(f"line {i} " + "x" * 80 for i in range(200))
+        with patch("rehoboam.notify.telegram.requests.post") as post:
+            post.return_value = MagicMock(status_code=200)
+            assert send_message("T", "C", text) is True
+        sent = [c[1]["json"]["text"] for c in post.call_args_list]
+        assert len(sent) > 1
+        assert all(len(s) <= 4096 for s in sent)
+        # nothing lost, and no line torn in half
+        assert "\n".join(sent).split("\n") == text.split("\n")
+
+    def test_a_short_message_is_sent_as_one(self):
+        with patch("rehoboam.notify.telegram.requests.post") as post:
+            post.return_value = MagicMock(status_code=200)
+            send_message("T", "C", "short")
+        assert post.call_count == 1
+
+    def test_one_failed_chunk_makes_the_whole_send_false(self):
+        text = "\n".join("y" * 200 for _ in range(60))
+        with patch("rehoboam.notify.telegram.requests.post") as post:
+            post.side_effect = [MagicMock(status_code=200), MagicMock(status_code=500)]
+            assert send_message("T", "C", text) is False


### PR DESCRIPTION
Follow-on to #71, which added the approval gate but left it undeliverable: the eight settings it needs did not exist on `func-rehoboam`.

## Secrets reach the Function the same way `KICKBASE_PASSWORD` does

`.env` → `deploy.sh` → `@secure()` Bicep param → Key Vault secret → app setting reference. Nothing secret is committed.

This had to be a code change rather than `az functionapp config appsettings set`: the app settings are a declarative `Microsoft.Web/sites/config` resource, so the next `deploy.sh infra` replaces the whole collection and any CLI addition would vanish silently.

Every setting is optional. Key Vault rejects an empty secret value, so the secret resources are conditional and the matching app settings are merged in by the same condition via `union()` — an unconfigured channel is genuinely *absent* rather than present-but-blank, which is what the code's own "no token configured" short-circuit expects. The KV reference URIs are built from the vault URI rather than from the conditional resources, so a resource that was never created is never dereferenced.

With nothing set, the bot trades exactly as it does today.

## The daily summary goes over Telegram, not SMTP

The summary was email-only, which forces a mail provider on a bot that already has a working Telegram channel.

Proton specifically cannot do this job: [SMTP submission needs a paid plan **and** a custom-domain address](https://proton.me/support/smtp-submission), and Proton Bridge binds to `localhost`, which an Azure Function can never reach.

So `send_message` sends plain text with no buttons, splitting on line boundaries to respect Telegram's 4096-character cap — nothing dropped, no figure torn in half. A summary measured against the live squad came to **944 characters**, so splitting is a guard rather than a routine path.

`send_proposal` and `send_message` now share one `_post`, keeping the credential-safe error handling in one place: `requests` embeds the request URL in its exception messages and that URL contains the bot token, so neither path may log the exception object or a traceback.

Email is kept and still wired, so adding SMTP later needs no code change.

## Verified live

- `@reh_kickbase_bot` authenticated; chat id read from `getUpdates`
- A rendered proposal delivered to the real chat through `send_proposal`
- A real daily summary — actual squad, budget and market — delivered through `render_daily_summary` + `send_message`
- 984 passed, 1 skipped; ruff clean; `az bicep build` compiles; `function_app.py` compiles

The 6 pre-existing `send_proposal` tests still pass unchanged after the `_post` refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)