### PR TITLE
Never upload a database we failed to download

### DIFF
--- a/rehoboam/azure_blob.py
+++ b/rehoboam/azure_blob.py
@@ -30,7 +30,23 @@ BACKUP_SUFFIX = ".local-bak"
 FETCH_SIDECAR = ".fetch_state.json"
 
 FetchStatus = Literal["downloaded", "missing_in_blob", "skipped_dry_run", "error"]
-PushStatus = Literal["uploaded", "missing_local", "skipped_dry_run", "error"]
+PushStatus = Literal[
+    "uploaded",
+    "missing_local",
+    "skipped_dry_run",
+    "skipped_fetch_failed",
+    "skipped_shrunk",
+    "error",
+]
+
+# Key under which the sidecar records files whose most recent fetch failed.
+# Not a DB file name, so `check_freshness`'s per-file lookup ignores it.
+FAILED_FETCH_KEY = "_failed_fetch"
+
+# Refuse to overwrite a blob with a local file this much smaller. SQLite files
+# do not shrink by half in normal operation; an empty database replacing a real
+# one does exactly that.
+SHRINK_GUARD_RATIO = 0.5
 
 
 class MissingAzureCredentials(RuntimeError):
@@ -108,6 +124,8 @@ def _get_container(connection_string: str | None, container_name: str):
 def _probe_blob(container, name: str) -> BlobInfo:
     try:
         props = container.get_blob_client(name).get_blob_properties()
+        if props is None:
+            return BlobInfo(name=name, last_modified=None, size=None)
         return BlobInfo(name=name, last_modified=props.last_modified, size=props.size)
     except Exception as e:  # noqa: BLE001
         if "BlobNotFound" in str(e):
@@ -148,6 +166,7 @@ def fetch_state(
     dest_dir.mkdir(parents=True, exist_ok=True)
     results: list[FetchResult] = []
     sidecar_updates: dict[str, str] = {}
+    failed_fetches: list[str] = []
 
     for name in [n for n in DB_FILES if only is None or n in only]:
         blob = _probe_blob(container, name)
@@ -208,17 +227,27 @@ def fetch_state(
                     error=str(e),
                 )
             )
+            failed_fetches.append(name)
             logger.warning("Failed to download %s: %s", name, e)
 
-    if sidecar_updates:
+    if sidecar_updates or failed_fetches or not dry_run:
         sidecar_path = dest_dir / FETCH_SIDECAR
-        existing: dict[str, str] = {}
+        existing: dict = {}
         if sidecar_path.exists():
             try:
                 existing = json.loads(sidecar_path.read_text())
             except (json.JSONDecodeError, OSError):
                 existing = {}
         existing.update(sidecar_updates)
+        # A file that downloaded cleanly this time is no longer suspect; one
+        # that failed is, until a later fetch succeeds. push_state reads this
+        # to avoid uploading a database it never managed to pull.
+        previously = [f for f in existing.get(FAILED_FETCH_KEY, []) if f not in sidecar_updates]
+        still_failed = sorted(set(previously) | set(failed_fetches))
+        if still_failed:
+            existing[FAILED_FETCH_KEY] = still_failed
+        else:
+            existing.pop(FAILED_FETCH_KEY, None)
         sidecar_path.write_text(json.dumps(existing, indent=2, sort_keys=True))
 
     return results
@@ -274,6 +303,19 @@ def check_freshness(
     return stale
 
 
+def _failed_fetches(source_dir: Path) -> list[str]:
+    """DB files whose most recent download failed, per the fetch sidecar."""
+    sidecar_path = source_dir / FETCH_SIDECAR
+    if not sidecar_path.exists():
+        return []
+    try:
+        recorded = json.loads(sidecar_path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return []
+    value = recorded.get(FAILED_FETCH_KEY) or []
+    return [str(v) for v in value] if isinstance(value, list) else []
+
+
 def push_state(
     connection_string: str | None,
     container_name: str,
@@ -304,8 +346,31 @@ def push_state(
     container = _get_container(connection_string, container_name)
     results: list[PushResult] = []
 
+    # Files whose most recent fetch failed. Uploading one would replace real
+    # state with whatever is on local disk — and on a cold container that is a
+    # freshly created, EMPTY database, because BidLearner's CREATE TABLE IF NOT
+    # EXISTS turns a missing file into a valid empty one. push_state would then
+    # report "uploaded", i.e. success, having destroyed the learning history.
+    unfetched = set(_failed_fetches(source_dir))
+
     for name in [n for n in DB_FILES if only is None or n in only]:
         local_path = source_dir / name
+
+        if name in unfetched and not force:
+            logger.error(
+                "Refusing to upload %s: its last download failed, so the local "
+                "copy is not known to be real state",
+                name,
+            )
+            results.append(
+                PushResult(
+                    db_file=name,
+                    local_path=local_path,
+                    local_size=None,
+                    status="skipped_fetch_failed",
+                )
+            )
+            continue
 
         if not local_path.exists():
             results.append(
@@ -330,6 +395,35 @@ def push_state(
                 )
             )
             continue
+
+        # Defence in depth against every other way a truncated file could
+        # reach here (corruption, an interrupted write, a bug upstream).
+        if not force:
+            # A probe failure means the guard has nothing to compare against.
+            # It cannot fire, and refusing every push because one metadata read
+            # failed would be a worse outage than the case it protects.
+            try:
+                blob_size = _probe_blob(container, name).size
+            except Exception:  # noqa: BLE001
+                logger.warning("Could not size %s before upload; shrink guard skipped", name)
+                blob_size = None
+            if blob_size and size < blob_size * SHRINK_GUARD_RATIO:
+                logger.error(
+                    "Refusing to upload %s: local file is %d bytes against a "
+                    "blob of %d — a shrink this large is not normal operation",
+                    name,
+                    size,
+                    blob_size,
+                )
+                results.append(
+                    PushResult(
+                        db_file=name,
+                        local_path=local_path,
+                        local_size=size,
+                        status="skipped_shrunk",
+                    )
+                )
+                continue
 
         try:
             with open(local_path, "rb") as f:

--- a/tests/test_azure_blob.py
+++ b/tests/test_azure_blob.py
@@ -15,6 +15,7 @@ import pytest
 from rehoboam import azure_blob
 from rehoboam.azure_blob import (
     DB_FILES,
+    FAILED_FETCH_KEY,
     FETCH_SIDECAR,
     BlobChangedSinceFetch,
     MissingAzureCredentials,
@@ -230,7 +231,7 @@ def test_push_state_uploads_existing_files(monkeypatch, tmp_path):
     results = push_state("conn", "rehoboam-data", tmp_path)
 
     assert all(r.status == "uploaded" for r in results)
-    assert container.get_blob_client.call_count == len(DB_FILES)
+    assert len([r for r in results if r.status == "uploaded"]) == len(DB_FILES)
 
 
 def test_push_state_skips_missing_local(monkeypatch, tmp_path):
@@ -473,7 +474,7 @@ def test_push_state_only_restricts_to_the_named_files(monkeypatch, tmp_path):
     results = push_state("conn", "rehoboam-data", tmp_path, only={"bid_learning.db"})
 
     assert [r.db_file for r in results] == ["bid_learning.db"]
-    assert container.get_blob_client.call_count == 1
+    assert len([r for r in results if r.status == "uploaded"]) == 1
 
 
 def test_push_state_only_none_is_unchanged(monkeypatch, tmp_path):
@@ -485,7 +486,7 @@ def test_push_state_only_none_is_unchanged(monkeypatch, tmp_path):
     results = push_state("conn", "rehoboam-data", tmp_path, only=None)
 
     assert [r.db_file for r in results] == list(DB_FILES)
-    assert container.get_blob_client.call_count == len(DB_FILES)
+    assert len([r for r in results if r.status == "uploaded"]) == len(DB_FILES)
 
 
 def test_push_state_only_ignores_drift_in_files_it_is_not_pushing(monkeypatch, tmp_path):
@@ -520,3 +521,113 @@ def test_push_state_only_ignores_drift_in_files_it_is_not_pushing(monkeypatch, t
     )
     results = push_state("conn", "rehoboam-data", tmp_path, only={"bid_learning.db"})
     assert [r.db_file for r in results] == ["bid_learning.db"]
+
+
+class TestAFailedDownloadCannotDestroyTheBlob:
+    """REH-94: the chain that silently replaced the learning DB with an empty one.
+
+    fetch_state swallows a per-file download failure. On a cold container there
+    is then no local file, and BidLearner's CREATE TABLE IF NOT EXISTS turns
+    that into a valid EMPTY database. push_state uploaded it and reported
+    "uploaded" — success — having destroyed every learning table.
+    """
+
+    def _container_where_one_download_fails(self, failing: str):
+        ts = datetime(2026, 8, 24, 8, 0, 0, tzinfo=timezone.utc)
+        payload = b"real-data" * 100
+        spec = {n: {"props": _props(ts, len(payload)), "data": payload} for n in DB_FILES}
+        container = _make_container(spec)
+        original = container.get_blob_client
+
+        def _client(name):
+            client = original(name)
+            if name == failing:
+                client.download_blob.side_effect = OSError("transient azure error")
+            return client
+
+        container.get_blob_client = MagicMock(side_effect=_client)
+        return container
+
+    def test_a_failed_download_is_recorded_in_the_sidecar(self, monkeypatch, tmp_path):
+        container = self._container_where_one_download_fails("bid_learning.db")
+        _patch_container(monkeypatch, container)
+
+        fetch_state("conn", "rehoboam-data", tmp_path, backup=False)
+
+        recorded = json.loads((tmp_path / FETCH_SIDECAR).read_text())
+        assert recorded[FAILED_FETCH_KEY] == ["bid_learning.db"]
+
+    def test_push_refuses_to_upload_a_file_it_failed_to_download(self, monkeypatch, tmp_path):
+        container = self._container_where_one_download_fails("bid_learning.db")
+        _patch_container(monkeypatch, container)
+        fetch_state("conn", "rehoboam-data", tmp_path, backup=False)
+
+        # What BidLearner does next: a missing file becomes a valid empty one.
+        (tmp_path / "bid_learning.db").write_bytes(b"empty-db")
+
+        results = push_state("conn", "rehoboam-data", tmp_path)
+        by_file = {r.db_file: r.status for r in results}
+        assert by_file["bid_learning.db"] == "skipped_fetch_failed"
+        assert by_file["value_tracking.db"] == "uploaded"
+
+    def test_a_later_successful_download_clears_the_mark(self, monkeypatch, tmp_path):
+        container = self._container_where_one_download_fails("bid_learning.db")
+        _patch_container(monkeypatch, container)
+        fetch_state("conn", "rehoboam-data", tmp_path, backup=False)
+
+        ts = datetime(2026, 8, 24, 9, 0, 0, tzinfo=timezone.utc)
+        payload = b"real-data" * 100
+        healthy = _make_container(
+            {n: {"props": _props(ts, len(payload)), "data": payload} for n in DB_FILES}
+        )
+        _patch_container(monkeypatch, healthy)
+        fetch_state("conn", "rehoboam-data", tmp_path, backup=False)
+
+        recorded = json.loads((tmp_path / FETCH_SIDECAR).read_text())
+        assert FAILED_FETCH_KEY not in recorded
+
+    def test_force_still_allows_a_deliberate_push(self, monkeypatch, tmp_path):
+        """The escape hatch stays open for an operator who means it."""
+        sidecar = {FAILED_FETCH_KEY: ["bid_learning.db"]}
+        (tmp_path / FETCH_SIDECAR).write_text(json.dumps(sidecar))
+        for n in DB_FILES:
+            (tmp_path / n).write_bytes(b"x" * 4096)
+        ts = datetime(2026, 8, 24, 8, 0, 0, tzinfo=timezone.utc)
+        _patch_container(
+            monkeypatch, _make_container({n: {"props": _props(ts, 4096)} for n in DB_FILES})
+        )
+
+        results = push_state("conn", "rehoboam-data", tmp_path, force=True)
+        assert {r.db_file: r.status for r in results}["bid_learning.db"] == "uploaded"
+
+
+class TestTheShrinkGuard:
+    """Defence in depth: every other route to uploading a truncated file."""
+
+    def _blob_of(self, size):
+        ts = datetime(2026, 8, 24, 8, 0, 0, tzinfo=timezone.utc)
+        return _make_container({n: {"props": _props(ts, size)} for n in DB_FILES})
+
+    def test_a_drastically_smaller_local_file_is_refused(self, monkeypatch, tmp_path):
+        for n in DB_FILES:
+            (tmp_path / n).write_bytes(b"x" * 100)
+        _patch_container(monkeypatch, self._blob_of(1_000_000))
+
+        results = push_state("conn", "rehoboam-data", tmp_path)
+        assert all(r.status == "skipped_shrunk" for r in results)
+
+    def test_normal_growth_and_minor_shrinkage_still_upload(self, monkeypatch, tmp_path):
+        for n in DB_FILES:
+            (tmp_path / n).write_bytes(b"x" * 900)
+        _patch_container(monkeypatch, self._blob_of(1000))
+
+        results = push_state("conn", "rehoboam-data", tmp_path)
+        assert all(r.status == "uploaded" for r in results)
+
+    def test_a_blob_that_does_not_exist_yet_is_not_a_shrink(self, monkeypatch, tmp_path):
+        for n in DB_FILES:
+            (tmp_path / n).write_bytes(b"x" * 10)
+        _patch_container(monkeypatch, _make_container({n: {} for n in DB_FILES}))
+
+        results = push_state("conn", "rehoboam-data", tmp_path)
+        assert all(r.status == "uploaded" for r in results)


### PR DESCRIPTION
Closes REH-94. A partial blob download could silently replace the entire learning history with an empty database — and report success.

Pre-existing, and live twice a day since deployment.

## The chain

1. `fetch_state` swallows a **per-file** download failure — records `status="error"`, logs a warning, does not raise. So `download_databases()` returns normally even when `bid_learning.db` specifically never arrived.
2. On a cold container there is then no local file, and `BidLearner`'s `CREATE TABLE IF NOT EXISTS` turns that into a **valid, empty** database.
3. `check_freshness` cannot object: it skips any file with no sidecar entry, and `fetch_state` only writes sidecar entries for files it downloaded *successfully*.
4. `push_state` uploads the empty file and records `"uploaded"` — success.

Destroyed in the process: `auction_outcomes`, `flip_outcomes`, `matchday_outcomes`, `predicted_eps`, `team_value_history`, `league_rank_history`, `matchday_lineup_results`, `player_mv_history`.

## Two guards, because they fail differently

**Never push what we failed to pull.** `fetch_state` records failed downloads under `FAILED_FETCH_KEY` in the sidecar and clears the mark when a later fetch succeeds. `push_state` refuses anything on that list — a local copy we never managed to pull is not known to be real state. Exact, and targets the known chain.

**Shrink guard**, as defence in depth for every other route to the same outcome (corruption, an interrupted write, a bug upstream). `push_state` refuses to overwrite a blob with a local file under `SHRINK_GUARD_RATIO` of its size. SQLite files do not halve in normal operation; an empty database replacing a real one does exactly that.

Deliberate edge cases:

- a blob that **cannot be sized** skips the check rather than blocking the push — the guard has nothing to compare against, and refusing every upload because one metadata read failed would be a worse outage than the case it protects
- a blob that **does not exist yet** is not a shrink
- **`force` bypasses both**, as it already bypasses the freshness check; an operator who means it keeps the escape hatch

Both new statuses make `learning_db_synced` return `False`, so a refusal reaches the approval webhook as **"NOT SAVED - do not tap again"** rather than passing silently.

## Tests

Seven new tests reproducing the chain end to end — a download that fails, the empty database that replaces it, and the upload that must not happen. Both guards were verified to fail with the check disabled before being restored.

Also re-aimed three existing assertions that counted `get_blob_client` calls as a proxy for uploads. That proxy broke the moment the implementation probed blob sizes; they now assert on the upload outcomes they actually meant.

1,029 passed, 1 skipped; ruff, black and bandit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)