### PR TITLE
Flip-buy only rising players, and never above market value

### DIFF
--- a/rehoboam/config.py
+++ b/rehoboam/config.py
@@ -189,6 +189,33 @@ class Settings(BaseSettings):
             "least mid-table'. Pre-season estimate awaiting live-market validation."
         ),
     )
+    max_flip_overpay_pct: float = Field(
+        default=1.0,
+        ge=0.0,
+        description=(
+            "Most a flip buy may pay above the player's market value, as a "
+            "percentage. A flip is bought to be sold, so anything paid over "
+            "market value has to be earned back before the trade breaks even. "
+            "Measured over 151 real flips the strategy lost EUR 55.3M at a 28% "
+            "win rate, and the losses concentrated in the larger trades "
+            "(EUR -67.1M over the 84 flips of EUR 5M or more). Buying at or "
+            "near market value removes the part of that loss which was simply "
+            "overpaying at entry."
+        ),
+    )
+    flip_buys_require_rising_trend: bool = Field(
+        default=True,
+        description=(
+            "Only flip-buy a player whose market value is already rising. The "
+            "alternative branches were all bets on mean reversion — a stable "
+            "performer, a dip inside an uptrend, a recovery signal, or a "
+            "high-quality player more than 25% below peak. Each is a "
+            "prediction that the market is wrong, and across 151 flips those "
+            "predictions lost money. A rising trend is the one case where the "
+            "market is already moving our way and the trade needs no "
+            "contrarian call to work."
+        ),
+    )
     min_ep_upgrade_threshold: float = Field(
         default=25.0,
         description=(

--- a/rehoboam/diagnostics/flip_branches.py
+++ b/rehoboam/diagnostics/flip_branches.py
@@ -161,6 +161,10 @@ def shipped_opportunity(
         min_profit_pct=FLIP_MIN_PROFIT_PCT,
         max_hold_days=FLIP_MAX_HOLD_DAYS,
         max_risk_score=max_risk_score,
+        # Mirrors the full shipped ladder, including the mean-reversion
+        # branches the live path now skips by default — a diagnostic that
+        # silently lost branches would stop explaining past decisions.
+        require_rising_trend=False,
     )
     player = CorpusMarketPlayer(
         id="reconcile",

--- a/rehoboam/profit_trader.py
+++ b/rehoboam/profit_trader.py
@@ -42,17 +42,33 @@ class ProfitTrader:
     """Find and execute profit trading opportunities"""
 
     def __init__(
-        self, min_profit_pct: float = 10.0, max_hold_days: int = 7, max_risk_score: float = 50.0
+        self,
+        min_profit_pct: float = 10.0,
+        max_hold_days: int = 7,
+        max_risk_score: float = 50.0,
+        max_overpay_pct: float = 1.0,
+        require_rising_trend: bool = True,
     ):
         """
         Args:
             min_profit_pct: Minimum profit percentage to consider
             max_hold_days: Maximum days to hold before selling
             max_risk_score: Maximum risk score (0-100)
+            max_overpay_pct: Most a flip may pay above market value. A flip is
+                bought to be sold, so any premium at entry has to be earned
+                back before the trade breaks even.
+            require_rising_trend: Only flip a player whose value is already
+                rising, rather than betting on mean reversion.
         """
         self.min_profit_pct = min_profit_pct
         self.max_hold_days = max_hold_days
         self.max_risk_score = max_risk_score
+        self.max_overpay_pct = max_overpay_pct
+        self.require_rising_trend = require_rising_trend
+
+    def _max_flip_price(self, player) -> int:
+        """Ceiling on what a flip may pay: market value plus the allowed premium."""
+        return int(player.market_value * (1.0 + self.max_overpay_pct / 100.0))
 
     def find_profit_opportunities(
         self,
@@ -82,6 +98,7 @@ class ProfitTrader:
         healthy = 0
         affordable = 0
         has_trend_data = 0
+        not_rising_filtered = 0
         meets_threshold = 0
         small_sample_filtered = 0
 
@@ -153,6 +170,14 @@ class ProfitTrader:
                 if trend_direction == "rising" and trend_pct > 5:
                     # Expect trend to continue (cap at 20%)
                     expected_appreciation = min(trend_pct, 20)
+                elif self.require_rising_trend:
+                    # Every branch below is a bet that the market is wrong —
+                    # mean reversion on a dip, a recovery, a stable performer,
+                    # or a fallen high-scorer. Across 151 real flips those bets
+                    # lost EUR 55.3M at a 28% win rate. A rising trend is the
+                    # one case where the market is already moving our way.
+                    not_rising_filtered += 1
+                    continue
                 elif is_recovery and player.average_points >= 30:
                     # Recovery signal: short-term reversal after dip → catch the bounce
                     expected_appreciation = 12
@@ -262,7 +287,7 @@ class ProfitTrader:
             opportunities.append(
                 ProfitOpportunity(
                     player=player,
-                    buy_price=player.price,
+                    buy_price=min(player.price, self._max_flip_price(player)),
                     market_value=player.market_value,
                     value_gap=value_gap,
                     value_gap_pct=value_gap_pct,

--- a/rehoboam/replay/flip_buys.py
+++ b/rehoboam/replay/flip_buys.py
@@ -207,6 +207,9 @@ def make_flip_buy_fn(
         min_profit_pct=FLIP_MIN_PROFIT_PCT,
         max_hold_days=FLIP_MAX_HOLD_DAYS,
         max_risk_score=FLIP_MAX_RISK_SCORE,
+        # The replay reconstructs historical behaviour, which included the
+        # mean-reversion branches. Gating them here would rewrite history.
+        require_rising_trend=False,
     )
     max_debt_pct = shipped_max_debt_pct()
 

--- a/rehoboam/trader.py
+++ b/rehoboam/trader.py
@@ -801,6 +801,8 @@ class Trader:
             min_profit_pct=8.0,
             max_hold_days=7,
             max_risk_score=60.0,
+            max_overpay_pct=self.settings.max_flip_overpay_pct,
+            require_rising_trend=self.settings.flip_buys_require_rising_trend,
         )
 
         max_opps = 5 if flip_budget < current_budget else 10

--- a/tests/test_flip_entry_rules.py
+++ b/tests/test_flip_entry_rules.py
@@ -1,0 +1,122 @@
+"""Flip buys: rising trends only, and never far above market value.
+
+A flip is bought to be sold, so any premium at entry must be earned back
+before the trade breaks even. Across 151 real flips the strategy lost
+EUR 55.3M at a 28% win rate.
+"""
+
+from types import SimpleNamespace
+
+from rehoboam.config import Settings
+from rehoboam.profit_trader import ProfitTrader
+
+
+def _player(price, mv, avg=50.0):
+    return SimpleNamespace(
+        id="1",
+        first_name="A",
+        last_name="B",
+        position="Midfielder",
+        price=price,
+        market_value=mv,
+        average_points=avg,
+        team_id="40",
+        status=0,
+        points=0,
+        user_offer_id=None,
+        user_offer_price=0,
+    )
+
+
+def _trend(direction, pct, **extra):
+    base = {
+        "has_data": True,
+        "trend": direction,
+        "trend_pct": pct,
+        "current_value": 1_000_000,
+        "peak_value": 1_000_000,
+        "is_dip_in_uptrend": False,
+        "is_secular_decline": False,
+        "is_recovery": False,
+    }
+    base.update(extra)
+    return base
+
+
+def _find(trader, player, trend):
+    return trader.find_profit_opportunities(
+        market_players=[player],
+        current_budget=50_000_000,
+        player_trends={player.id: trend},
+        max_opportunities=5,
+    )
+
+
+class TestRisingOnly:
+    def test_a_rising_player_is_a_candidate(self):
+        t = ProfitTrader(min_profit_pct=5.0)
+        assert _find(t, _player(1_000_000, 1_000_000), _trend("rising", 12.0))
+
+    def test_a_falling_player_is_not(self):
+        t = ProfitTrader(min_profit_pct=5.0)
+        assert (
+            _find(t, _player(1_000_000, 1_000_000), _trend("falling", -30.0, peak_value=2_000_000))
+            == []
+        )
+
+    def test_a_stable_player_is_not(self):
+        """Stable was a bet on modest drift, not on momentum."""
+        t = ProfitTrader(min_profit_pct=5.0)
+        assert _find(t, _player(1_000_000, 1_000_000, avg=60.0), _trend("stable", 0.0)) == []
+
+    def test_a_dip_in_an_uptrend_is_not(self):
+        """Mean reversion is a prediction the market is wrong."""
+        t = ProfitTrader(min_profit_pct=5.0)
+        assert (
+            _find(t, _player(1_000_000, 1_000_000), _trend("falling", -8.0, is_dip_in_uptrend=True))
+            == []
+        )
+
+    def test_the_mean_reversion_branches_still_work_when_opted_in(self):
+        """They are disabled, not deleted — the replay still needs them."""
+        t = ProfitTrader(min_profit_pct=5.0, require_rising_trend=False)
+        assert _find(t, _player(1_000_000, 1_000_000, avg=60.0), _trend("stable", 0.0))
+
+
+class TestTheEntryPriceIsCapped:
+    """A guard rather than a routine clamp.
+
+    Flips only consider Kickbase-listed players, and for those the asking
+    price IS the market value — `is_kickbase` is literally
+    `price == market_value`. So the live path already buys at market value and
+    the cap never binds. It exists so that a listing priced above market value
+    can never be flipped at a premium, whatever route it arrives by: a flip is
+    bought to be sold, so any premium has to be earned back before the trade
+    breaks even.
+    """
+
+    def test_the_ceiling_is_market_value_plus_the_allowed_premium(self):
+        t = ProfitTrader(max_overpay_pct=1.0)
+        assert t._max_flip_price(_player(1_000_000, 1_000_000)) == 1_010_000
+
+    def test_zero_percent_means_never_above_market_value(self):
+        t = ProfitTrader(max_overpay_pct=0.0)
+        assert t._max_flip_price(_player(1_000_000, 1_000_000)) == 1_000_000
+
+    def test_a_kickbase_listing_is_bought_at_market_value(self):
+        """The normal case: asking price equals market value, so nothing clamps."""
+        t = ProfitTrader(min_profit_pct=5.0)
+        opps = _find(t, _player(1_000_000, 1_000_000), _trend("rising", 12.0))
+        assert opps[0].buy_price == 1_000_000
+
+    def test_the_cap_binds_if_a_listing_is_ever_priced_above_market_value(self):
+        t = ProfitTrader(min_profit_pct=5.0)
+        player = _player(1_000_000, 1_000_000)
+        assert min(1_200_000, t._max_flip_price(player)) == 1_010_000
+
+
+class TestDefaults:
+    def test_the_shipped_settings_are_one_percent_and_rising_only(self):
+        s = Settings()
+        assert s.max_flip_overpay_pct == 1.0
+        assert s.flip_buys_require_rising_trend is True

--- a/tests/test_profit_dip_buying.py
+++ b/tests/test_profit_dip_buying.py
@@ -1,6 +1,11 @@
 """Tests for dip-buying logic in ProfitTrader.find_profit_opportunities()
 and the matchday hold-time cap in auto_trader._max_flip_hold_days().
-"""
+
+
+NOTE: these cover the mean-reversion branches (dip-in-uptrend, recovery,
+stable, below-peak), which are opt-in since flip buying was restricted to
+rising trends by default. They pass require_rising_trend=False to reach the
+behaviour under test; the default path deliberately skips all of it."""
 
 from rehoboam.auto_trader import _max_flip_hold_days
 from rehoboam.kickbase_client import MarketPlayer
@@ -50,7 +55,7 @@ class TestDipInUptrendBuy:
     def test_dip_in_uptrend_creates_opportunity(self):
         """A short-term dip in a longer uptrend → flip candidate."""
         player = _make_player(average_points=35.0)
-        trader = ProfitTrader()
+        trader = ProfitTrader(require_rising_trend=False)
         opps = trader.find_profit_opportunities(
             market_players=[player],
             current_budget=20_000_000,
@@ -65,7 +70,7 @@ class TestDipInUptrendBuy:
     def test_dip_in_uptrend_requires_decent_avg_points(self):
         """Sub-30 avg points → dip-in-uptrend not enough; skip."""
         player = _make_player(average_points=15.0)
-        trader = ProfitTrader()
+        trader = ProfitTrader(require_rising_trend=False)
         opps = trader.find_profit_opportunities(
             market_players=[player],
             current_budget=20_000_000,
@@ -80,7 +85,7 @@ class TestDipInUptrendBuy:
     def test_recovery_signal_triggers_buy(self):
         """Recovery (short-term up after dip) → flip candidate."""
         player = _make_player(average_points=32.0)
-        trader = ProfitTrader()
+        trader = ProfitTrader(require_rising_trend=False)
         opps = trader.find_profit_opportunities(
             market_players=[player],
             current_budget=20_000_000,
@@ -97,7 +102,7 @@ class TestSecularDeclineBlocked:
         """A falling player flagged as secular decline should NOT be a flip candidate
         even if they're far below peak."""
         player = _make_player(average_points=50.0)
-        trader = ProfitTrader()
+        trader = ProfitTrader(require_rising_trend=False)
         opps = trader.find_profit_opportunities(
             market_players=[player],
             current_budget=20_000_000,
@@ -121,7 +126,7 @@ class TestLowerDipThreshold:
         with high avg_points qualifies as a mean-reversion play. (Old code
         only triggered below -50%.)"""
         player = _make_player(price=4_000_000, market_value=4_000_000, average_points=50.0)
-        trader = ProfitTrader()
+        trader = ProfitTrader(require_rising_trend=False)
         opps = trader.find_profit_opportunities(
             market_players=[player],
             current_budget=20_000_000,
@@ -141,7 +146,7 @@ class TestLowerDipThreshold:
         """Far below peak BUT secular decline → still skipped (regression
         check that the new is_secular_decline gate fires)."""
         player = _make_player(price=4_000_000, market_value=4_000_000, average_points=50.0)
-        trader = ProfitTrader()
+        trader = ProfitTrader(require_rising_trend=False)
         opps = trader.find_profit_opportunities(
             market_players=[player],
             current_budget=20_000_000,


### PR DESCRIPTION
Flip buying accepted five entry patterns. Only one — a rising trend — was a bet that the market was already moving our way. The other four were predictions that the market is **wrong**:

- a stable performer drifting up
- a dip inside an uptrend
- a recovery signal
- a high-quality player more than 25% below peak

Measured over the 151 real flips in `flip_outcomes`:

| | flips | total |
| --- | --- | --- |
| **All** | 151 | **−€55.3M** |
| Losses | 109 | −€133.9M |
| Wins | 42 | +€78.7M |

A **28% win rate**, −€0.37M average. The damage concentrates in the larger trades: restricted to buys of €5M or more it is worse still, **−€67.1M over 84 flips**.

Two things weaken the strategy further in 26/27. Head-to-head rewards points, not money. And the 19.12 hard reset wipes budget and squads, so profit banked before then cannot be carried — it is now saving into an account that gets emptied in December.

## Changes

Flip buying now requires a rising trend by default.

The mean-reversion branches are **disabled, not deleted**: `flip_branches` mirrors the shipped ladder to explain past decisions, and `replay/flip_buys` reconstructs historical behaviour. Gating those would rewrite the history they exist to report, so both opt out explicitly.

Entry price is capped at market value plus `max_flip_overpay_pct`, defaulting to 1%. This is a **guard rather than a routine clamp**, and the reason is worth recording: flips only consider Kickbase-listed players, and for those `is_kickbase` is literally `price == market_value` — so the live path already buys at market value and the cap never binds today. It exists so a listing priced above market value can never be flipped at a premium, because a flip is bought to be sold and any premium must be earned back before breaking even.

Both are `Settings` fields, re-tunable from `.env` mid-season without a deploy.

Six existing tests covered the mean-reversion branches; they now pass `require_rising_trend=False` to reach the behaviour they test, with a note saying why.

1,045 passed, 1 skipped; ruff, black and bandit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)