### PR TITLE
fix(scoring): per-player availability when last status is stale (REH-98)

### DIFF
--- a/rehoboam/config.py
+++ b/rehoboam/config.py
@@ -272,6 +272,20 @@ class Settings(BaseSettings):
         ),
     )
 
+    stale_availability_shrinkage_k: float = Field(
+        default=20.0,
+        description=(
+            "Pseudo-count pulling a player's own played share toward the league "
+            "prior when his last-played status is too old to use (REH-98). Once "
+            "`max_status_age_days` discards the status, the fitted model returns "
+            "the marginal prior — pre-season that is P(start)=56% for every "
+            "player in the game, so EP carries no availability signal at all. "
+            "This reweights it by the player's own share of matchdays on the "
+            "pitch, downward only. Mirrors the fitted `availability_k`; raise it "
+            "to weaken the correction, set it very high to disable."
+        ),
+    )
+
     min_days_to_match_for_starter_swap: int = Field(
         default=3,
         description=(

--- a/rehoboam/scoring/v2/adapter.py
+++ b/rehoboam/scoring/v2/adapter.py
@@ -33,17 +33,28 @@ from functools import lru_cache
 
 from rehoboam.scoring.models import DataQuality, PlayerData, PlayerScore
 from rehoboam.scoring.v2.availability import (
+    DEFAULT_STALE_SHRINKAGE_K,
     DEFAULT_UNCERTAIN_START_MULTIPLIER,
     OUT_STATUSES,
     UNCERTAIN_STATUSES,
     AvailabilityModel,
     apply_availability_override,
+    apply_stale_history_prior,
 )
 from rehoboam.scoring.v2.coefficients import load_coefficients
 from rehoboam.scoring.v2.features import PLAYED_STATUSES
 from rehoboam.scoring.v2.rate import RateModel
 
 DGW_MULTIPLIER = 1.8
+
+# Statuses that describe a match the player was actually assessed for. Status 0
+# means the fixture has not been played, so it is not evidence either way.
+PLAYED_OR_ABSENT_STATUSES: frozenset[int] = frozenset({1, 3, 4, 5})
+# Of those, the ones where he was on the pitch.
+PLAYED_STATUSES_ON_PITCH: frozenset[int] = frozenset({3, 5})
+
+# Fewest recorded matchdays for a season to count as availability evidence.
+MIN_SEASON_MATCHDAYS = 5
 
 
 @lru_cache(maxsize=1)
@@ -131,6 +142,48 @@ def last_played_status(
     )
 
 
+def recent_played_share(performance: dict | None) -> tuple[int, int] | None:
+    """``(matchdays on the pitch, matchdays recorded)`` from the latest season.
+
+    Feeds ``apply_stale_history_prior`` when the last-played status is too old
+    to use (REH-98). Reads the ``performance`` dict the scorer has already
+    fetched, so it costs no extra HTTP traffic.
+
+    The denominator is matchdays *recorded*, not appearances: a matchday spent
+    as an unused sub (status 4) or out of the squad (status 1) is exactly the
+    evidence this exists to capture. Fixtures not yet played carry status 0 and
+    are excluded — they describe a match that has not happened, not a state the
+    player was in, the same rule ``prev_status_from_history`` applies. That
+    exclusion is what lets a not-yet-started season fall through to the last
+    real one during the pre-season.
+
+    **Most recent qualifying season only.** A blend of the last two smears the
+    signal this exists to read: a player whose role is changing. Uzun finished
+    2025/26 with four consecutive starts after half a season out of the squad.
+
+    **2. Bundesliga counts.** REH-90 establishes that 2.BL scoring *rate* must
+    not be read as Bundesliga rate, but availability is a different quantity —
+    a secure role travels across divisions in a way points-per-match does not.
+
+    Returns None when no season qualifies, which the caller treats as "no
+    evidence" and leaves the marginal prior untouched.
+    """
+    if not performance:
+        return None
+
+    for season in reversed(performance.get("it") or []):
+        recorded = [
+            match.get("st")
+            for match in season.get("ph") or []
+            if match.get("st") in PLAYED_OR_ABSENT_STATUSES
+        ]
+        if len(recorded) < MIN_SEASON_MATCHDAYS:
+            continue
+        return sum(1 for st in recorded if st in PLAYED_STATUSES_ON_PITCH), len(recorded)
+
+    return None
+
+
 def has_top_flight_history(player_details: dict | None) -> bool:
     """Has this player ever recorded Bundesliga scoring?
 
@@ -161,13 +214,37 @@ def availability_probs(
     *,
     live_status: int | None = None,
     uncertain_start_multiplier: float = DEFAULT_UNCERTAIN_START_MULTIPLIER,
+    played_history: tuple[int, int] | None = None,
+    stale_shrinkage_k: float = DEFAULT_STALE_SHRINKAGE_K,
 ) -> dict[int, float]:
     """Fitted transition probabilities with any serving-time override applied.
 
     One implementation, so the composed EP and the note reporting P(start) can
     never disagree about what the model believes.
+
+    ``played_history`` is the player's own ``(played, matchdays)`` record and is
+    consulted **only when ``prev_status`` is None** (REH-98). A fresh in-season
+    status is real per-player evidence and outranks a season-long average; this
+    path exists for the window where that evidence has aged out and every
+    player would otherwise share the league marginal.
+
+    Order is deliberate: the stale prior runs first, the live injury override
+    second, so a player flagged out is out whatever last season says.
     """
     probs = availability.predict(prev_status)
+
+    if prev_status is None and played_history is not None:
+        played, matchdays = played_history
+        probs = apply_stale_history_prior(
+            probs,
+            played=played,
+            matchdays=matchdays,
+            prior_played_share=sum(
+                availability.prior.get(s, 0.0) for s in PLAYED_STATUSES_ON_PITCH
+            ),
+            shrinkage_k=stale_shrinkage_k,
+        )
+
     return apply_availability_override(
         probs, live_status, uncertain_start_multiplier=uncertain_start_multiplier
     )
@@ -182,6 +259,8 @@ def compose_ep(
     *,
     live_status: int | None = None,
     uncertain_start_multiplier: float = DEFAULT_UNCERTAIN_START_MULTIPLIER,
+    played_history: tuple[int, int] | None = None,
+    stale_shrinkage_k: float = DEFAULT_STALE_SHRINKAGE_K,
 ) -> float:
     """Probability-weighted expected points, in real Kickbase points.
 
@@ -195,6 +274,8 @@ def compose_ep(
         availability,
         live_status=live_status,
         uncertain_start_multiplier=uncertain_start_multiplier,
+        played_history=played_history,
+        stale_shrinkage_k=stale_shrinkage_k,
     )
     return sum(probs[s] * rate.predict(player_id, s, position) for s in PLAYED_STATUSES)
 
@@ -204,13 +285,20 @@ def score_player_v2(
     *,
     max_status_age_days: float | None = None,
     uncertain_start_multiplier: float = DEFAULT_UNCERTAIN_START_MULTIPLIER,
+    stale_shrinkage_k: float = DEFAULT_STALE_SHRINKAGE_K,
+    now: datetime | None = None,
 ) -> PlayerScore:
     """Score a player with the fitted v2 models. Pure — no I/O beyond cached load."""
     availability, rate, _meta = _models()
     player = data.player
     position = player.position or None
 
-    prev_status = last_played_status(data.performance, max_age_days=max_status_age_days)
+    prev_status = last_played_status(data.performance, now=now, max_age_days=max_status_age_days)
+
+    # REH-98: with no usable status the fitted model returns the league
+    # marginal, which pre-season is identical for every player in the game.
+    # The player's own record is the only availability signal left.
+    played_history = recent_played_share(data.performance) if prev_status is None else None
 
     # Withhold the fitted quality coefficient from players whose fitted record
     # is not top-flight: `rate.predict` then falls back to the position prior,
@@ -232,6 +320,8 @@ def score_player_v2(
         rate,
         live_status=live_status,
         uncertain_start_multiplier=uncertain_start_multiplier,
+        played_history=played_history,
+        stale_shrinkage_k=stale_shrinkage_k,
     )
 
     dgw_multiplier = DGW_MULTIPLIER if data.is_dgw else 1.0
@@ -242,6 +332,8 @@ def score_player_v2(
         availability,
         live_status=live_status,
         uncertain_start_multiplier=uncertain_start_multiplier,
+        played_history=played_history,
+        stale_shrinkage_k=stale_shrinkage_k,
     )
     notes = [
         f"v2: availability P(start)={probs[5]:.0%} "

--- a/rehoboam/scoring/v2/availability.py
+++ b/rehoboam/scoring/v2/availability.py
@@ -46,6 +46,15 @@ OUT_STATUSES: frozenset[int] = frozenset({4, 256})
 UNCERTAIN_STATUSES: frozenset[int] = frozenset({2})
 DEFAULT_UNCERTAIN_START_MULTIPLIER = 0.5
 
+# --- Stale-history availability prior (REH-98) -----------------------------
+#
+# `max_status_age_days` discards an end-of-season status and falls back to the
+# marginal prior. Correct in itself, but the fallback is league-wide: during
+# the pre-season every player is scored P(start)=56% at once, so EP carries no
+# availability signal in the window where the largest signings are made.
+DEFAULT_STALE_SHRINKAGE_K = 20.0
+DEFAULT_STALE_MIN_MATCHDAYS = 5
+
 
 @dataclass(frozen=True)
 class AvailabilityModel:
@@ -125,6 +134,58 @@ def apply_availability_override(
         return adjusted
 
     return dict(probs)
+
+
+def apply_stale_history_prior(
+    probs: dict[int, float],
+    *,
+    played: int,
+    matchdays: int,
+    prior_played_share: float,
+    shrinkage_k: float = DEFAULT_STALE_SHRINKAGE_K,
+    min_matchdays: int = DEFAULT_STALE_MIN_MATCHDAYS,
+) -> dict[int, float]:
+    """Reweight a marginal prior by the player's own share of matchdays played.
+
+    Applies only when the fitted model had no usable ``prev_status`` -- that is,
+    when ``predict`` returned the league marginal. In-season this path is
+    inert; pre-season it is the only availability signal available.
+
+    **Downward only, by construction**, for the reason
+    ``apply_availability_override`` documents: quality is pooled across
+    statuses, so ``rate(5)`` overstates a true starter's mean by ~24% and stays
+    calibrated only because ``P(5)`` is the fitted ~82%. A player who played
+    *more* than the league average is therefore returned unchanged -- he is
+    under-rated, and correcting that needs the within-status quality refit
+    (REH-53), not a bigger probability.
+
+    **The quantity is played share, not start share.** ``rate.py`` records that
+    quality normalises against a reference pooled over statuses 3 and 5, so the
+    start-versus-substitute mix is already inside the quality coefficient. The
+    split it does not encode is played-versus-not. Scaling 3 and 5 by a common
+    factor corrects the second and leaves the first alone; scaling by start
+    share would count the same evidence twice.
+
+    Status 4 (unused sub) is deliberately untouched. The freed mass goes to
+    status 1, whose base rate is 0.0, so the correction can only reduce EP.
+
+    A record shorter than ``min_matchdays`` is left alone: no history is not
+    evidence of unavailability, which is REH-41's problem rather than this one.
+    """
+    if matchdays <= 0 or matchdays < min_matchdays or prior_played_share <= 0.0:
+        return dict(probs)
+
+    shrunk_share = (played + shrinkage_k * prior_played_share) / (matchdays + shrinkage_k)
+    ratio = min(1.0, shrunk_share / prior_played_share)
+    if ratio >= 1.0:
+        return dict(probs)
+
+    adjusted = dict(probs)
+    for status in (3, 5):
+        if status in adjusted:
+            adjusted[status] *= ratio
+    adjusted[1] = adjusted.get(1, 0.0) + (1.0 - sum(adjusted.values()))
+    return adjusted
 
 
 def fit_availability(

--- a/rehoboam/trader.py
+++ b/rehoboam/trader.py
@@ -463,6 +463,9 @@ class Trader:
                         uncertain_start_multiplier=getattr(
                             self.settings, "uncertain_start_multiplier", 0.5
                         ),
+                        stale_shrinkage_k=getattr(
+                            self.settings, "stale_availability_shrinkage_k", 20.0
+                        ),
                     )
                 )
                 market_player_map[player.id] = player
@@ -507,6 +510,9 @@ class Trader:
                         max_status_age_days=self.settings.max_status_age_days,
                         uncertain_start_multiplier=getattr(
                             self.settings, "uncertain_start_multiplier", 0.5
+                        ),
+                        stale_shrinkage_k=getattr(
+                            self.settings, "stale_availability_shrinkage_k", 20.0
                         ),
                     )
                 )

--- a/tests/test_scoring_v2/test_recent_played_share.py
+++ b/tests/test_scoring_v2/test_recent_played_share.py
@@ -1,0 +1,123 @@
+"""Extracting a player's own availability record from `performance` (REH-98).
+
+`apply_stale_history_prior` needs the share of matchdays a player was actually
+on the pitch. This is where that comes from: the same `performance` dict the
+scorer already fetches, so it costs no extra HTTP traffic.
+
+Policy, decided 2026-08-25:
+
+- **Most recent qualifying season only.** A blend of the last two smears
+  exactly the signal this exists to read -- a player whose role is changing.
+  Can Uzun finished 2025/26 with four consecutive starts after half a season
+  out of the squad; a two-season average would hide that in both directions.
+- **2. Bundesliga counts.** REH-90 establishes that 2.BL *scoring rate* must
+  not be read as Bundesliga rate, but availability is a different quantity:
+  "started 31 of 34" is evidence of durability and a secure role, and that
+  travels across divisions in a way that points-per-match does not.
+
+The denominator is matchdays *recorded*, not appearances. A matchday spent as
+an unused sub (status 4) or out of the squad (status 1) is precisely the
+evidence being captured -- counting only appearances would make every player
+look perfectly available.
+"""
+
+import pytest
+
+from rehoboam.scoring.v2.adapter import recent_played_share
+
+
+def _season(title: str, statuses: list[int], competition: str = "Bundesliga") -> dict:
+    return {
+        "ti": title,
+        "n": competition,
+        "ph": [{"day": i + 1, "st": st} for i, st in enumerate(statuses)],
+    }
+
+
+def _perf(*seasons: dict) -> dict:
+    """`it` is ordered oldest-first, as the API returns it."""
+    return {"it": list(seasons)}
+
+
+class TestTheDenominatorCountsMatchdaysNotAppearances:
+    def test_uzun_is_read_as_21_of_34(self):
+        """15 starts, 6 sub appearances, 13 matchdays not on the pitch."""
+        statuses = [5] * 15 + [3] * 6 + [4] * 11 + [1] * 2
+        assert recent_played_share(_perf(_season("2025/2026", statuses))) == (21, 34)
+
+    def test_an_ever_present_is_read_as_all_of_them(self):
+        assert recent_played_share(_perf(_season("2025/2026", [5] * 34))) == (34, 34)
+
+    def test_unused_subs_stay_in_the_denominator(self):
+        """The whole point: a benched matchday is evidence, not an absence."""
+        played, matchdays = recent_played_share(_perf(_season("2025/2026", [5] * 10 + [4] * 24)))
+        assert (played, matchdays) == (10, 34)
+
+
+class TestUnplayedFixturesAreExcluded:
+    def test_status_zero_does_not_count_against_a_player(self):
+        """Pre-season: the 2026/27 fixtures exist but have not been played."""
+        statuses = [5] * 10 + [0] * 24
+        assert recent_played_share(_perf(_season("2025/2026", statuses))) == (10, 10)
+
+    def test_a_not_yet_started_season_is_skipped_for_the_last_real_one(self):
+        """The live pre-season case that motivated the ticket."""
+        result = recent_played_share(
+            _perf(
+                _season("2025/2026", [5] * 30 + [4] * 4),
+                _season("2026/2027", [0] * 34),
+            )
+        )
+        assert result == (30, 34)
+
+
+class TestSeasonSelection:
+    def test_the_most_recent_qualifying_season_wins(self):
+        result = recent_played_share(
+            _perf(
+                _season("2024/2025", [5] * 34),
+                _season("2025/2026", [4] * 34),
+            )
+        )
+        assert result == (0, 34), "the older ever-present season must not win"
+
+    def test_second_bundesliga_counts_as_availability_evidence(self):
+        result = recent_played_share(
+            _perf(_season("2025/2026", [5] * 30 + [4] * 4, competition="2. Bundesliga"))
+        )
+        assert result == (30, 34)
+
+    def test_a_season_shorter_than_the_minimum_is_skipped(self):
+        """A three-match cameo is not a role; fall through to a real season."""
+        result = recent_played_share(
+            _perf(
+                _season("2024/2025", [5] * 20 + [4] * 14),
+                _season("2025/2026", [3] * 3),
+            )
+        )
+        assert result == (20, 34)
+
+
+class TestNoEvidence:
+    def test_missing_performance_returns_none(self):
+        assert recent_played_share(None) is None
+
+    def test_empty_performance_returns_none(self):
+        assert recent_played_share({}) is None
+
+    def test_a_player_with_no_seasons_returns_none(self):
+        """Onyedika: transferred in, zero Kickbase history. REH-41 owns him."""
+        assert recent_played_share(_perf()) is None
+
+    def test_a_player_with_only_unplayed_fixtures_returns_none(self):
+        assert recent_played_share(_perf(_season("2026/2027", [0] * 34))) is None
+
+
+class TestMalformedData:
+    @pytest.mark.parametrize("season", [{"ti": "2025/2026"}, {"ti": "x", "ph": None}])
+    def test_a_season_without_matches_is_skipped(self, season):
+        assert recent_played_share(_perf(season)) is None
+
+    def test_a_match_without_a_status_is_ignored(self):
+        perf = {"it": [{"ti": "2025/2026", "ph": [{"day": i} for i in range(34)]}]}
+        assert recent_played_share(perf) is None

--- a/tests/test_scoring_v2/test_stale_history_prior.py
+++ b/tests/test_scoring_v2/test_stale_history_prior.py
@@ -1,0 +1,207 @@
+"""Per-player availability when the last-played status is stale (REH-98).
+
+`max_status_age_days` correctly discards an end-of-season status -- squads
+rotate through dead rubbers, and without the bound the final matchday of one
+season drives availability for the whole of the next. But the fallback is the
+league-wide *marginal prior*, so during the pre-season every player in the
+league is scored P(start)=56% simultaneously. On 2026-08-25, three days before
+MD1, nine live market candidates all came back with the identical availability
+term; the buy ranking was a pure points-when-playing ranking with availability
+held constant.
+
+That flatters exactly the wrong player. Can Uzun started 15 of 34 matchdays in
+2025/26 -- unused sub or out of squad for MD10-13, MD17, MD20-26 and MD28 --
+and was ranked above Nathaniel Brown, who started 30 of 34. Uzun contributes
+18% fewer points per matchday and the model could not see it.
+
+Direction matters, for the reason `test_availability_override.py` records:
+quality is pooled across statuses, so rate(5) overstates a true starter's mean
+by ~24% and stays calibrated only because P(5) is the fitted ~82% rather than
+100%. Forcing probability DOWNWARD cannot inflate anything. So this correction
+is downward-only, like the injury override beside it.
+
+The scaling quantity is *played share* (statuses 3+5 against all), never start
+share. Pooled quality already absorbs each player's 3-vs-5 mix; the split it
+does not encode is played-vs-not. Scaling P(3) and P(5) by a common factor
+corrects the second without double-counting the first.
+"""
+
+import pytest
+
+from rehoboam.scoring.v2.availability import apply_stale_history_prior
+
+# The fitted marginal prior from coefficients.json -- what every player
+# currently receives pre-season.
+FITTED_PRIOR: dict[int, float] = {1: 0.0388, 3: 0.1945, 4: 0.2089, 5: 0.5578}
+PRIOR_PLAYED_SHARE = FITTED_PRIOR[3] + FITTED_PRIOR[5]  # 0.7523
+
+
+class TestBelowAverageAvailabilityIsReduced:
+    def test_uzun_loses_start_probability(self):
+        """21 of 34 matchdays played -- the case that motivated the ticket."""
+        out = apply_stale_history_prior(
+            FITTED_PRIOR,
+            played=21,
+            matchdays=34,
+            prior_played_share=PRIOR_PLAYED_SHARE,
+            shrinkage_k=20.0,
+        )
+        assert out[5] < FITTED_PRIOR[5]
+        assert out[5] == pytest.approx(0.4949, abs=0.001)
+
+    def test_the_freed_mass_becomes_did_not_play(self):
+        out = apply_stale_history_prior(
+            FITTED_PRIOR,
+            played=21,
+            matchdays=34,
+            prior_played_share=PRIOR_PLAYED_SHARE,
+            shrinkage_k=20.0,
+        )
+        assert out[1] > FITTED_PRIOR[1]
+
+    def test_unused_sub_probability_is_left_alone(self):
+        """Status 4 is not evidence about the played-vs-not split we correct."""
+        out = apply_stale_history_prior(
+            FITTED_PRIOR,
+            played=21,
+            matchdays=34,
+            prior_played_share=PRIOR_PLAYED_SHARE,
+            shrinkage_k=20.0,
+        )
+        assert out[4] == pytest.approx(FITTED_PRIOR[4])
+
+
+class TestAboveAverageAvailabilityIsNeverInflated:
+    def test_brown_is_returned_unchanged(self):
+        """33 of 34 matchdays. Under-rated, but inflating him would expose the
+        ~24% starter bias that the paired availability+rate models cancel."""
+        out = apply_stale_history_prior(
+            FITTED_PRIOR,
+            played=33,
+            matchdays=34,
+            prior_played_share=PRIOR_PLAYED_SHARE,
+            shrinkage_k=20.0,
+        )
+        assert out == pytest.approx(FITTED_PRIOR)
+
+    def test_an_ever_present_is_returned_unchanged(self):
+        out = apply_stale_history_prior(
+            FITTED_PRIOR,
+            played=34,
+            matchdays=34,
+            prior_played_share=PRIOR_PLAYED_SHARE,
+            shrinkage_k=20.0,
+        )
+        assert out[5] == pytest.approx(FITTED_PRIOR[5])
+
+
+class TestTheStartVersusSubMixIsPreserved:
+    def test_scaling_does_not_change_the_ratio_of_start_to_sub(self):
+        """The property that avoids double-counting against pooled quality.
+
+        `rate.py` records that quality normalises against a reference pooled
+        over statuses 3 and 5, so the 3-vs-5 mix is already in the quality
+        coefficient. Only the played-vs-not split is new information.
+        """
+        out = apply_stale_history_prior(
+            FITTED_PRIOR,
+            played=10,
+            matchdays=34,
+            prior_played_share=PRIOR_PLAYED_SHARE,
+            shrinkage_k=20.0,
+        )
+        assert out[5] / out[3] == pytest.approx(FITTED_PRIOR[5] / FITTED_PRIOR[3])
+
+
+class TestShrinkage:
+    def test_a_short_record_is_pulled_toward_no_correction(self):
+        """Six matchdays, none played, must not zero out a player.
+
+        Above `min_matchdays`, so this exercises shrinkage rather than the
+        guard: without it the ratio would be 0.0 and the player would score 0.
+        """
+        out = apply_stale_history_prior(
+            FITTED_PRIOR,
+            played=0,
+            matchdays=6,
+            prior_played_share=PRIOR_PLAYED_SHARE,
+            shrinkage_k=20.0,
+        )
+        assert out[5] > 0.4 * FITTED_PRIOR[5]
+
+    def test_a_long_record_moves_further_than_a_short_one(self):
+        """Same 50% share, but 34 matchdays is stronger evidence than 10."""
+        short = apply_stale_history_prior(
+            FITTED_PRIOR,
+            played=5,
+            matchdays=10,
+            prior_played_share=PRIOR_PLAYED_SHARE,
+            shrinkage_k=20.0,
+        )
+        long_ = apply_stale_history_prior(
+            FITTED_PRIOR,
+            played=17,
+            matchdays=34,
+            prior_played_share=PRIOR_PLAYED_SHARE,
+            shrinkage_k=20.0,
+        )
+        assert long_[5] < short[5]
+
+
+class TestGuards:
+    def test_no_recorded_matchdays_leaves_the_prior_alone(self):
+        """A cold-start player is not evidence of unavailability (REH-41)."""
+        out = apply_stale_history_prior(
+            FITTED_PRIOR,
+            played=0,
+            matchdays=0,
+            prior_played_share=PRIOR_PLAYED_SHARE,
+            shrinkage_k=20.0,
+        )
+        assert out == pytest.approx(FITTED_PRIOR)
+
+    def test_a_record_below_the_minimum_leaves_the_prior_alone(self):
+        out = apply_stale_history_prior(
+            FITTED_PRIOR,
+            played=0,
+            matchdays=2,
+            prior_played_share=PRIOR_PLAYED_SHARE,
+            shrinkage_k=20.0,
+            min_matchdays=5,
+        )
+        assert out == pytest.approx(FITTED_PRIOR)
+
+    def test_a_zero_prior_played_share_cannot_divide_by_zero(self):
+        out = apply_stale_history_prior(
+            FITTED_PRIOR,
+            played=10,
+            matchdays=34,
+            prior_played_share=0.0,
+            shrinkage_k=20.0,
+        )
+        assert out == pytest.approx(FITTED_PRIOR)
+
+
+class TestOutputIsAProbabilityDistribution:
+    @pytest.mark.parametrize("played", [0, 7, 21, 33, 34])
+    def test_probabilities_sum_to_one(self, played):
+        out = apply_stale_history_prior(
+            FITTED_PRIOR,
+            played=played,
+            matchdays=34,
+            prior_played_share=PRIOR_PLAYED_SHARE,
+            shrinkage_k=20.0,
+        )
+        assert sum(out.values()) == pytest.approx(1.0)
+        assert all(0.0 <= p <= 1.0 for p in out.values())
+
+    def test_the_input_mapping_is_not_mutated(self):
+        before = dict(FITTED_PRIOR)
+        apply_stale_history_prior(
+            FITTED_PRIOR,
+            played=10,
+            matchdays=34,
+            prior_played_share=PRIOR_PLAYED_SHARE,
+            shrinkage_k=20.0,
+        )
+        assert FITTED_PRIOR == before

--- a/tests/test_scoring_v2/test_stale_prior_end_to_end.py
+++ b/tests/test_scoring_v2/test_stale_prior_end_to_end.py
@@ -1,0 +1,110 @@
+"""`score_player_v2` end to end with a stale availability record (REH-98).
+
+The live reproduction: on 2026-08-25, three days before MD1, nine market
+candidates all scored P(start)=56% because the last Bundesliga matchday was
+2026-05-16 -- 101 days back, past `max_status_age_days=60`. EP became a pure
+points-when-playing ranking, and Can Uzun (15 of 34 starts) outranked Nathaniel
+Brown (30 of 34) while contributing 18% fewer points per matchday.
+
+These tests use the real fitted coefficients, so they assert the behaviour the
+production scorer actually has.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from rehoboam.kickbase_client import MarketPlayer
+from rehoboam.scoring.models import PlayerData
+from rehoboam.scoring.v2.adapter import score_player_v2
+
+STALE_MATCH_DATE = "2026-05-16T13:30:00Z"
+NOW = datetime(2026, 8, 25, tzinfo=timezone.utc)
+
+
+def _perf(statuses: list[int], match_date: str = STALE_MATCH_DATE) -> dict:
+    return {
+        "it": [
+            {
+                "ti": "2025/2026",
+                "n": "Bundesliga",
+                "ph": [{"day": i + 1, "st": st, "md": match_date} for i, st in enumerate(statuses)],
+            }
+        ]
+    }
+
+
+def _data(performance: dict | None, pid: str = "6081") -> PlayerData:
+    return PlayerData(
+        player=MarketPlayer(
+            id=pid,
+            first_name="Test",
+            last_name="Player",
+            position="Midfielder",
+            team_id="4",
+            team_name="Frankfurt",
+            market_value=28_288_063,
+            price=28_288_063,
+            points=2232,
+            average_points=106.0,
+            status=0,
+        ),
+        performance=performance,
+        player_details=None,
+        team_strength=None,
+        opponent_strength=None,
+        is_dgw=False,
+    )
+
+
+# The two shapes that motivated the ticket, as real status sequences.
+UZUN = [5] * 15 + [3] * 6 + [4] * 11 + [1] * 2  # 21 of 34
+BROWN = [5] * 29 + [3] * 4 + [4] * 1  # 33 of 34
+
+
+def _score(statuses: list[int], **kwargs):
+    return score_player_v2(_data(_perf(statuses)), max_status_age_days=60.0, now=NOW, **kwargs)
+
+
+class TestTheRankingInversionIsCorrected:
+    def test_a_frequently_absent_player_scores_below_an_ever_present(self):
+        """The headline defect: EP had these two the wrong way round."""
+        assert _score(UZUN).expected_points < _score(BROWN).expected_points
+
+    def test_the_ever_present_is_unchanged_from_the_marginal_prior(self):
+        """Downward-only: Brown is under-rated, not inflated. REH-53 owns that."""
+        no_record = score_player_v2(_data(None), max_status_age_days=60.0, now=NOW)
+        assert _score(BROWN).expected_points == pytest.approx(no_record.expected_points, rel=1e-9)
+
+    def test_the_absent_player_actually_loses_points(self):
+        no_record = score_player_v2(_data(None), max_status_age_days=60.0, now=NOW)
+        assert _score(UZUN).expected_points < no_record.expected_points
+
+
+class TestTheNoteReportsTheCorrectedProbability:
+    def test_p_start_in_the_note_reflects_the_reduction(self):
+        """`availability_probs` is shared, so the note cannot disagree with EP."""
+        note = _score(UZUN).notes[0]
+        assert "P(start)=56%" not in note
+
+    def test_an_ever_present_still_reports_the_marginal(self):
+        assert "P(start)=56%" in _score(BROWN).notes[0]
+
+
+class TestFreshHistoryIsUnaffected:
+    def test_an_in_season_status_still_drives_availability(self):
+        """With a recent match the prev_status path wins and this is inert."""
+        recent = _perf(UZUN, match_date="2026-08-22T13:30:00Z")
+        fresh = score_player_v2(_data(recent), max_status_age_days=60.0, now=NOW)
+        stale = _score(UZUN)
+        assert fresh.expected_points != pytest.approx(stale.expected_points)
+
+
+class TestNoHistoryIsNotPenalised:
+    def test_a_cold_start_player_keeps_the_marginal_prior(self):
+        """Onyedika: transferred in with no Kickbase history. REH-41 owns him."""
+        empty = score_player_v2(_data({"it": []}), max_status_age_days=60.0, now=NOW)
+        no_record = score_player_v2(_data(None), max_status_age_days=60.0, now=NOW)
+        assert empty.expected_points == pytest.approx(no_record.expected_points)

--- a/tests/test_scoring_v2/test_stale_prior_wiring.py
+++ b/tests/test_scoring_v2/test_stale_prior_wiring.py
@@ -1,0 +1,72 @@
+"""Wiring the stale-history prior into the scoring path (REH-98).
+
+`availability_probs` is the single chokepoint -- "so the composed EP and the
+note reporting P(start) can never disagree about what the model believes" --
+so the correction goes there and the note reports it for free.
+
+Two ordering rules matter:
+
+1. It applies ONLY when `prev_status is None`. A fresh in-season status is
+   real per-player evidence and beats a season-long average; this path exists
+   for the window where that evidence has aged out.
+2. It runs BEFORE `apply_availability_override`, so a live injury flag still
+   wins outright. A player marked out is out, whatever last season says.
+"""
+
+import pytest
+
+from rehoboam.scoring.v2.adapter import availability_probs
+from rehoboam.scoring.v2.availability import AvailabilityModel
+
+PRIOR = {1: 0.0388, 3: 0.1945, 4: 0.2089, 5: 0.5578}
+TRANSITIONS = {
+    1: {1: 0.727, 3: 0.041, 4: 0.201, 5: 0.031},
+    3: {1: 0.008, 3: 0.543, 4: 0.135, 5: 0.314},
+    4: {1: 0.015, 3: 0.171, 4: 0.661, 5: 0.152},
+    5: {1: 0.010, 3: 0.089, 4: 0.064, 5: 0.837},
+}
+
+
+def _model() -> AvailabilityModel:
+    return AvailabilityModel(transitions=TRANSITIONS, prior=PRIOR, shrinkage_k=20.0)
+
+
+class TestAppliesOnlyWhenTheStatusIsStale:
+    def test_a_stale_status_lets_the_players_own_record_reduce_it(self):
+        """Uzun: 21 of 34, no usable prev_status. This is the fix."""
+        out = availability_probs(None, _model(), played_history=(21, 34))
+        assert out[5] < PRIOR[5]
+
+    def test_a_fresh_status_ignores_the_season_record_entirely(self):
+        """In-season, prev_status=5 is better evidence than a season average."""
+        out = availability_probs(5, _model(), played_history=(21, 34))
+        assert out == pytest.approx(TRANSITIONS[5])
+
+    def test_no_record_leaves_the_marginal_prior_untouched(self):
+        out = availability_probs(None, _model(), played_history=None)
+        assert out == pytest.approx(PRIOR)
+
+    def test_an_above_average_record_is_not_inflated(self):
+        """Brown: 33 of 34. Downward-only, so he stays at the prior."""
+        out = availability_probs(None, _model(), played_history=(33, 34))
+        assert out == pytest.approx(PRIOR)
+
+
+class TestTheInjuryOverrideStillWins:
+    def test_a_long_term_injury_beats_a_good_availability_record(self):
+        out = availability_probs(None, _model(), live_status=256, played_history=(34, 34))
+        assert out[5] == pytest.approx(0.0)
+        assert out[1] == pytest.approx(1.0)
+
+    def test_the_two_corrections_compose_downward(self):
+        """An uncertain flag on top of a poor record reduces further."""
+        record_only = availability_probs(None, _model(), played_history=(21, 34))
+        both = availability_probs(None, _model(), live_status=2, played_history=(21, 34))
+        assert both[5] < record_only[5]
+
+
+class TestTheReportedProbabilityMatchesTheComposedEp:
+    def test_output_remains_a_probability_distribution(self):
+        out = availability_probs(None, _model(), played_history=(7, 34))
+        assert sum(out.values()) == pytest.approx(1.0)
+        assert all(0.0 <= p <= 1.0 for p in out.values())


### PR DESCRIPTION
Closes REH-98.

## The defect

`max_status_age_days` correctly discards an end-of-season status — squads rotate through dead rubbers, and without the bound the last matchday of one season drives availability for the whole of the next. But the fallback is the **league-wide marginal prior**, so pre-season every player in the game gets the same one.

On 2026-08-25, three days before MD1, all nine live market candidates came back identical:

```
Raum  84.0  P(start)=56%  rate=139      Bell      63.5  P(start)=56%  rate=105
Tah   73.2  P(start)=56%  rate=121      Brown     62.5  P(start)=56%  rate=103
...                                     Onyedika  48.2  P(start)=56%  rate=80
```

`EP = Σ P(status) × rate(...)` degenerated to `constant × rate` — a pure points-when-playing ranking with availability held constant, during the window where the largest signings happen.

It flattered exactly the wrong player. **Can Uzun** started 15 of 34 matchdays (unused sub or out of squad for MD10-13, MD17, MD20-26, MD28) and outranked **Nathaniel Brown** (30 of 34), while contributing 18% fewer points per matchday.

## The fix

Reweight the marginal prior by the player's own share of matchdays on the pitch, read from the `performance` dict the scorer already fetches. No extra HTTP traffic.

**Downward only**, for the reason `apply_availability_override` already documents: quality is pooled across statuses, so `rate(5)` overstates a true starter's mean by ~24% and stays calibrated only because `P(5)` is the fitted ~82%. A player who played *more* than the league average is returned unchanged — under-rated, but correcting that needs the within-status quality refit (REH-53), not a bigger probability.

**The scaling quantity is played share, never start share.** `rate.py` records that quality normalises against a reference pooled over statuses 3 and 5, so the start-vs-sub mix is already inside the quality coefficient. Only played-vs-not is new information. Scaling 3 and 5 by a common factor corrects the second without counting the first twice.

## Evidence

Nine live candidates, scored against last season's actual points per matchday — zeros included, the quantity a Total Points league is won on:

| | played | EP before | EP after | Δ | P(start) |
|---|---|---|---|---|---|
| Raum | 30/34 | 84.0 | 84.0 | — | 56% |
| Tah | 28/34 | 73.2 | 73.2 | — | 56% |
| Diks | 30/34 | 69.0 | 69.0 | — | 56% |
| Brown | 33/34 | 62.5 | 62.5 | — | 56% |
| Baku | 32/34 | 58.8 | 58.8 | — | 56% |
| **Uzun** | 21/34 | 65.4 | **58.1** | −7.3 | 49% |
| **Matsima** | 18/34 | 69.8 | **56.8** | −13.0 | 45% |
| **Bell** | 18/34 | 63.5 | **51.7** | −11.8 | 45% |
| Onyedika | none | 48.2 | 48.2 | — | 56% |

**Spearman against actual pts/matchday: 0.405 → 0.929.** The one remaining inversion is Baku, ranked 5th against a true 3rd — precisely the under-rated ever-present that downward-only deliberately leaves on the table.

## Policy decisions

Both recorded in `recent_played_share`'s docstring:

- **Most recent qualifying season only**, not a two-season blend. A blend smears the signal this exists to read — a player whose role is changing. Uzun finished 2025/26 with four consecutive starts after half a season out of the squad.
- **2. Bundesliga counts.** REH-90 establishes that 2.BL *scoring rate* must not be read as Bundesliga rate, but availability is a different quantity: a secure role travels across divisions in a way points-per-match does not.

## On the replay

The season replay is **unchanged at 27,751** (verified by stash-and-rerun, identical both sides). In-season `prev_status` is fresh, so this path never fires there.

That is confirmation the change is inert in-season — not evidence it works. The harness now disclaims being a gate for scoring changes, and this is a case where it genuinely cannot be one. The nine-candidate set above is the real evidence.

## Tests

46 new tests across four files, all TDD'd red-first. 1119 pass, 1 skipped, no regressions. Ruff clean; the 33 mypy errors are pre-existing and none are in the touched files.

`stale_availability_shrinkage_k` is a `Settings` field per the repo's global constraint — raise it to weaken the correction, set it very high to disable, no deploy needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)