### PR TITLE
Plan buys against the budget instead of ranking by raw gain

### DIFF
--- a/rehoboam/scoring/decision.py
+++ b/rehoboam/scoring/decision.py
@@ -545,8 +545,13 @@ class DecisionEngine:
                     final_recs.append(rec)
             # else: skip — no squad data to generate sell plan
 
-        # Sort by marginal EP gain (primary), then by raw EP (secondary)
-        final_recs.sort(key=lambda r: (r.marginal_ep_gain, r.score.expected_points), reverse=True)
+        # Order for a budget, not for a single pick. See `plan_buys`.
+        final_recs = plan_buys(
+            final_recs,
+            budget=budget,
+            squad=squad_list,
+            lineup_map=lineup_map,
+        )
         top = final_recs[:top_n]
         logger.info(
             "recommend_buys: %d candidates considered, %d viable, returning top %d "
@@ -936,3 +941,99 @@ def _dummy_score(player_id: str, ep: float) -> PlayerScore:
         lineup_probability=None,
         minutes_trend=None,
     )
+
+
+def plan_buys(
+    recs: list,
+    *,
+    budget: float,
+    squad: list,
+    lineup_map: dict[str, float],
+) -> list:
+    """Order buy recommendations for a *budget*, not for a single pick.
+
+    Ranking by absolute marginal gain answers "which one player helps most",
+    which is the wrong question when several can be afforded. Measured live on
+    2026-08-24 with EUR 62.2M and four free slots: Kimmich at +88.2 for
+    EUR 59.8M was proposed first, and the EUR 1.8M left could not cover
+    Trimmel at +30.4 for EUR 4.2M — 7.3 points per EUR million against
+    Kimmich's 1.5.
+
+    Two things make this harder than sorting by points per euro.
+
+    **Marginal gains do not add up.** Each is measured against the current best
+    eleven, so once a signing joins it, the next candidate competes against a
+    better worst starter and is worth less than its headline number. Summing
+    the original figures promises a total the squad will never deliver. Every
+    remaining candidate is therefore re-measured after each pick, and the
+    recommendation carries the re-measured gain. Candidates that no longer
+    improve the eleven drop out: an upgrade on the old worst starter may be no
+    upgrade on his replacement.
+
+    **Greedy by ratio can be worse than one big signing.** On the same live
+    data it took four cheap players worth +70.0 re-measured, over Kimmich alone
+    at +88.2 — a strictly worse squad. So both orderings are built and the one
+    that actually delivers more points is returned, which is the standard
+    knapsack guarantee rather than a heuristic hoping for the best.
+
+    Returns the chosen plan first, in execution order, followed by everything
+    unaffordable ranked by raw gain so nothing is silently lost.
+    """
+    from rehoboam.formation import select_best_eleven
+
+    def _cost(rec) -> int:
+        return int(getattr(rec.player, "price", 0) or getattr(rec.player, "market_value", 0) or 0)
+
+    def _build(prefer_efficiency: bool) -> tuple[list, list[float], float]:
+        """Greedily fill the budget, re-measuring gains as the squad changes."""
+        remaining = list(recs)
+        chosen: list = []
+        gains: list[float] = []
+        working_squad = list(squad)
+        working_map = dict(lineup_map)
+        spend_left = float(budget)
+
+        while remaining and working_squad:
+            current_best = select_best_eleven(working_squad, working_map)
+            current_total = sum(working_map.get(p.id, 0.0) for p in current_best)
+
+            best_rec, best_gain, best_key = None, 0.0, 0.0
+            for rec in remaining:
+                cost = _cost(rec)
+                if cost <= 0 or cost > spend_left:
+                    continue
+                augmented = working_squad + [rec.player]
+                aug_map = dict(working_map)
+                aug_map[rec.player.id] = rec.score.expected_points
+                gain = (
+                    sum(aug_map.get(p.id, 0.0) for p in select_best_eleven(augmented, aug_map))
+                    - current_total
+                )
+                if gain <= 0:
+                    continue
+                key = gain / (cost / 1_000_000) if prefer_efficiency else gain
+                if key > best_key:
+                    best_rec, best_gain, best_key = rec, gain, key
+
+            if best_rec is None:
+                break
+
+            chosen.append(best_rec)
+            gains.append(best_gain)
+            remaining.remove(best_rec)
+            spend_left -= _cost(best_rec)
+            working_squad = working_squad + [best_rec.player]
+            working_map[best_rec.player.id] = best_rec.score.expected_points
+
+        return chosen, gains, sum(gains)
+
+    by_efficiency = _build(prefer_efficiency=True)
+    by_absolute = _build(prefer_efficiency=False)
+    chosen, gains, _total = max((by_efficiency, by_absolute), key=lambda plan: plan[2])
+
+    for rec, gain in zip(chosen, gains, strict=True):
+        rec.marginal_ep_gain = gain
+
+    leftover = [r for r in recs if r not in chosen]
+    leftover.sort(key=lambda r: (r.marginal_ep_gain, r.score.expected_points), reverse=True)
+    return chosen + leftover

--- a/tests/test_buy_planning.py
+++ b/tests/test_buy_planning.py
@@ -1,0 +1,136 @@
+"""Ordering buy recommendations for a budget rather than for a single pick.
+
+Ranking by absolute marginal gain answers "which one player helps most". With
+money for several, that is the wrong question — and it cost a real opportunity
+on 2026-08-24, when one EUR 59.8M signing crowded out three cheaper ones.
+"""
+
+from types import SimpleNamespace
+
+from rehoboam.scoring.decision import plan_buys
+
+
+def _player(pid, position, price):
+    return SimpleNamespace(
+        id=pid, last_name=pid, position=position, price=price, market_value=price
+    )
+
+
+def _rec(pid, position, price, ep, gain):
+    return SimpleNamespace(
+        player=_player(pid, position, price),
+        score=SimpleNamespace(expected_points=ep, player_id=pid),
+        marginal_ep_gain=gain,
+    )
+
+
+def _squad(n=11, ep=30.0):
+    """A legal eleven of interchangeable players."""
+    squad, lineup = [], {}
+    spec = [("Goalkeeper", 1), ("Defender", 4), ("Midfielder", 4), ("Forward", 2)]
+    i = 0
+    for position, count in spec:
+        for _ in range(count):
+            p = _player(f"s{i}", position, 1_000_000)
+            squad.append(p)
+            lineup[p.id] = ep
+            i += 1
+    return squad[:n], lineup
+
+
+class TestWhicheverPlanScoresMore:
+    """Neither ordering wins by default; the one worth more points does."""
+
+    def _weak_spots(self, n):
+        """A squad with `n` weak starters, so `n` cheap signings each help."""
+        squad, lineup = _squad(ep=50.0)
+        for p in [x for x in squad if x.position == "Defender"][:n]:
+            lineup[p.id] = 10.0
+        return squad, lineup
+
+    def test_several_cheap_upgrades_beat_one_expensive_one_when_they_add_up(self):
+        """The live failure: one big buy consumed the budget and blocked three."""
+        squad, lineup = self._weak_spots(3)
+        big = _rec("big", "Midfielder", 59_800_000, 120.0, 70.0)
+        cheap = [_rec(f"c{i}", "Defender", 4_000_000, 60.0, 50.0) for i in range(3)]
+        planned = plan_buys([big, *cheap], budget=62_000_000, squad=squad, lineup_map=lineup)
+        chosen = [r.player.id for r in planned[:3]]
+        assert set(chosen) == {"c0", "c1", "c2"}
+        assert sum(r.marginal_ep_gain for r in planned[:3]) > 70.0
+
+    def test_one_big_signing_wins_when_the_cheap_options_do_not_add_up(self):
+        """Greedy-by-ratio alone would take the cheap player and lose points."""
+        squad, lineup = self._weak_spots(1)
+        big = _rec("big", "Midfielder", 59_800_000, 120.0, 88.0)
+        small = _rec("small", "Defender", 4_200_000, 60.0, 30.0)
+        planned = plan_buys([big, small], budget=62_000_000, squad=squad, lineup_map=lineup)
+        assert planned[0].player.id == "big"
+
+    def test_both_still_fit_when_the_budget_allows(self):
+        squad, lineup = _squad()
+        big = _rec("big", "Midfielder", 40_000_000, 120.0, 88.0)
+        small = _rec("small", "Defender", 4_000_000, 60.0, 30.0)
+        planned = plan_buys([big, small], budget=60_000_000, squad=squad, lineup_map=lineup)
+        assert {r.player.id for r in planned[:2]} == {"big", "small"}
+
+    def test_an_unaffordable_candidate_is_kept_but_ranked_last(self):
+        """Nothing is silently dropped — it just cannot be planned for."""
+        squad, lineup = _squad()
+        cheap = _rec("cheap", "Defender", 1_000_000, 60.0, 30.0)
+        huge = _rec("huge", "Midfielder", 500_000_000, 200.0, 150.0)
+        planned = plan_buys([cheap, huge], budget=5_000_000, squad=squad, lineup_map=lineup)
+        assert planned[0].player.id == "cheap"
+        assert planned[-1].player.id == "huge"
+
+
+class TestGainsAreNotAdditive:
+    """Each gain is measured against the current eleven, so they shrink."""
+
+    def test_the_second_signing_is_re_measured_against_the_improved_eleven(self):
+        """One weak starter, so only the FIRST signing gets to replace him."""
+        squad, lineup = _squad(ep=50.0)
+        weakest = next(p for p in squad if p.position == "Midfielder")
+        lineup[weakest.id] = 10.0
+
+        a = _rec("a", "Midfielder", 1_000_000, 90.0, 80.0)
+        b = _rec("b", "Midfielder", 1_000_000, 80.0, 70.0)
+        planned = plan_buys([a, b], budget=10_000_000, squad=squad, lineup_map=lineup)
+
+        first = next(r for r in planned if r.player.id == "a")
+        second = next(r for r in planned if r.player.id == "b")
+        # a replaces the 10.0 starter (+80); b then replaces a 50.0 (+30).
+        assert first.marginal_ep_gain == 80.0
+        assert second.marginal_ep_gain == 30.0
+        assert second.marginal_ep_gain < 70.0
+
+    def test_a_candidate_who_no_longer_improves_the_eleven_is_dropped(self):
+        """An upgrade on the old worst starter can be no upgrade on his replacement."""
+        squad, lineup = _squad(ep=30.0)
+        strong = _rec("strong", "Midfielder", 1_000_000, 100.0, 70.0)
+        weak = _rec("weak", "Midfielder", 1_000_000, 30.0, 0.1)
+        planned = plan_buys([strong, weak], budget=10_000_000, squad=squad, lineup_map=lineup)
+        assert planned[0].player.id == "strong"
+        assert planned[0].marginal_ep_gain > 0
+        # `weak` matches the worst starter exactly, so it adds nothing.
+        assert next(r for r in planned if r.player.id == "weak") is planned[-1]
+
+
+class TestEdges:
+    def test_no_candidates_returns_empty(self):
+        squad, lineup = _squad()
+        assert plan_buys([], budget=10_000_000, squad=squad, lineup_map=lineup) == []
+
+    def test_no_squad_returns_the_input_ranked_rather_than_crashing(self):
+        r = _rec("a", "Midfielder", 1_000_000, 90.0, 60.0)
+        assert plan_buys([r], budget=10_000_000, squad=[], lineup_map={}) == [r]
+
+    def test_zero_budget_plans_nothing_but_keeps_the_candidates(self):
+        squad, lineup = _squad()
+        r = _rec("a", "Midfielder", 1_000_000, 90.0, 60.0)
+        assert plan_buys([r], budget=0, squad=squad, lineup_map=lineup) == [r]
+
+    def test_a_priceless_candidate_is_not_planned(self):
+        """Cost 0 means unknown, not free."""
+        squad, lineup = _squad()
+        r = _rec("a", "Midfielder", 0, 90.0, 60.0)
+        assert plan_buys([r], budget=10_000_000, squad=squad, lineup_map=lineup) == [r]


### PR DESCRIPTION
Closes REH-97.

## The bug

Candidates were ordered by absolute marginal EP gain, which answers *"which one player helps most"* — the wrong question when several are affordable.

Live on 2026-08-24 with €62.2M and four free slots:

```
would propose Kimmich for EUR 60,431,872
Cannot afford Trimmel (EUR 4,337,182 > EUR 1,785,650)
Cannot afford Hansen  (EUR 4,710,845 > EUR 1,785,650)
Cannot afford Medina  (EUR 12,888,180 > EUR 1,785,650)
```

Kimmich returns 1.5 points per €M; Trimmel returns 7.3. The ranking never posed the question.

## Two things that made this harder than sorting by points per euro

Both were found by **running** the fix, not by reasoning about it.

**Marginal gains do not add up.** Each is measured against the current best eleven, so once a signing joins it, the next candidate competes against a better worst starter. Re-measured, the cheap alternatives collapsed:

| player | headline | re-measured |
| --- | --- | --- |
| Trimmel | +30.4 | +30.4 |
| Hansen | +26.1 | **+15.2** |
| Medina | +26.1 | **+11.4** |
| Brown | +35.8 | **+13.0** |

Summing the headline figures would have promised 118 points the squad was never going to deliver. Candidates that stop improving the eleven now drop out of the plan entirely — an upgrade on the old worst starter can be no upgrade on his replacement.

**Greedy-by-ratio can be worse than one big signing.** The first version of this fix did exactly that: it took four cheap players worth **+70.0** re-measured over Kimmich alone at **+88.2** — a strictly worse squad — and would have shipped as an improvement.

## The fix

Build both orderings, re-measuring gains after every pick, and return whichever actually delivers more points. That is the standard knapsack guarantee rather than a heuristic hoping for the best.

On today's market that selects Kimmich — the same answer as before, but now because it was measured against the alternative rather than because it happened to sort first. When the cheap options do add up, it takes them.

## Tests

Two tests in the first draft encoded the same wrong premises as the code: one assumed gains stay constant across signings (they only do when every starter is identical), the other that efficiency always wins. Both were rewritten around cases that actually discriminate — including one asserting a big signing correctly beats a cheap one when the cheap options don't add up, which is the regression the first draft would have introduced.

1,022 passed, 1 skipped; ruff, black and bandit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)