### PR TITLE
Stop a deploy silently disabling trading, and stop the budget cap stripping a must-have's premium

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,3 +71,11 @@ SMTP_PORT=587
 SMTP_USER=
 SMTP_PASSWORD=
 ALERT_EMAIL_TO=
+
+# --- Deployed behaviour (REH-100) ------------------------------------------
+# What the AZURE FUNCTION should do. Deliberately separate from DRY_RUN above,
+# which controls local `rehoboam auto` runs and is safe at true. An infra
+# deploy replaces the whole app-settings collection, so these must be stated
+# explicitly or a deploy silently overwrites production.
+DEPLOY_DRY_RUN=false
+DEPLOY_AGGRESSIVE=true

--- a/deploy/bicep/main.bicepparam
+++ b/deploy/bicep/main.bicepparam
@@ -11,9 +11,19 @@ param tradingFunctionAppName = 'func-rehoboam'
 param externalFunctionAppName = 'func-rehoboam-external'
 
 // App behavior flags.
+//
+// dryRun and aggressiveMode are deliberately NOT set here. The app settings are
+// a declarative Microsoft.Web/sites/config resource, so Bicep replaces the whole
+// collection on every `deploy.sh infra` — a value hard-coded in this file
+// silently overwrites whatever production is actually running.
+//
+// That happened on 2026-08-24: an infra deploy to install Telegram secrets reset
+// DRY_RUN to 'true' on the live bot. It kept starting sessions and reporting
+// success while placing no bids and sending no proposals, which is the worst
+// shape of failure — indistinguishable from a quiet market. deploy.sh now
+// requires DRY_RUN in .env and passes it through, so the deployed value always
+// reflects a stated intent rather than a default nobody looked at.
 param leagueIndex = '0'
-param dryRun = 'true'
-param aggressiveMode = 'true'
 
 // Secrets: OVERRIDE these via CLI -p flags from deploy.sh — never commit real values here.
 // Example: az deployment group create ... -p kickbaseEmail=you@example.com kickbasePassword=secret

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -42,10 +42,22 @@ source_env() {
   fi
 }
 
-# Optional notification channels. Absent means the channel stays disabled —
-# the bot keeps trading, it just cannot tell anyone about it. Passed through
-# to Bicep, which only creates a Key Vault secret when the value is non-empty.
-notify_params() {
+# Everything the Bicep template needs beyond the Kickbase credentials.
+#
+# The notification channels are optional: absent means the channel stays
+# disabled — the bot keeps trading, it just cannot tell anyone about it. Bicep
+# only creates a Key Vault secret when the value is non-empty.
+#
+# DEPLOY_DRY_RUN and DEPLOY_AGGRESSIVE are NOT optional and have no default. App
+# settings are a declarative resource, so every infra deploy replaces the whole
+# collection; a default would silently overwrite whatever production is running.
+#
+# They are deliberately NOT the plain DRY_RUN/AGGRESSIVE that the CLI reads.
+# Those two mean the opposite thing locally: DRY_RUN=true is the safe default
+# for running `rehoboam auto` by hand, and is exactly the value that must NOT
+# reach the deployed bot. Sharing one variable would make a safe local setting
+# silently disable production.
+deploy_params() {
   echo "telegramBotToken=${TELEGRAM_BOT_TOKEN:-}" \
        "telegramChatId=${TELEGRAM_CHAT_ID:-}" \
        "telegramWebhookSecret=${TELEGRAM_WEBHOOK_SECRET:-}" \
@@ -53,13 +65,22 @@ notify_params() {
        "smtpPort=${SMTP_PORT:-587}" \
        "smtpUser=${SMTP_USER:-}" \
        "smtpPassword=${SMTP_PASSWORD:-}" \
-       "alertEmailTo=${ALERT_EMAIL_TO:-}"
+       "alertEmailTo=${ALERT_EMAIL_TO:-}" \
+       "dryRun=${DEPLOY_DRY_RUN}" \
+       "aggressiveMode=${DEPLOY_AGGRESSIVE}"
 }
 
 deploy_infra() {
   source_env
   : "${KICKBASE_EMAIL:?must be set in .env}"
   : "${KICKBASE_PASSWORD:?must be set in .env}"
+  # Required, with no default. An infra deploy rewrites the whole app-settings
+  # collection, so an unset value would silently reset the live bot to
+  # simulation — it keeps running and reporting success while placing no bids.
+  : "${DEPLOY_DRY_RUN:?must be set in .env — an infra deploy overwrites the live value}"
+  : "${DEPLOY_AGGRESSIVE:?must be set in .env — an infra deploy overwrites the live value}"
+
+  echo "==> Deploying with DRY_RUN=$DEPLOY_DRY_RUN AGGRESSIVE=$DEPLOY_AGGRESSIVE"
 
   if [[ "$SUBACTION" == "--what-if" ]]; then
     echo "==> Running Bicep what-if (preview only)..."
@@ -68,7 +89,7 @@ deploy_infra() {
       --template-file "$BICEP_TEMPLATE" \
       --parameters "$BICEP_PARAMS" \
       --parameters kickbaseEmail="$KICKBASE_EMAIL" kickbasePassword="$KICKBASE_PASSWORD" \
-      --parameters $(notify_params)
+      --parameters $(deploy_params)
     return
   fi
 
@@ -81,7 +102,7 @@ deploy_infra() {
     --template-file "$BICEP_TEMPLATE" \
     --parameters "$BICEP_PARAMS" \
     --parameters kickbaseEmail="$KICKBASE_EMAIL" kickbasePassword="$KICKBASE_PASSWORD" \
-    --parameters $(notify_params) \
+    --parameters $(deploy_params) \
     --output table
 }
 

--- a/rehoboam/bidding_strategy.py
+++ b/rehoboam/bidding_strategy.py
@@ -413,8 +413,22 @@ class SmartBidding:
         recommended_bid = asking_price + overbid_amount
 
         # EP-proportional max: floor at asking_price so we never refuse an
-        # affordable player just because their price exceeds the fraction threshold.
-        ep_max_bid = max(ep_max_bid, asking_price)
+        # affordable player just because their price exceeds the fraction
+        # threshold — and include the premium, or the floor silently strips it.
+        #
+        # Kimmich, 2026-08-24: gain +88.2 cleared BID_FULL_COMMIT_GAIN so the
+        # ramp returned its maximum 0.8, but 0.8 x EUR 62.2M = EUR 49.8M sits
+        # BELOW his EUR 59.8M asking price. Flooring at the asking price alone
+        # left no overbid room at all, so the only thing lifting the bid was the
+        # market-value floor: our single most-wanted player, tier must_have, got
+        # a 1% bid that any rival beats with 2%. The more a player is worth to
+        # us relative to the budget, the weaker the bid became — the reverse of
+        # what the tiers exist to express.
+        #
+        # The fraction decides how much of the war chest a gain justifies, and
+        # `budget_ceiling` below still caps the total. It should not also decide
+        # whether we may pay a premium on a player we have already committed to.
+        ep_max_bid = max(ep_max_bid, asking_price + overbid_amount)
 
         # Hard cap at EP-proportional max and hard budget ceiling
         recommended_bid = min(recommended_bid, ep_max_bid, budget_ceiling)

--- a/tests/test_ep_bidding.py
+++ b/tests/test_ep_bidding.py
@@ -431,3 +431,49 @@ class TestAggressiveCompetitorsHelper:
             conn.commit()
 
         assert learner.has_aggressive_competitors() is True
+
+
+class TestAnExpensivePlayerStillGetsHisPremium:
+    """The EP-proportional cap must not strip the overbid off a must-have.
+
+    Kimmich, 2026-08-24: gain +88.2 cleared BID_FULL_COMMIT_GAIN so the ramp
+    returned its maximum 0.8 — but 0.8 x EUR 62.2M is EUR 49.8M, BELOW his
+    EUR 59.8M asking price. Flooring the ceiling at the asking price alone left
+    no room for a premium, so the only thing lifting the bid was the
+    market-value floor: a 1% bid on our single most-wanted player, which any
+    rival beats with 2%.
+    """
+
+    def _bid(self, asking, budget, gain=88.2):
+        from rehoboam.bidding_strategy import SmartBidding
+
+        return (
+            SmartBidding()
+            .calculate_ep_bid(
+                asking_price=asking,
+                market_value=asking,
+                expected_points=120.0,
+                marginal_ep_gain=gain,
+                confidence=0.70,
+                current_budget=budget,
+                player_id="1685",
+            )
+            .recommended_bid
+        )
+
+    def test_a_must_have_priced_above_the_ep_cap_still_bids_a_premium(self):
+        bid = self._bid(asking=59_833_537, budget=62_217_522)
+        assert bid > int(59_833_537 * 1.01), "stuck on the market-value floor"
+
+    def test_the_premium_is_still_capped_by_the_budget(self):
+        budget = 62_217_522
+        assert self._bid(asking=59_833_537, budget=budget) <= budget
+
+    def test_a_cheap_player_is_unaffected(self):
+        """Only players expensive relative to the budget were being squeezed."""
+        cheap = self._bid(asking=4_177_182, budget=62_217_522, gain=30.4)
+        assert cheap > int(4_177_182 * 1.05)
+
+    def test_an_unaffordable_player_is_still_refused(self):
+        """The budget ceiling remains a hard limit, not a suggestion."""
+        assert self._bid(asking=90_000_000, budget=62_217_522) == 0


### PR DESCRIPTION
Two production bugs found by the bot doing nothing last night.

## 1. An infra deploy silently disabled live trading

Running `deploy.sh infra` yesterday to install the Telegram secrets reset `DRY_RUN` to `'true'` on the live bot. App settings are a declarative `Microsoft.Web/sites/config` resource, so Bicep replaces the **whole collection** every time — and `main.bicepparam` hard-coded `param dryRun = 'true'`.

The failure shape is the bad one: the bot kept waking on schedule, kept building a session, kept reporting success — and placed no bids and sent no proposals. Indistinguishable from a quiet market. It went unnoticed for two scheduled runs.

The behaviour flags are no longer defaulted anywhere. `deploy.sh` requires them in `.env`, prints what it is about to deploy, and refuses to run without them.

They are deliberately **not** the plain `DRY_RUN`/`AGGRESSIVE` the CLI reads. Those mean the opposite thing locally: `DRY_RUN=true` is the safe default for running `rehoboam auto` by hand, and is exactly the value that must never reach the deployed bot. The first version of this fix sourced `DRY_RUN` straight from `.env` and would have re-disabled production on the next deploy. Deployment now reads `DEPLOY_DRY_RUN` / `DEPLOY_AGGRESSIVE`.

Verified: `--what-if` refuses when unset, and renders `'DRY_RUN', 'false'` when set.

## 2. The players we want most were getting our weakest bids

`max_bid_fraction` decides how much of the war chest a marginal gain justifies. The result was floored at the asking price so an affordable player is never refused for costing more than the fraction allows — but the floor was the asking price **alone**, which silently removed all overbid room.

Kimmich: gain +88.2 cleared `BID_FULL_COMMIT_GAIN` (82.0), so the ramp returned its maximum 0.8 — and 0.8 × €62.2M is €49.8M, **below** his €59.8M asking price. The premium was cut to nothing and only the market-value floor lifted the bid, giving exactly `MV × 1.01`. Tier `must_have`, top of the measured distribution, and a **1% bid that any rival beats with 2%**.

The relationship was inverted: the more a player was worth to us relative to the budget, the weaker our bid. Under the approval gate that is worse than a lost auction — it spends one of the owner's approvals on a bid that was never going to win.

The floor now includes the premium. The fraction still decides how much of the budget a gain justifies, and `budget_ceiling` still caps the total; it simply no longer decides whether we may pay a premium on a player we have already committed to.

Live effect — Kimmich **1.0% → 4.0%**, or 12.0% with a sell plan behind it. Trimmel at +30.4 unchanged at 9.6%: cheap players were never squeezed, only expensive must-haves.

Verified failing against the old floor at exactly `int(59833537 * 1.01)`.

1,039 passed, 1 skipped; ruff, black and bandit clean. Production was corrected separately and a session run manually to confirm recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)