### PR TITLE
Implement the league Top-5 forced sale, and correct the REH-95 record

### DIFF
--- a/rehoboam/auto_trader.py
+++ b/rehoboam/auto_trader.py
@@ -434,6 +434,66 @@ class AutoTrader:
         )
         return True
 
+    def _settle_top5_obligation(self, league, ctx) -> None:
+        """Discharge the league's Top-5 forced sale for the last finished matchday.
+
+        The pool is chosen by what players scored THAT matchday; which of them
+        to give up is chosen by expected points from here on. A one-off big
+        score is the cheapest thing to lose, and first place has no choice at
+        all — see `rehoboam.top5`.
+        """
+        from . import top5
+
+        last_finished = self._last_finished_matchday(league)
+        if last_finished is None:
+            return
+
+        forward_ep = {
+            str(s.player_id): float(s.expected_points)
+            for s in (ctx.ep_result.get("squad_scores") or [])
+        }
+        sale = top5.settle(
+            api=self.api,
+            league=league,
+            learner=self.learner,
+            squad=list(ctx.squad or []),
+            forward_ep=forward_ep,
+            matchday=last_finished,
+            dry_run=self.dry_run,
+        )
+        if sale is None:
+            return
+        verb = "would sell" if self.dry_run else "sold"
+        console.print(
+            f"[yellow]Top-5 rule: finished {sale.place} on matchday "
+            f"{last_finished} — {verb} {sale.chosen_name} ({sale.reason})[/yellow]"
+        )
+
+    def _last_finished_matchday(self, league) -> int | None:
+        """The most recent matchday whose window has closed, or None.
+
+        Read from the H2H fixture list, which carries each matchday's end time.
+        """
+        from datetime import datetime, timezone
+
+        from .h2h import _parse_iso
+
+        try:
+            payload = self.api.client.session.get(
+                f"{self.api.client.BASE_URL}/v4/leagues/{league.id}/matchups"
+            ).json()
+        except Exception:
+            logger.warning("top5: could not read the fixture list", exc_info=True)
+            return None
+
+        now = datetime.now(timezone.utc)
+        finished = [
+            int(md.get("day") or 0)
+            for md in payload.get("mds") or []
+            if (ends := _parse_iso(md.get("ed"))) is not None and ends < now
+        ]
+        return max(finished) if finished else None
+
     def _has_pending_proposal(
         self,
         player_id: str,
@@ -1432,6 +1492,17 @@ class AutoTrader:
             self.tracker.reconcile_finished_matchdays(ctx.squad, squad_perf)
         except Exception:
             logger.exception("reconcile_finished_matchdays failed (non-fatal)")
+
+        # League Top-5 rule: finishing in the top five of a matchday obliges us
+        # to give up one of our best performers from it. Settled here, right
+        # after the matchday is reconciled, because the obligation only exists
+        # once a matchday has actually finished — and settled at most once per
+        # matchday, which `record_forced_sale` enforces on the database rather
+        # than on this call site.
+        try:
+            self._settle_top5_obligation(league, ctx)
+        except Exception:
+            logger.exception("top5 settlement failed (non-fatal)")
         try:
             squad_scores = ctx.ep_result.get("squad_scores") or []
             lineup_map = ctx.ep_result.get("lineup_map") or {}

--- a/rehoboam/bid_learner.py
+++ b/rehoboam/bid_learner.py
@@ -2,6 +2,7 @@
 
 import json
 import sqlite3
+import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -518,6 +519,21 @@ class BidLearner:
                 ON manager_transfers(manager_id, transfer_dt)
             """
             )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS forced_sales (
+                    matchday INTEGER PRIMARY KEY,
+                    place INTEGER NOT NULL,
+                    player_id TEXT NOT NULL,
+                    player_name TEXT NOT NULL,
+                    pool TEXT NOT NULL,
+                    reason TEXT NOT NULL,
+                    executed INTEGER NOT NULL,
+                    settled_at REAL NOT NULL
+                )
+                """
+            )
+
             conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS trade_proposals (
@@ -1695,6 +1711,50 @@ class BidLearner:
                 "UPDATE trade_proposals SET status = ? WHERE proposal_id = ?",
                 (status, proposal_id),
             )
+
+    def record_forced_sale(
+        self,
+        *,
+        matchday: int,
+        place: int,
+        player_id: str,
+        player_name: str,
+        pool: str,
+        reason: str,
+        executed: bool,
+    ) -> bool:
+        """Log a Top-5 forced sale. False if this matchday was already settled.
+
+        The matchday is the primary key, so a second call for the same one is
+        refused rather than selling a second player — the rule takes exactly
+        one player per matchday, and a re-run of the session must not compound
+        it.
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.execute(
+                "INSERT OR IGNORE INTO forced_sales "
+                "(matchday, place, player_id, player_name, pool, reason, executed, settled_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    int(matchday),
+                    int(place),
+                    str(player_id),
+                    player_name,
+                    pool,
+                    reason,
+                    1 if executed else 0,
+                    time.time(),
+                ),
+            )
+            return cur.rowcount > 0
+
+    def forced_sale_settled(self, matchday: int) -> bool:
+        """Has the Top-5 obligation for this matchday already been discharged?"""
+        with sqlite3.connect(self.db_path) as conn:
+            row = conn.execute(
+                "SELECT 1 FROM forced_sales WHERE matchday = ?", (int(matchday),)
+            ).fetchone()
+        return row is not None
 
     def proposals_for_player(self, player_id: str) -> list[dict]:
         """Every proposal ever made for this player, newest first."""

--- a/rehoboam/kickbase_client.py
+++ b/rehoboam/kickbase_client.py
@@ -65,7 +65,9 @@ class MarketPlayer:
     seller_user_id: str | None = None  # None if KICKBASE is selling
     offer_count: int = 0  # Number of offers on player
     user_offer_price: int | None = None  # Your bid amount if you made one
-    user_offer_id: str | None = None  # Your offer ID (needed to cancel bid)
+    user_offer_id: str | None = None  # `uoid`: USER id of the offer holder,
+    # present only on listings we have bid on. Not an offer id, despite
+    # cancel_offer passing it as {offer_id} — see has_user_offer (REH-95).
     listed_at: str | None = None  # When player was listed (ISO datetime)
     offers: list = None  # List of all offers
 
@@ -102,19 +104,26 @@ class MarketPlayer:
     def has_user_offer(self) -> bool:
         """Do WE currently hold an offer on this player?
 
-        ``uoid`` is an OFFER id, not a user id: it is the path segment
-        ``cancel_offer`` deletes at
-        ``/market/{player_id}/offers/{offer_id}``. The previous version
-        compared it against the requesting user's id, which can never match,
-        so ``get_my_bids`` always returned an empty list. Everything that
-        depends on it silently did nothing — ``pending_bid_total`` never
-        reduced the flip budget, ``available_slots`` never counted an open
-        bid, and the "already bidding on this player" guard never fired.
+        ``uoid`` is a USER id — the id of the manager holding the offer.
+        Observed on a real listing 2026-08-25, with our own bid live::
 
-        Kickbase only includes the field on a listing WE have bid on, so its
-        presence is the signal. Note this errs safe in a way the old check did
-        not: over-reporting an open bid makes the bot more conservative about
-        budget and slots, while under-reporting let it overspend.
+            "uoid": "3616202",                        # our user id
+            "ofs": [{"u": "3616202", "uoid": "3616202", "uop": 60447397}]
+
+        REH-95 claimed the opposite: that ``uoid`` was an OFFER id, inferred
+        from ``cancel_offer`` passing it as ``{offer_id}`` in the delete path
+        and from a stale comment on this dataclass. That inference was wrong.
+        The equality check it replaced worked correctly, ``get_my_bids`` was
+        never returning an empty list, and the guards built on it —
+        ``pending_bid_total``, ``available_slots``, the already-bidding check —
+        were all functioning. Cancellation also works passing this value, so
+        that path was never broken either.
+
+        Presence is kept over equality because Kickbase only includes the field
+        on a listing we have bid on, so the two agree, and presence keeps
+        working if the value ever changes shape. It also errs safe: reporting
+        an open bid we do not have makes the bot more conservative about budget
+        and slots, whereas missing one would let it overspend.
         """
         return self.user_offer_id is not None
 

--- a/rehoboam/top5.py
+++ b/rehoboam/top5.py
@@ -1,0 +1,279 @@
+"""The league's Top-5 rule: finishing well costs you a player.
+
+House rule for 26/27, applied after every matchday:
+
+    1. the matchday winner sells his best-scoring player of that matchday
+    2. second sells one of his top 2 of that matchday
+    3. third sells one of his top 3
+    4. fourth sells one of his top 4
+    5. fifth sells one of his top 5
+
+Sixth and below owe nothing. So the obligation is: *finish Nth, and you must
+give up one of your N best performers from that matchday*.
+
+Two consequences shape this module.
+
+**The pool is ranked by that matchday's points, but the choice should not be.**
+A player who scored 90 once and is a reliable 30 every week costs less to lose
+than one who scored 85 and is a reliable 80. Which to sell is a question about
+FUTURE value, so the pool is selected on matchday points and the sale is chosen
+on expected points. Only the winner has no choice at all — his pool is a single
+player.
+
+**Rank determines freedom.** Finishing first is the most expensive outcome in
+the league: it takes your best performer with no say in the matter. Finishing
+fifth costs you the weakest of five candidates. That is worth knowing before
+optimising a lineup for a big score.
+
+The rule itself is pure — it takes standings and points a caller has already
+fetched and returns a decision. Everything that touches the API or sells a
+player lives below the divider at the bottom of the file, so the part that
+decides can be tested without the part that acts.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+# Places that owe a sale, and how many of your top performers are eligible.
+# Index is the finishing place, value is the pool size — they happen to be
+# equal, which is the whole rule in one line.
+MAX_PLACE_WITH_OBLIGATION = 5
+
+
+@dataclass(frozen=True)
+class ForcedSale:
+    """What the rule requires of us this matchday."""
+
+    place: int
+    pool: list[str]
+    chosen: str
+    chosen_name: str
+    reason: str
+
+    @property
+    def had_a_choice(self) -> bool:
+        """First place has none: the pool is exactly his best scorer."""
+        return len(self.pool) > 1
+
+
+def matchday_place(standings: list[dict], my_id: str) -> int | None:
+    """Our 1-based finishing place for a matchday, or None if we are absent.
+
+    ``standings`` is the ranking payload's manager list for one matchday, each
+    entry carrying an id and that matchday's points. Ties are broken by keeping
+    the API's own order, which is what the league sees.
+    """
+    ranked = sorted(
+        standings,
+        key=lambda m: -float(m.get("sp") or 0.0),
+    )
+    for index, manager in enumerate(ranked, start=1):
+        if str(manager.get("i")) == str(my_id):
+            return index
+    return None
+
+
+def eligible_pool(place: int, player_points: dict[str, float]) -> list[str]:
+    """The players the rule lets us choose from, best scorer first.
+
+    Nth place may sell any of his top N performers. Outside the top five the
+    pool is empty — nothing is owed.
+    """
+    if place < 1 or place > MAX_PLACE_WITH_OBLIGATION:
+        return []
+    ordered = sorted(player_points, key=lambda pid: -player_points[pid])
+    return ordered[:place]
+
+
+def choose_least_damaging(
+    pool: list[str],
+    forward_ep: dict[str, float],
+    names: dict[str, str] | None = None,
+) -> tuple[str, str] | None:
+    """Which of the eligible players to give up, and why.
+
+    Chosen on expected points from here on, NOT on what he scored that
+    matchday: the rule takes a player away, and what it costs us is everything
+    he would have contributed afterwards. A one-off big score is the cheapest
+    thing to lose.
+
+    A player missing from ``forward_ep`` is treated as worth 0.0 going forward,
+    so an unscored player is given up before a scored one. That is deliberate —
+    we should not keep a player we cannot evaluate ahead of one we can.
+    """
+    if not pool:
+        return None
+    names = names or {}
+    chosen = min(pool, key=lambda pid: forward_ep.get(pid, 0.0))
+    chosen_ep = forward_ep.get(chosen, 0.0)
+
+    if len(pool) == 1:
+        reason = f"first place — no choice, {names.get(chosen, chosen)} is the pool"
+    else:
+        kept = [p for p in pool if p != chosen]
+        best_kept = max((forward_ep.get(p, 0.0) for p in kept), default=0.0)
+        reason = (
+            f"lowest expected points of {len(pool)} eligible "
+            f"({chosen_ep:.1f} vs {best_kept:.1f} for the best we keep)"
+        )
+    return chosen, reason
+
+
+def forced_sale(
+    *,
+    standings: list[dict],
+    my_id: str,
+    matchday_points: dict[str, float],
+    forward_ep: dict[str, float],
+    names: dict[str, str] | None = None,
+) -> ForcedSale | None:
+    """The whole rule. None when we finished outside the top five.
+
+    ``matchday_points`` is what OUR players scored that matchday; it selects
+    the pool. ``forward_ep`` is what they are worth from here; it picks the
+    sale out of that pool.
+    """
+    place = matchday_place(standings, my_id)
+    if place is None:
+        logger.info("top5: we do not appear in the matchday standings")
+        return None
+    if place > MAX_PLACE_WITH_OBLIGATION:
+        logger.info("top5: finished %d — no forced sale", place)
+        return None
+    if not matchday_points:
+        logger.warning("top5: finished %d but no player points available", place)
+        return None
+
+    pool = eligible_pool(place, matchday_points)
+    decision = choose_least_damaging(pool, forward_ep, names)
+    if decision is None:
+        return None
+    chosen, reason = decision
+    names = names or {}
+    return ForcedSale(
+        place=place,
+        pool=pool,
+        chosen=chosen,
+        chosen_name=names.get(chosen, chosen),
+        reason=reason,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The impure half: fetching what the rule needs, and discharging it.
+# ---------------------------------------------------------------------------
+
+PLAYED_STATUSES = (1, 3, 4, 5)
+
+
+def matchday_standings(api, league, matchday: int) -> list[dict]:
+    """Every manager's points for one matchday. Empty list on failure."""
+    try:
+        payload = api.client.session.get(
+            f"{api.client.BASE_URL}/v4/leagues/{league.id}/ranking?dayNumber={matchday}"
+        ).json()
+        return list(payload.get("us") or [])
+    except Exception:
+        logger.warning("top5: could not read matchday %s standings", matchday, exc_info=True)
+        return []
+
+
+def squad_matchday_points(api, league, squad, matchday: int) -> dict[str, float]:
+    """What each of our players scored on one matchday.
+
+    Only players who actually took the field count: an unused substitute has no
+    matchday score to be "best" at, and including him at 0.0 would put him in
+    the pool ahead of nobody but still muddy the ranking.
+    """
+    points: dict[str, float] = {}
+    for player in squad:
+        try:
+            perf = api.client.get_player_performance(league.id, player.id)
+        except Exception:
+            logger.warning("top5: no performance for %s", player.id, exc_info=True)
+            continue
+        for season in perf.get("it") or []:
+            for match in season.get("ph") or []:
+                if int(match.get("day") or 0) != matchday:
+                    continue
+                if match.get("st") not in PLAYED_STATUSES:
+                    continue
+                points[str(player.id)] = float(match.get("p") or 0.0)
+    return points
+
+
+def settle(
+    *,
+    api,
+    league,
+    learner,
+    squad,
+    forward_ep: dict[str, float],
+    matchday: int,
+    dry_run: bool = False,
+) -> ForcedSale | None:
+    """Work out the Top-5 obligation for a finished matchday and discharge it.
+
+    Returns the decision, or None when nothing is owed or it was already
+    settled. Selling is instant rather than a market listing: the obligation is
+    to be rid of the player, and a listing nobody buys does not discharge it.
+    """
+    if learner is not None and learner.forced_sale_settled(matchday):
+        logger.info("top5: matchday %d already settled", matchday)
+        return None
+
+    standings = matchday_standings(api, league, matchday)
+    if not standings:
+        return None
+
+    points = squad_matchday_points(api, league, squad, matchday)
+    names = {str(p.id): p.last_name for p in squad}
+    decision = forced_sale(
+        standings=standings,
+        my_id=str(api.user.id),
+        matchday_points=points,
+        forward_ep=forward_ep,
+        names=names,
+    )
+    if decision is None:
+        return None
+
+    logger.info(
+        "top5: finished %d on matchday %d — selling %s (%s)",
+        decision.place,
+        matchday,
+        decision.chosen_name,
+        decision.reason,
+    )
+
+    executed = False
+    if not dry_run:
+        player = next((p for p in squad if str(p.id) == decision.chosen), None)
+        if player is None:
+            logger.error("top5: %s is not in the squad any more", decision.chosen)
+        else:
+            try:
+                api.sell_player_instant(league, player)
+                executed = True
+            except Exception:
+                logger.exception("top5: could not sell %s", decision.chosen_name)
+
+    if learner is not None:
+        try:
+            learner.record_forced_sale(
+                matchday=matchday,
+                place=decision.place,
+                player_id=decision.chosen,
+                player_name=decision.chosen_name,
+                pool=",".join(names.get(p, p) for p in decision.pool),
+                reason=decision.reason,
+                executed=executed,
+            )
+        except Exception:
+            logger.exception("top5: could not record the forced sale")
+
+    return decision

--- a/tests/test_my_bids.py
+++ b/tests/test_my_bids.py
@@ -1,7 +1,14 @@
-"""REH-95: `uoid` is an offer id, so it can never equal a user id.
+"""Detecting the listings we have an open bid on.
 
-`has_user_offer` compared the two, so `get_my_bids()` always returned an empty
-list and every guard built on it silently did nothing.
+`uoid` is a USER id — the manager holding the offer — confirmed against a live
+listing on 2026-08-25 while our own bid was open. REH-95 claimed it was an
+OFFER id and that the previous equality check therefore never matched; that was
+wrong, and `get_my_bids()` was working the whole time.
+
+Presence is used rather than equality because Kickbase only returns the field
+on a listing we have bid on, so the two agree, and presence survives the value
+changing shape. It also errs safe: reporting a bid we do not hold makes the bot
+more conservative, missing one would let it overspend.
 """
 
 from unittest.mock import MagicMock
@@ -34,13 +41,14 @@ class TestHasUserOffer:
     def test_a_listing_with_no_offer_id_is_not(self):
         assert _listing().has_user_offer() is False
 
-    def test_an_offer_id_that_looks_nothing_like_a_user_id_still_counts(self):
-        """The old check required uoid == user id, which never held.
+    def test_it_does_not_depend_on_the_value_matching_our_user_id(self):
+        """Presence is the signal, whatever shape the value takes.
 
-        Kickbase only returns `uoid` on a listing we have bid on, and it is
-        the value `cancel_offer` deletes at /market/{pid}/offers/{offer_id}.
+        Today `uoid` holds our user id. Testing presence rather than equality
+        means this keeps working if that ever changes, without pretending to
+        know which it is.
         """
-        assert _listing(uoid="9f3c-not-a-user-id").has_user_offer() is True
+        assert _listing(uoid="9f3c-some-other-shape").has_user_offer() is True
 
 
 class TestGetMyBids:

--- a/tests/test_top5.py
+++ b/tests/test_top5.py
@@ -1,0 +1,254 @@
+"""The Top-5 rule: finishing well costs you a player.
+
+Nth place must give up one of his N best performers from that matchday.
+First place has no choice at all; fifth has the most.
+"""
+
+from rehoboam.top5 import (
+    ForcedSale,
+    choose_least_damaging,
+    eligible_pool,
+    forced_sale,
+    matchday_place,
+)
+
+
+def _standings(*pairs):
+    """(manager_id, matchday_points), in any order."""
+    return [{"i": i, "sp": p} for i, p in pairs]
+
+
+class TestFindingOurPlace:
+    def test_it_ranks_by_matchday_points(self):
+        s = _standings(("a", 500), ("me", 900), ("b", 700))
+        assert matchday_place(s, "me") == 1
+        assert matchday_place(s, "b") == 2
+        assert matchday_place(s, "a") == 3
+
+    def test_a_manager_not_in_the_standings_has_no_place(self):
+        assert matchday_place(_standings(("a", 500)), "me") is None
+
+    def test_missing_points_count_as_zero_rather_than_crashing(self):
+        s = [{"i": "me"}, {"i": "a", "sp": 100}]
+        assert matchday_place(s, "me") == 2
+
+
+class TestTheEligiblePool:
+    """Nth place may sell any of his top N."""
+
+    def _points(self):
+        return {"p1": 100.0, "p2": 90.0, "p3": 80.0, "p4": 70.0, "p5": 60.0, "p6": 50.0}
+
+    def test_first_place_has_a_pool_of_exactly_his_best_scorer(self):
+        assert eligible_pool(1, self._points()) == ["p1"]
+
+    def test_third_place_may_choose_from_his_top_three(self):
+        assert eligible_pool(3, self._points()) == ["p1", "p2", "p3"]
+
+    def test_fifth_place_may_choose_from_his_top_five(self):
+        assert eligible_pool(5, self._points()) == ["p1", "p2", "p3", "p4", "p5"]
+
+    def test_sixth_place_owes_nothing(self):
+        assert eligible_pool(6, self._points()) == []
+
+    def test_a_pool_cannot_exceed_the_squad(self):
+        assert eligible_pool(5, {"p1": 10.0, "p2": 5.0}) == ["p1", "p2"]
+
+
+class TestChoosingWhoToLose:
+    """Selected on FUTURE value, not on what he scored that matchday."""
+
+    def test_it_gives_up_the_lowest_expected_points_not_the_lowest_scorer(self):
+        pool = ["spike", "steady"]
+        # `spike` scored more that day but is worth far less from here on.
+        chosen, _ = choose_least_damaging(pool, {"spike": 20.0, "steady": 80.0})
+        assert chosen == "spike"
+
+    def test_first_place_gets_no_choice_and_the_reason_says_so(self):
+        chosen, reason = choose_least_damaging(["only"], {"only": 90.0})
+        assert chosen == "only"
+        assert "no choice" in reason
+
+    def test_the_reason_compares_against_the_best_player_kept(self):
+        _, reason = choose_least_damaging(["a", "b", "c"], {"a": 10.0, "b": 80.0, "c": 50.0})
+        assert "10.0" in reason and "80.0" in reason
+
+    def test_an_unscored_player_is_given_up_before_a_scored_one(self):
+        """We should not keep a player we cannot evaluate over one we can."""
+        chosen, _ = choose_least_damaging(["known", "unknown"], {"known": 40.0})
+        assert chosen == "unknown"
+
+    def test_an_empty_pool_yields_no_decision(self):
+        assert choose_least_damaging([], {"a": 1.0}) is None
+
+
+class TestTheWholeRule:
+    def _args(self, my_points, **over):
+        base = {
+            "standings": _standings(("me", 900), ("a", 800), ("b", 700)),
+            "my_id": "me",
+            "matchday_points": my_points,
+            "forward_ep": {"star": 95.0, "spike": 12.0, "solid": 60.0},
+            "names": {"star": "Star", "spike": "Spike", "solid": "Solid"},
+        }
+        base.update(over)
+        return base
+
+    def test_winning_forces_the_sale_of_the_best_scorer(self):
+        sale = forced_sale(**self._args({"spike": 120.0, "star": 90.0, "solid": 80.0}))
+        assert sale.place == 1
+        assert sale.chosen == "spike"
+        assert sale.had_a_choice is False
+
+    def test_third_place_picks_the_least_valuable_of_three(self):
+        sale = forced_sale(
+            **self._args(
+                {"star": 120.0, "solid": 110.0, "spike": 100.0, "other": 10.0},
+                standings=_standings(("a", 999), ("b", 950), ("me", 900)),
+            )
+        )
+        assert sale.place == 3
+        assert sale.pool == ["star", "solid", "spike"]
+        assert sale.chosen == "spike"
+        assert sale.had_a_choice is True
+
+    def test_finishing_sixth_owes_nothing(self):
+        standings = _standings(*[(f"m{i}", 1000 - i) for i in range(5)], ("me", 100))
+        assert forced_sale(**self._args({"star": 50.0}, standings=standings)) is None
+
+    def test_being_absent_from_the_standings_owes_nothing(self):
+        assert forced_sale(**self._args({"star": 50.0}, my_id="ghost")) is None
+
+    def test_no_player_points_yields_no_sale_rather_than_a_wrong_one(self):
+        assert forced_sale(**self._args({})) is None
+
+    def test_the_result_names_the_player_for_a_human_to_read(self):
+        sale = forced_sale(**self._args({"spike": 120.0}))
+        assert isinstance(sale, ForcedSale)
+        assert sale.chosen_name == "Spike"
+
+
+class TestSettling:
+    """The adapter: fetch, decide, sell once, remember."""
+
+    def _api(self, standings, points_by_player, user_id="me"):
+        from unittest.mock import MagicMock
+
+        api = MagicMock()
+        api.user.id = user_id
+        api.client.BASE_URL = "https://x"
+        api.client.session.get.return_value.json.return_value = {"us": standings}
+
+        def _perf(league_id, player_id):
+            pts = points_by_player.get(str(player_id))
+            if pts is None:
+                return {"it": []}
+            return {"it": [{"ph": [{"day": 1, "st": 5, "p": pts}]}]}
+
+        api.client.get_player_performance.side_effect = _perf
+        return api
+
+    def _squad(self):
+        from types import SimpleNamespace
+
+        return [SimpleNamespace(id=p, last_name=p.title()) for p in ("spike", "star", "solid")]
+
+    def _learner(self, tmp_path):
+        from rehoboam.bid_learner import BidLearner
+
+        return BidLearner(db_path=tmp_path / "b.db")
+
+    def test_it_sells_the_least_damaging_eligible_player(self, tmp_path):
+        from types import SimpleNamespace
+
+        from rehoboam.top5 import settle
+
+        api = self._api(_standings(("me", 900), ("a", 800)), {"spike": 120, "star": 90})
+        learner = self._learner(tmp_path)
+        sale = settle(
+            api=api,
+            league=SimpleNamespace(id="L"),
+            learner=learner,
+            squad=self._squad(),
+            forward_ep={"spike": 12.0, "star": 95.0},
+            matchday=1,
+        )
+        assert sale.place == 1
+        assert sale.chosen == "spike"
+        api.sell_player_instant.assert_called_once()
+
+    def test_a_second_run_for_the_same_matchday_sells_nothing(self, tmp_path):
+        """A re-run must not compound the obligation."""
+        from types import SimpleNamespace
+
+        from rehoboam.top5 import settle
+
+        learner = self._learner(tmp_path)
+        args = {
+            "league": SimpleNamespace(id="L"),
+            "learner": learner,
+            "squad": self._squad(),
+            "forward_ep": {"spike": 12.0, "star": 95.0},
+            "matchday": 1,
+        }
+        api1 = self._api(_standings(("me", 900), ("a", 800)), {"spike": 120, "star": 90})
+        settle(api=api1, **args)
+        api2 = self._api(_standings(("me", 900), ("a", 800)), {"spike": 120, "star": 90})
+        assert settle(api=api2, **args) is None
+        api2.sell_player_instant.assert_not_called()
+
+    def test_a_dry_run_decides_but_does_not_sell(self, tmp_path):
+        from types import SimpleNamespace
+
+        from rehoboam.top5 import settle
+
+        api = self._api(_standings(("me", 900), ("a", 800)), {"spike": 120})
+        sale = settle(
+            api=api,
+            league=SimpleNamespace(id="L"),
+            learner=self._learner(tmp_path),
+            squad=self._squad(),
+            forward_ep={"spike": 12.0},
+            matchday=1,
+            dry_run=True,
+        )
+        assert sale is not None
+        api.sell_player_instant.assert_not_called()
+
+    def test_finishing_outside_the_top_five_sells_nothing(self, tmp_path):
+        from types import SimpleNamespace
+
+        from rehoboam.top5 import settle
+
+        standings = _standings(*[(f"m{i}", 1000 - i) for i in range(6)], ("me", 1))
+        api = self._api(standings, {"spike": 120})
+        assert (
+            settle(
+                api=api,
+                league=SimpleNamespace(id="L"),
+                learner=self._learner(tmp_path),
+                squad=self._squad(),
+                forward_ep={"spike": 12.0},
+                matchday=1,
+            )
+            is None
+        )
+        api.sell_player_instant.assert_not_called()
+
+    def test_a_player_who_did_not_play_is_not_in_the_pool(self, tmp_path):
+        """An unused sub has no matchday score to be 'best' at."""
+        from types import SimpleNamespace
+
+        from rehoboam.top5 import settle
+
+        api = self._api(_standings(("me", 900), ("a", 800)), {"star": 90})
+        sale = settle(
+            api=api,
+            league=SimpleNamespace(id="L"),
+            learner=self._learner(tmp_path),
+            squad=self._squad(),
+            forward_ep={"spike": 1.0, "star": 95.0},
+            matchday=1,
+        )
+        assert sale.pool == ["star"]
+        assert sale.chosen == "star"


### PR DESCRIPTION
## The Top-5 rule

House rule for 26/27, applied after every matchday:

| finish | must sell |
| --- | --- |
| 1st | his best scorer of that matchday — **no choice** |
| 2nd | one of his top 2 |
| 3rd | one of his top 3 |
| 4th | one of his top 4 |
| 5th | one of his top 5 |

Sixth and below owe nothing. Finish Nth, give up one of your N best performers.

### The pool is ranked by matchday points, the choice is not

A player who scored 90 once and is a reliable 30 every week costs less to lose than one who scored 85 and is a reliable 80 — what the rule takes is everything he would have contributed *afterwards*. So the pool is selected on that matchday's points and the sale is chosen on **expected points going forward**.

That is what makes finishing 5th much cheaper than finishing 1st: five candidates to pick the weakest from, versus none at all.

### Smaller calls

- **A player who did not take the field is not in the pool.** An unused substitute has no matchday score to be "best" at, and including him at 0.0 would muddy the ranking the rule is defined over.
- **Instant sale, not a market listing.** The obligation is to be rid of the player; a listing nobody buys does not discharge it.
- **Settled at most once per matchday, enforced in the database** — `forced_sales` has the matchday as its PRIMARY KEY, so a re-run of the session cannot compound the obligation into a second sale.

The rule itself is pure and sits above a divider in `top5.py`; everything that touches the API or sells lives below it, so the deciding half is testable without the acting half. Wired in immediately after `reconcile_finished_matchdays`, and non-fatal throughout.

Verified live: `_last_finished_matchday` returns `None` and settlement is silent — correct, since matchday 1 does not start until 28 August. It first does real work after that matchday closes on the 31st.

### Strategic consequence

This is what prompted cancelling a €60.4M bid on Kimmich. Concentrating the budget in one outstanding player is exactly what this rule punishes, because that player is the one it takes. Depth is the defence.

## Correcting REH-95

REH-95 claimed `uoid` was an **offer** id and that comparing it to a user id could never match, so `get_my_bids()` always returned empty and the guards built on it silently did nothing.

That was wrong. Observed on a live listing with our own bid open:

```json
"uoid": "3616202",
"ofs": [{ "u": "3616202", "uoid": "3616202", "uop": 60447397 }]
```

`uoid` is a **user** id. The equality check it replaced was correct, `get_my_bids` was never returning empty, and `pending_bid_total` / `available_slots` / the already-bidding guard were all working. Cancellation works passing this value too — verified by cancelling a real bid.

The wrong inference came from `cancel_offer` passing `user_offer_id` as `{offer_id}` in the delete path, and from the dataclass comment reading "Your offer ID". Both are corrected here. The ticket said to verify next time a bid was open; the endpoint shape was treated as decisive instead, and the live probe run at the time correctly reported itself inconclusive — it should have stopped the change rather than being worked around.

The presence check stays, on its own merits rather than the false premise: behaviourally identical here, survives the value changing shape, and errs safe.

1,073 passed, 1 skipped; ruff, black and bandit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)