### PR TITLE
fix(bidding): one bid ceiling, tier-scaled with an absolute floor (REH-99)

### DIFF
--- a/rehoboam/auto_trader.py
+++ b/rehoboam/auto_trader.py
@@ -364,6 +364,7 @@ class AutoTrader:
 
         from .notify.render import render_proposal
         from .notify.telegram import send_proposal
+        from .services.bid_ceiling import tier_for_marginal_gain
 
         proposal_id = uuid.uuid4().hex[:12]
         player = rec.player
@@ -407,6 +408,17 @@ class AutoTrader:
             )
             return True
 
+        # REH-99: record the tier the bid was sized under. Approval recomputes
+        # the ceiling from it against the *live* market value, so a proposal is
+        # re-checked as the world is at approval time rather than waved through
+        # on the stale number it was priced at.
+        tier = tier_for_marginal_gain(
+            float(rec.marginal_ep_gain),
+            must_have=self.settings.bid_tier_must_have,
+            strong=self.settings.bid_tier_strong_upgrade,
+            solid=self.settings.bid_tier_solid_upgrade,
+        )
+
         try:
             self.learner.record_proposal(
                 proposal_id=proposal_id,
@@ -415,6 +427,7 @@ class AutoTrader:
                 bid=int(rec.recommended_bid),
                 market_value=int(player.market_value),
                 message=message,
+                tier=tier.value,
             )
         except Exception:
             logger.exception("proposal: could not record %s", proposal_id)

--- a/rehoboam/bid_learner.py
+++ b/rehoboam/bid_learner.py
@@ -548,6 +548,15 @@ class BidLearner:
                 )
                 """
             )
+            # REH-99: approval recomputes the bid ceiling against the *live*
+            # market value, which needs the tier the bid was sized under. Added
+            # separately so an existing prod table gains it in place; rows
+            # written before this land with tier NULL and fall back to the
+            # tightest tier, which refuses rather than over-permits.
+            try:
+                conn.execute("ALTER TABLE trade_proposals ADD COLUMN tier TEXT")
+            except sqlite3.OperationalError:
+                pass  # already present
 
             # REH-22: drop legacy tables that no live code references.
             # `position_bidding_stats` was orphaned by REH-27 (writer + reader
@@ -1657,13 +1666,19 @@ class BidLearner:
         bid: int,
         market_value: int,
         message: str,
+        tier: str | None = None,
     ) -> None:
-        """Persist a proposal awaiting approval."""
+        """Persist a proposal awaiting approval.
+
+        ``tier`` is the marginal-EP band the bid was sized under. Approval
+        needs it to recompute the ceiling against the live market value
+        (REH-99); None falls back to the tightest tier.
+        """
         with sqlite3.connect(self.db_path) as conn:
             conn.execute(
                 "INSERT OR REPLACE INTO trade_proposals "
                 "(proposal_id, player_id, player_name, bid, market_value, message, "
-                " status, created_at) VALUES (?, ?, ?, ?, ?, ?, 'pending', ?)",
+                " status, created_at, tier) VALUES (?, ?, ?, ?, ?, ?, 'pending', ?, ?)",
                 (
                     proposal_id,
                     player_id,
@@ -1672,6 +1687,7 @@ class BidLearner:
                     int(market_value),
                     message,
                     datetime.now().timestamp(),
+                    tier,
                 ),
             )
 

--- a/rehoboam/bidding_strategy.py
+++ b/rehoboam/bidding_strategy.py
@@ -177,7 +177,9 @@ class SmartBidding:
         tier_strong_upgrade: float = TIER_STRONG_UPGRADE,
         tier_solid_upgrade: float = TIER_SOLID_UPGRADE,
         full_commit_gain: float = BID_FULL_COMMIT_GAIN,  # gain earning max budget share
+        ceiling_policy=None,  # REH-99: the ceiling the safety gate enforces
     ):
+        self.ceiling_policy = ceiling_policy
         self.default_overbid_pct = default_overbid_pct
         self.max_overbid_pct = max_overbid_pct
         self.high_value_threshold = high_value_threshold
@@ -438,6 +440,14 @@ class SmartBidding:
         market_value_floor = int(market_value * 1.01)
         if recommended_bid < market_value_floor:
             recommended_bid = min(market_value_floor, budget_ceiling)
+
+        # REH-99: the ceiling the safety gate will enforce. Applied last so
+        # nothing downstream can lift the bid back over it — this is what makes
+        # a proposal shown in Telegram a proposal that can actually execute.
+        if self.ceiling_policy is not None and market_value > 0:
+            recommended_bid = min(
+                recommended_bid, self.ceiling_policy.max_bid(market_value, ep_tier)
+            )
 
         # If we still can't afford the asking price (truly out of budget), signal no-bid
         if recommended_bid < asking_price:

--- a/rehoboam/config.py
+++ b/rehoboam/config.py
@@ -326,15 +326,51 @@ class Settings(BaseSettings):
             "Pre-season estimate awaiting live-market validation."
         ),
     )
-    max_overbid_pct: float = Field(
+    # Bid ceiling (REH-99). Replaces the flat `max_overbid_pct = 8.0`, which was
+    # enforced only in safety_gate while SmartBidding sized bids against its own
+    # 20%/30% caps — so Telegram offered buys the gate then refused.
+    #
+    # 8.0 came from REH-64's read that margin beyond ~8% bought no win rate. Two
+    # things undermine it. The band table behind it is confounded: the bot bids
+    # higher precisely when a player is contested, and contested players are
+    # harder to win by construction. And the 12.2% round-trip toll it rests on is
+    # flip economics — it only bites if you sell, while a held player amortises
+    # the premium over 30+ matchdays. Measured against the 12 lost auctions
+    # carrying `winning_overbid_pct`, a flat 8% would have won none of them.
+    overbid_floor_eur: int = Field(
+        default=250_000,
+        description=(
+            "Absolute euro headroom allowed above market value regardless of "
+            "percentage, because a percentage is the wrong unit at the cheap end. "
+            "Chiarodia (market value EUR 591,389) was lost to a winner paying "
+            "EUR 156,085 over while an 8% cap held the bot to EUR 47,311 — a "
+            "EUR 109k gap against a EUR 62M budget."
+        ),
+    )
+    overbid_pct_marginal: float = Field(
         default=8.0,
         description=(
-            "Hard ceiling on how far above market value any bid may go, enforced by "
-            "services/safety_gate.check_buy. 8.0 comes from REH-64's measurement: a "
-            "3-8% overbid won 50% of auctions and an 8-15% overbid won the same 50%, "
-            "so margin beyond ~8% bought almost no win rate while the bot averaged "
-            "+12.2% and lost EUR 55.3M across 151 flips. Distinct from SmartBidding's "
-            "own internal caps — this is the outer limit nothing may cross."
+            "Overbid ceiling for a marginal candidate. Stays at REH-64's figure: "
+            "these are churn candidates that genuinely pay the 12.2% round-trip toll."
+        ),
+    )
+    overbid_pct_solid: float = Field(
+        default=15.0,
+        description="Overbid ceiling for a solid upgrade. Covers the observed Suzuki loss (+10.2%).",
+    )
+    overbid_pct_strong: float = Field(
+        default=25.0,
+        description="Overbid ceiling for a strong upgrade.",
+    )
+    overbid_pct_must_have: float = Field(
+        default=35.0,
+        description=(
+            "Overbid ceiling for a must-have. Covers the contested band actually "
+            "observed on lost auctions (Bitshiabu +32.1%, Vandevoordt +27.5%, "
+            "Honorat +33.9%, Lemperle +33.2%). Deliberately below the runaway "
+            "cheap-end winners (+102% to +385%) — that is the league overpaying, "
+            "not the bot being outbid. Rests on 12 rows: re-tune as "
+            "`auction_outcomes` fills."
         ),
     )
 
@@ -390,6 +426,25 @@ class Settings(BaseSettings):
     smtp_user: str = Field(default="", repr=False, description="SMTP username.")
     smtp_password: str = Field(default="", repr=False, description="SMTP password or app password.")
     alert_email_to: str = Field(default="", description="Recipient of the daily summary.")
+
+    def bid_ceiling_policy(self):
+        """The configured bid ceiling, as one value (REH-99).
+
+        Built here so `SmartBidding` and `safety_gate.check_buy` receive the
+        same policy object rather than each assembling their own from loose
+        fields — which is how the 8%/20% split arose in the first place.
+        """
+        from rehoboam.services.bid_ceiling import BidCeilingPolicy, Tier
+
+        return BidCeilingPolicy(
+            floor_eur=self.overbid_floor_eur,
+            tier_pcts={
+                Tier.MARGINAL: self.overbid_pct_marginal,
+                Tier.SOLID: self.overbid_pct_solid,
+                Tier.STRONG: self.overbid_pct_strong,
+                Tier.MUST_HAVE: self.overbid_pct_must_have,
+            },
+        )
 
 
 def get_settings() -> Settings:

--- a/rehoboam/notify/approval.py
+++ b/rehoboam/notify/approval.py
@@ -128,7 +128,10 @@ def handle_callback(
             current_budget=budget,
             free_slots=free_slots,
             known_player_ids=market.keys(),
-            max_overbid_pct=settings.max_overbid_pct,
+            # None for rows written before REH-99 added the column; the ceiling
+            # falls back to the tightest tier, refusing rather than over-permitting.
+            tier=proposal.get("tier"),
+            ceiling_policy=settings.bid_ceiling_policy(),
             club_id=str(getattr(live, "team_id", "") or "") or None,
             squad_club_counts=club_counts,
         )

--- a/rehoboam/replay/driver.py
+++ b/rehoboam/replay/driver.py
@@ -25,6 +25,7 @@ from rehoboam.replay.market import ReplayMarket
 from rehoboam.replay.state import initial_state
 from rehoboam.scoring.v2.adapter import compose_ep, prev_status_from_history
 from rehoboam.scoring.v2.coefficients import load_coefficients
+from rehoboam.services.bid_ceiling import BidCeilingPolicy, Tier
 
 SEASON = "2025/2026"
 LEAGUE_ID = "1933872"
@@ -421,11 +422,25 @@ def make_ep_bid_fn(
     def _default(name: str) -> float:
         return float(Settings.model_fields[name].default)
 
+    # REH-99: the same ceiling the live bidder and the safety gate use. Built
+    # from the shipped defaults, like the tiers above — if the replay bid
+    # differently from live it would stop measuring the bot that actually runs.
+    ceiling_policy = BidCeilingPolicy(
+        floor_eur=int(Settings.model_fields["overbid_floor_eur"].default),
+        tier_pcts={
+            Tier.MARGINAL: _default("overbid_pct_marginal"),
+            Tier.SOLID: _default("overbid_pct_solid"),
+            Tier.STRONG: _default("overbid_pct_strong"),
+            Tier.MUST_HAVE: _default("overbid_pct_must_have"),
+        },
+    )
+
     bidding = SmartBidding(
         tier_must_have=_default("bid_tier_must_have"),
         tier_strong_upgrade=_default("bid_tier_strong_upgrade"),
         tier_solid_upgrade=_default("bid_tier_solid_upgrade"),
         full_commit_gain=_default("bid_full_commit_gain"),
+        ceiling_policy=ceiling_policy,
     )
 
     def bid(player_id: str, price: int, at: float, gain: float, budget: int) -> int:

--- a/rehoboam/services/bid_ceiling.py
+++ b/rehoboam/services/bid_ceiling.py
@@ -1,0 +1,114 @@
+"""How far above market value a bid may go. One definition, two callers.
+
+`SmartBidding` sizes a bid and `safety_gate.check_buy` verifies one. Before
+REH-99 they used different constants — 20%/30% in the bidder, 8% in the gate,
+never connected — so Telegram offered buys the gate would refuse and the
+Approve button could not work. Both now call `max_allowed_bid`, which is why
+the number a proposal shows is always a number that can execute.
+
+    max_allowed_bid = market_value + max(floor, market_value x tier_pct)
+
+**The floor exists because a percentage is the wrong unit at the cheap end.**
+Fabio Chiarodia, market value EUR 591,389, was lost to a winner paying
+EUR 156,085 over while an 8% cap held the bot to EUR 47,311 — a EUR 109k gap
+against a EUR 62M budget.
+
+**The tier percentage exists because the round-trip toll is not universal.**
+REH-64 measured a 12.2% toll and capped every buy at 8% on the strength of it,
+but that toll is flip economics: it only bites if you sell. A must-have held to
+score points all season has no round trip and amortises the premium over 30+
+matchdays. A marginal churn candidate genuinely does pay it, and stays tight.
+
+Across the 12 lost auctions carrying `winning_overbid_pct`, a flat 8% would
+have won none; the lowest winning overbid was 8.4%.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+
+
+class Tier(str, Enum):
+    """Marginal-EP bands, mirroring the ones `SmartBidding` already assigns."""
+
+    MARGINAL = "marginal"
+    SOLID = "solid_upgrade"
+    STRONG = "strong_upgrade"
+    MUST_HAVE = "must_have"
+
+
+#: Applied when the tier is unknown — a stale or corrupted proposal must not
+#: buy itself a larger ceiling by losing its tier.
+FALLBACK_TIER = Tier.MARGINAL
+
+
+def tier_for_marginal_gain(
+    marginal_ep_gain: float,
+    *,
+    must_have: float,
+    strong: float,
+    solid: float,
+) -> Tier:
+    """Band a marginal EP gain, using the thresholds `SmartBidding` is given.
+
+    Thresholds are passed in rather than read from config so this stays pure
+    and so the bidder and the gate cannot drift onto different bands.
+    """
+    if marginal_ep_gain >= must_have:
+        return Tier.MUST_HAVE
+    if marginal_ep_gain >= strong:
+        return Tier.STRONG
+    if marginal_ep_gain >= solid:
+        return Tier.SOLID
+    return Tier.MARGINAL
+
+
+def max_allowed_bid(
+    *,
+    market_value: int,
+    tier: Tier | str | None,
+    floor_eur: int,
+    tier_pcts: Mapping[Tier, float],
+) -> int:
+    """The highest bid permitted for this player, in euros.
+
+    Returns 0 for a non-positive market value: `check_buy` reports that as its
+    own failure, and this must not hand back a spendable ceiling computed from
+    a nonsense input.
+    """
+    if market_value <= 0:
+        return 0
+
+    resolved = FALLBACK_TIER
+    if tier is not None:
+        try:
+            resolved = Tier(tier)
+        except ValueError:
+            resolved = FALLBACK_TIER
+
+    pct = tier_pcts.get(resolved, tier_pcts[FALLBACK_TIER])
+    return market_value + max(floor_eur, int(market_value * pct / 100.0))
+
+
+@dataclass(frozen=True)
+class BidCeilingPolicy:
+    """The configured ceiling, carried as one value instead of loose numbers.
+
+    Built from `Settings.bid_ceiling_policy()` and handed to both
+    `SmartBidding` and `safety_gate.check_buy`, so neither can be constructed
+    with half the policy or a stale copy of it.
+    """
+
+    floor_eur: int
+    tier_pcts: Mapping[Tier, float]
+
+    def max_bid(self, market_value: int, tier: Tier | str | None) -> int:
+        """The highest bid permitted for this player, in euros."""
+        return max_allowed_bid(
+            market_value=market_value,
+            tier=tier,
+            floor_eur=self.floor_eur,
+            tier_pcts=self.tier_pcts,
+        )

--- a/rehoboam/services/safety_gate.py
+++ b/rehoboam/services/safety_gate.py
@@ -12,6 +12,7 @@ from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 
 from rehoboam.config import MAX_PLAYERS_PER_CLUB
+from rehoboam.services.bid_ceiling import FALLBACK_TIER, BidCeilingPolicy, Tier
 
 
 @dataclass(frozen=True)
@@ -30,7 +31,8 @@ def check_buy(
     current_budget: int,
     free_slots: int,
     known_player_ids: Iterable[str],
-    max_overbid_pct: float,
+    tier: Tier | str | None,
+    ceiling_policy: BidCeilingPolicy,
     club_id: str | None = None,
     squad_club_counts: Mapping[str, int] | None = None,
     max_players_per_club: int = MAX_PLAYERS_PER_CLUB,
@@ -59,12 +61,18 @@ def check_buy(
     if market_value <= 0:
         reasons.append(f"invalid market value: EUR {market_value:,} (must be positive)")
     else:
-        cap = market_value * (1.0 + max_overbid_pct / 100.0)
+        # The ceiling is computed here rather than accepted as a number, so the
+        # last check before real money never trusts a caller's arithmetic. It
+        # is the same `max_allowed_bid` the bidder sized against, which is what
+        # stops a proposal being offered and then refused (REH-99).
+        cap = ceiling_policy.max_bid(market_value, tier)
         if bid > cap:
             over = (bid / market_value - 1.0) * 100.0
+            allowed = (cap / market_value - 1.0) * 100.0
             reasons.append(
-                f"overbid {over:.1f}% exceeds the {max_overbid_pct:.1f}% cap "
-                f"(bid EUR {bid:,} vs market value EUR {market_value:,})"
+                f"overbid {over:.1f}% exceeds the {allowed:.1f}% ceiling for tier "
+                f"{Tier(tier).value if tier else FALLBACK_TIER.value} "
+                f"(bid EUR {bid:,} vs max EUR {cap:,} on market value EUR {market_value:,})"
             )
 
     if free_slots <= 0:

--- a/rehoboam/trader.py
+++ b/rehoboam/trader.py
@@ -118,6 +118,10 @@ class Trader:
             tier_strong_upgrade=getattr(settings, "bid_tier_strong_upgrade", TIER_STRONG_UPGRADE),
             tier_solid_upgrade=getattr(settings, "bid_tier_solid_upgrade", TIER_SOLID_UPGRADE),
             full_commit_gain=getattr(settings, "bid_full_commit_gain", BID_FULL_COMMIT_GAIN),
+            # REH-99: the same ceiling `safety_gate.check_buy` enforces. Passing
+            # it here is the fix for the bug where the bidder used its own 20%/30%
+            # caps and Telegram offered buys the gate would then refuse.
+            ceiling_policy=settings.bid_ceiling_policy(),
         )
 
     # ------------------------------------------------------------------

--- a/tests/test_approval_webhook.py
+++ b/tests/test_approval_webhook.py
@@ -33,7 +33,8 @@ def settings(monkeypatch):
     monkeypatch.setenv("KICKBASE_PASSWORD", "t")
     s = Settings()
     s.telegram_webhook_secret = "s3cret"
-    s.max_overbid_pct = 8.0
+    # REH-99 replaced the flat `max_overbid_pct` with the tier table; the
+    # shipped defaults are what approval enforces, so nothing to override.
     return s
 
 

--- a/tests/test_bid_ceiling.py
+++ b/tests/test_bid_ceiling.py
@@ -1,0 +1,137 @@
+"""The single source of truth for how far above market value a bid may go (REH-99).
+
+Two caps used to exist independently: `Settings.max_overbid_pct = 8.0`, enforced
+only in `safety_gate.check_buy`, and `SmartBidding.max_overbid_pct = 20.0`
+(elite 30.0), which actually sized the bid. `trader.py` never passed the former
+to the latter, so Telegram offered buys the gate would refuse — the Approve
+button could not work. This module exists so the number shown and the number
+allowed are computed once, by the same code.
+
+The shape is `market_value + max(floor, market_value x tier_pct)`, and both
+halves are load-bearing:
+
+- **The absolute floor** fixes the cheap end. Fabio Chiarodia was lost at a
+  market value of EUR 591,389 to a winner paying EUR 156,085 over — while an 8%
+  cap stopped the bot at EUR 47,311. A EUR 109k gap against a EUR 62M budget.
+  A percentage is simply the wrong unit down there.
+- **The tier percentage** keeps discipline where it belongs. A marginal churn
+  candidate pays the 12.2% round-trip toll and should not be chased; a
+  must-have is held to score points all season, has no round trip, and
+  amortises the premium over 30+ matchdays.
+
+Measured against the 12 lost auctions carrying `winning_overbid_pct`, a flat 8%
+would have won **none** of them; the lowest winning overbid was 8.4%.
+"""
+
+import pytest
+
+from rehoboam.services.bid_ceiling import Tier, max_allowed_bid, tier_for_marginal_gain
+
+# Defaults from Settings, restated so a config change cannot silently
+# invalidate the cases these numbers were chosen against.
+FLOOR = 250_000
+PCTS = {
+    Tier.MARGINAL: 8.0,
+    Tier.SOLID: 15.0,
+    Tier.STRONG: 25.0,
+    Tier.MUST_HAVE: 35.0,
+}
+
+
+def _ceiling(mv: int, tier: Tier) -> int:
+    return max_allowed_bid(market_value=mv, tier=tier, floor_eur=FLOOR, tier_pcts=PCTS)
+
+
+class TestTheAbsoluteFloorCoversCheapPlayers:
+    def test_chiarodia_would_now_be_winnable(self):
+        """EUR 591,389 market value, lost to a winner paying EUR 156,085 over."""
+        assert _ceiling(591_389, Tier.MARGINAL) >= 591_389 + 156_085
+
+    def test_the_floor_beats_the_percentage_on_a_cheap_player(self):
+        mv = 591_389
+        assert _ceiling(mv, Tier.MARGINAL) == mv + FLOOR
+
+    def test_even_the_lowest_tier_gets_the_floor(self):
+        """The floor is about the unit being wrong, not about player quality."""
+        assert _ceiling(100_000, Tier.MARGINAL) == 100_000 + FLOOR
+
+
+class TestThePercentageTakesOverOnExpensivePlayers:
+    def test_the_percentage_beats_the_floor_once_it_is_larger(self):
+        mv = 20_000_000
+        assert _ceiling(mv, Tier.MARGINAL) == mv + int(mv * 0.08)
+
+    def test_a_must_have_may_go_further_than_a_marginal(self):
+        mv = 20_000_000
+        assert _ceiling(mv, Tier.MUST_HAVE) > _ceiling(mv, Tier.MARGINAL)
+
+    @pytest.mark.parametrize(
+        "name,mv,winner_extra,tier",
+        [
+            ("Suzuki", 7_329_934, 750_874, Tier.SOLID),
+            ("Bitshiabu", 5_466_049, 1_756_173, Tier.MUST_HAVE),
+            ("Vandevoordt", 9_508_586, 2_612_625, Tier.MUST_HAVE),
+            ("Honorat", 11_616_331, 3_939_228, Tier.MUST_HAVE),
+            ("Lemperle", 15_017_565, 4_982_433, Tier.MUST_HAVE),
+        ],
+    )
+    def test_real_lost_auctions_become_winnable_at_the_right_tier(
+        self, name, mv, winner_extra, tier
+    ):
+        """Every one of these was lost under the 8% cap."""
+        assert _ceiling(mv, tier) >= mv + winner_extra, name
+
+    def test_the_runaway_cheap_auctions_stay_out_of_reach(self):
+        """Inacio went at +385% of a EUR 5,028,049 market value.
+
+        That is the league overpaying, not the bot being outbid. The ceiling
+        must not chase it at any tier.
+        """
+        assert _ceiling(5_028_049, Tier.MUST_HAVE) < 5_028_049 + 19_361_516
+
+
+class TestMonotonicity:
+    def test_ceiling_never_decreases_as_tier_improves(self):
+        mv = 10_000_000
+        ceilings = [
+            _ceiling(mv, t) for t in (Tier.MARGINAL, Tier.SOLID, Tier.STRONG, Tier.MUST_HAVE)
+        ]
+        assert ceilings == sorted(ceilings)
+
+    def test_ceiling_always_exceeds_market_value(self):
+        for mv in (1, 500_000, 5_000_000, 50_000_000):
+            assert _ceiling(mv, Tier.MARGINAL) > mv
+
+
+class TestGuards:
+    @pytest.mark.parametrize("mv", [0, -1, -5_000_000])
+    def test_a_non_positive_market_value_allows_nothing(self, mv):
+        """`check_buy` reports invalid market value separately; this must not
+        hand back a spendable ceiling built on a nonsense input."""
+        assert _ceiling(mv, Tier.MUST_HAVE) == 0
+
+    def test_an_unknown_tier_falls_back_to_the_tightest(self):
+        """A stale or corrupted proposal must not buy itself a bigger ceiling."""
+        got = max_allowed_bid(market_value=20_000_000, tier=None, floor_eur=FLOOR, tier_pcts=PCTS)
+        assert got == _ceiling(20_000_000, Tier.MARGINAL)
+
+
+class TestTierFromMarginalGain:
+    """The tier must come from the same bands SmartBidding already uses."""
+
+    @pytest.mark.parametrize(
+        "gain,expected",
+        [
+            (100.0, Tier.MUST_HAVE),
+            (62.5, Tier.MUST_HAVE),
+            (50.0, Tier.STRONG),
+            (37.5, Tier.STRONG),
+            (30.0, Tier.SOLID),
+            (25.0, Tier.SOLID),
+            (10.0, Tier.MARGINAL),
+            (0.0, Tier.MARGINAL),
+            (-5.0, Tier.MARGINAL),
+        ],
+    )
+    def test_bands_match_the_configured_thresholds(self, gain, expected):
+        assert tier_for_marginal_gain(gain, must_have=62.5, strong=37.5, solid=25.0) == expected

--- a/tests/test_bid_ceiling_agreement.py
+++ b/tests/test_bid_ceiling_agreement.py
@@ -1,0 +1,138 @@
+"""The bidder and the gate must never disagree about the ceiling (REH-99).
+
+This is the regression test for the reported bug. `SmartBidding` sized bids
+with its own 20%/30% caps while `safety_gate.check_buy` enforced a 8% one, and
+`trader.py` never connected them — so a proposal could be rendered into
+Telegram at +16% and then refused by the gate when the user tapped Approve.
+The Approve button could not work, and the proposal was marked `failed`.
+
+The property asserted here is the one that matters: **anything the bidder is
+willing to propose, the gate is willing to execute.** It is checked across the
+market-value range where the two old constants disagreed, at every tier.
+"""
+
+import pytest
+
+from rehoboam.config import Settings
+from rehoboam.services.bid_ceiling import BidCeilingPolicy, Tier, max_allowed_bid
+from rehoboam.services.safety_gate import check_buy
+
+
+def _policy() -> BidCeilingPolicy:
+    return Settings(kickbase_email="test@example.com", kickbase_password="x").bid_ceiling_policy()
+
+
+MARKET_VALUES = [
+    591_389,  # Chiarodia — the cheap end, where the floor governs
+    2_205_708,
+    5_466_049,
+    12_543_020,  # Matsima — the listing that reproduced the bug
+    34_217_295,  # Raum
+    44_220_901,  # Undav, the most expensive live listing
+]
+
+
+class TestThePolicyMatchesTheBareFunction:
+    @pytest.mark.parametrize("mv", MARKET_VALUES)
+    @pytest.mark.parametrize("tier", list(Tier))
+    def test_policy_delegates_to_one_definition(self, mv, tier):
+        policy = _policy()
+        assert policy.max_bid(mv, tier) == max_allowed_bid(
+            market_value=mv,
+            tier=tier,
+            floor_eur=policy.floor_eur,
+            tier_pcts=policy.tier_pcts,
+        )
+
+
+class TestTheGateAcceptsWhatTheCeilingAllows:
+    @pytest.mark.parametrize("mv", MARKET_VALUES)
+    @pytest.mark.parametrize("tier", list(Tier))
+    def test_a_bid_at_the_ceiling_passes(self, mv, tier):
+        policy = _policy()
+        bid = policy.max_bid(mv, tier)
+        result = check_buy(
+            player_id="1",
+            bid=bid,
+            market_value=mv,
+            current_budget=200_000_000,
+            free_slots=3,
+            known_player_ids=["1"],
+            tier=tier,
+            ceiling_policy=policy,
+        )
+        assert result.ok, result.reasons
+
+    @pytest.mark.parametrize("mv", MARKET_VALUES)
+    @pytest.mark.parametrize("tier", list(Tier))
+    def test_one_euro_above_the_ceiling_is_refused(self, mv, tier):
+        policy = _policy()
+        result = check_buy(
+            player_id="1",
+            bid=policy.max_bid(mv, tier) + 1,
+            market_value=mv,
+            current_budget=200_000_000,
+            free_slots=3,
+            known_player_ids=["1"],
+            tier=tier,
+            ceiling_policy=policy,
+        )
+        assert not result.ok
+        assert any("exceeds" in r for r in result.reasons)
+
+
+class TestTheReportedBugCannotRecur:
+    def test_the_matsima_bid_is_capped_to_something_the_gate_accepts(self):
+        """The live reproduction. Market value EUR 12,543,020, +32.1 marginal
+        gain, so a solid upgrade.
+
+        The uncapped bidder proposed EUR 14,553,020 (+16.0%) and the old flat
+        8% gate refused it. The fix is not that the gate now waves that number
+        through — it is that the bidder is held to the same ceiling the gate
+        enforces, so what gets proposed is executable.
+        """
+        policy = _policy()
+        capped = policy.max_bid(12_543_020, Tier.SOLID)
+        assert capped < 14_553_020, "the old uncapped bid should be trimmed"
+
+        result = check_buy(
+            player_id="9642",
+            bid=capped,
+            market_value=12_543_020,
+            current_budget=62_257_522,
+            free_slots=4,
+            known_player_ids=["9642"],
+            tier=Tier.SOLID,
+            ceiling_policy=policy,
+        )
+        assert result.ok, result.reasons
+
+    def test_the_old_uncapped_bid_is_still_refused(self):
+        """The gate must not become toothless in the process."""
+        policy = _policy()
+        result = check_buy(
+            player_id="9642",
+            bid=14_553_020,
+            market_value=12_543_020,
+            current_budget=62_257_522,
+            free_slots=4,
+            known_player_ids=["9642"],
+            tier=Tier.SOLID,
+            ceiling_policy=policy,
+        )
+        assert not result.ok
+
+    def test_a_missing_tier_still_refuses_a_wild_bid(self):
+        """A corrupted proposal falls back to the tightest tier, not the widest."""
+        policy = _policy()
+        result = check_buy(
+            player_id="1",
+            bid=100_000_000,
+            market_value=12_543_020,
+            current_budget=200_000_000,
+            free_slots=3,
+            known_player_ids=["1"],
+            tier=None,
+            ceiling_policy=policy,
+        )
+        assert not result.ok

--- a/tests/test_safety_gate.py
+++ b/tests/test_safety_gate.py
@@ -4,7 +4,16 @@ A public webhook will call this before spending money, so it is written and
 tested before anything can reach it.
 """
 
+from rehoboam.config import Settings
+from rehoboam.services.bid_ceiling import BidCeilingPolicy, Tier
 from rehoboam.services.safety_gate import check_buy
+
+
+def _policy() -> BidCeilingPolicy:
+    """The shipped default policy. REH-99 replaced the flat 8% with a
+    tier table plus an absolute floor, so the marginal tier keeps 8% but a
+    cheap player also gets `overbid_floor_eur` of headroom."""
+    return Settings(kickbase_email="test@example.com", kickbase_password="x").bid_ceiling_policy()
 
 
 def _ok_kwargs(**over):
@@ -15,7 +24,8 @@ def _ok_kwargs(**over):
         "current_budget": 95_317_114,
         "free_slots": 2,
         "known_player_ids": {"6080", "859"},
-        "max_overbid_pct": 8.0,
+        "tier": Tier.MARGINAL,
+        "ceiling_policy": _policy(),
     }
     base.update(over)
     return base
@@ -42,8 +52,11 @@ class TestBudgetSafety:
 
 
 class TestOverbidCap:
+    """At this market value the marginal tier's 8% dominates `overbid_floor_eur`,
+    so the ceiling is unchanged by REH-99: 32,285,629 * 1.08 = 34,868,479."""
+
     def test_a_bid_above_the_cap_is_refused(self):
-        """32,285,629 * 1.08 = 34,868,479. A 38.3M bid is 18.7% over."""
+        """A 38.3M bid is 18.7% over."""
         r = check_buy(**_ok_kwargs(bid=38_336_318))
         assert r.ok is False
         assert any("overbid" in x.lower() for x in r.reasons)
@@ -121,7 +134,8 @@ class TestClubLimit:
             "current_budget": 50_000_000,
             "free_slots": 4,
             "known_player_ids": ["1"],
-            "max_overbid_pct": 8.0,
+            "tier": Tier.MARGINAL,
+            "ceiling_policy": _policy(),
         }
         base.update(over)
         return base


### PR DESCRIPTION
Closes REH-99. Reported bug: two buys arrived in Telegram above the 8% cap.

## Root cause — two caps, never connected

```
Settings.max_overbid_pct       = 8.0    enforced only in safety_gate.check_buy
SmartBidding.max_overbid_pct   = 20.0   what actually sized the bid (elite 30.0)
```

`trader.py:112` built `SmartBidding` passing the four tier fields but **not** the cap. `_propose_buy` rendered `recommended_bid` straight into the Telegram message with no gate check, and `check_buy`'s only call site is the Approve handler.

**Every proposal above 8% was dead on arrival** — Approve could not succeed, the gate refused, the proposal was marked `failed`.

## Why the obvious fix would have been wrong

Wiring 8% through to the bidder would have won **none of the 12** lost auctions carrying `winning_overbid_pct`. Lowest winning overbid: 8.4%.

| player | market value | winner paid | our 8% ceiling |
|---|---|---|---|
| Chiarodia | €591,389 | €156,085 | **€47,311** |
| Bitshiabu | €5,466,049 | €1,756,173 | €437,283 |
| Honorat | €11,616,331 | €3,939,228 | €929,306 |
| Lemperle | €15,017,565 | €4,982,433 | €1,201,405 |

Chiarodia was lost for want of **€109k against a €62M budget**.

Three problems with the 8% figure:

1. **The band table behind it is confounded.** It compares win rate by *our* overbid, but the bot bids higher precisely when a player is contested, and contested players are harder to win by construction. High-overbid buckets are the hard-auction population.
2. **Wrong population.** The 12.2% round-trip toll is flip economics — it only bites if you sell. A held player amortises the premium over 30+ matchdays.
3. **REH-64 says so itself**: *"rests on 26 samples and may cost contested stars."*

## The fix

One ceiling, computed once, used by both sides:

```
max_allowed_bid = market_value + max(floor, market_value × tier_pct)
```

The absolute floor fixes the cheap end where a percentage is the wrong unit; the tier percentage keeps discipline where the toll genuinely applies.

| field | default |
|---|---|
| `overbid_floor_eur` | 250,000 |
| `overbid_pct_marginal` | 8.0 |
| `overbid_pct_solid` | 15.0 |
| `overbid_pct_strong` | 25.0 |
| `overbid_pct_must_have` | 35.0 |

- `services/bid_ceiling.py` holds the single definition.
- `SmartBidding` applies it **last**, so nothing downstream can lift a bid back over it.
- `check_buy` **recomputes** it rather than trusting a number passed in — the last check before real money shouldn't rely on the caller's arithmetic.
- The replay gets the same policy, so it can't drift from live (REH-84).
- `trade_proposals` gains a `tier` column via guarded `ALTER`, so approval recomputes against the **live** market value. Pre-existing rows have `tier` NULL and fall back to the tightest tier — refusing rather than over-permitting.

## Verification

**Live market: 10 of 10 current candidates pass the gate they're checked against.** Five were above 8% and would have been refused before.

```
Awortwie-Grant     614,877   +19.4%  strong_upgrade  PASS
Raum            40,793,099   +19.0%  strong_upgrade  PASS
Undav           54,405,858   +23.0%  must_have       PASS
Tah             44,068,628   +19.0%  strong_upgrade  PASS
...
10 candidates, 0 refused
```

**Season replay unchanged at 27,751** (A/B by stash, identical both sides) — the ceiling is a backstop that doesn't move the strategy. A targeted check confirms it binds and isn't dead code: a solid-tier contested bid caps from +19.0% to +15.0%.

101 new tests. 1174 pass, 1 skipped. Pre-commit clean.

## Caveats

The numbers rest on 12 rows, one internally inconsistent (Rohr: our bid 25.6%, winner recorded 8.4%). They set the *shape*, not precise values — all are `Settings` fields, re-tunable from `.env` as `auction_outcomes` fills.

## Out of scope — needs its own ticket

`check_buy` guards only the approval path. `services/execution.py:129` (autonomous trade pairs, emergency fill) and `league_compliance.py:384` (compliance re-bid) call `api.buy_player` without it. The setting that calls itself *"the outer limit nothing may cross"* currently constrains only the path that asks permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)