### PR TITLE
feat(bidding): pace season capital — reserve the ability to keep buying (REH-85)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,16 @@ SMTP_USER=
 SMTP_PASSWORD=
 ALERT_EMAIL_TO=
 
+# --- Capital pacing (REH-85) ------------------------------------------------
+# Reserve enough budget after each buy to make the remaining moves needed.
+PACING_ENABLED=true
+# Moves the reserve protects once the squad is full at 15/15.
+PACING_IN_SEASON_MIN_MOVES=2
+# Trailing window (days) over manager_transfers to measure move costs.
+PACING_WINDOW_DAYS=90
+# Floor under the measured median move price (in EUR).
+PACING_MEDIAN_FLOOR_EUR=3000000
+
 # --- Deployed behaviour (REH-100) ------------------------------------------
 # What the AZURE FUNCTION should do. Deliberately separate from DRY_RUN above,
 # which controls local `rehoboam auto` runs and is safe at true. An infra

--- a/docs/superpowers/plans/2026-08-26-reh-85-capital-pacing.md
+++ b/docs/superpowers/plans/2026-08-26-reh-85-capital-pacing.md
@@ -632,7 +632,13 @@ ______________________________________________________________________
 - Consumes: `PacingContext` from Task 1.
 - Produces: `calculate_ep_bid(..., pacing: PacingContext | None = None)`. `None` means pacing is off, and every existing caller keeps working unchanged.
 
-Placement matters and is not arbitrary. `bidding_strategy.py:434` reads `ep_max_bid = max(ep_max_bid, asking_price + overbid_amount)` — the Kimmich fix of 2026-08-24, which deliberately floors the EP cap at the asking price so a wanted player is not priced out of his own auction. A pacing cap applied *before* that line would be floored straight back off. Apply it immediately after the REH-99 ceiling, which is the last thing that lowers a bid.
+Placement matters and is not arbitrary — **corrected 2026-08-26 during Task 5's review.** The mechanism is the **market-value floor**, not the Kimmich line.
+
+`bidding_strategy.py:442` is `recommended_bid = min(recommended_bid, ep_max_bid, budget_ceiling)` — a `min`, so the Kimmich line above it (which only raises `ep_max_bid`) cannot lift an already-reduced `recommended_bid`. What *can* is the market-value floor at lines 446-448, which unconditionally raises `recommended_bid` to `min(market_value * 1.01, budget_ceiling)` whenever it falls below that.
+
+So a pacing cap applied before the market-value floor is silently undone. Apply it immediately after the REH-99 ceiling, which is the last thing that lowers a bid.
+
+**A test for this must be built deliberately.** The obvious numbers do not discriminate: when `market_value * 1.01` is below the asking price, a misplaced cap gets rescued to a value still under asking, and the pre-existing `recommended_bid < asking_price -> 0` net zeroes it anyway — so the test passes either way. Choose `market_value` close enough to `asking_price` that the floor's rescue lands *above* asking, and verify by moving the block, watching the test fail, and moving it back.
 
 - [ ] **Step 1: Write the failing tests**
 

--- a/docs/superpowers/plans/2026-08-26-reh-85-capital-pacing.md
+++ b/docs/superpowers/plans/2026-08-26-reh-85-capital-pacing.md
@@ -238,7 +238,8 @@ def capital_reserve(
     completes, and `in_season_min_moves` is what remains at 15/15 so a full
     squad can still replace a player.
     """
-    moves = slots_to_fill if slots_to_fill > 0 else in_season_min_moves
+    moves_after_this_buy = max(slots_to_fill - 1, 0)
+    moves = moves_after_this_buy if slots_to_fill > 0 else in_season_min_moves
     return max(0, moves) * max(0, median_move)
 
 

--- a/docs/superpowers/plans/2026-08-26-reh-85-capital-pacing.md
+++ b/docs/superpowers/plans/2026-08-26-reh-85-capital-pacing.md
@@ -310,7 +310,11 @@ def test_auto_trader_slot_helper_delegates_to_the_pacing_module():
     from rehoboam import auto_trader
     from rehoboam.services import pacing
 
-    assert auto_trader.SQUAD_CAP is pacing.SQUAD_CAP
+    # Identity on the FUNCTION, not on SQUAD_CAP: CPython interns small
+    # integers, so `15 is 15` is True even for two separate definitions and
+    # would pass before this task did anything.
+    assert auto_trader.available_squad_slots is pacing.available_squad_slots
+    assert auto_trader.SQUAD_CAP == pacing.SQUAD_CAP
     for squad, bids in ((11, 1), (15, 0), (13, 2), (15, 2)):
         assert auto_trader._available_squad_slots(
             squad, bids
@@ -320,7 +324,7 @@ def test_auto_trader_slot_helper_delegates_to_the_pacing_module():
 - [ ] **Step 2: Run the test to verify it fails**
 
 Run: `uv run pytest tests/test_pacing.py::test_auto_trader_slot_helper_delegates_to_the_pacing_module -q`
-Expected: FAIL with `AssertionError` on `auto_trader.SQUAD_CAP is pacing.SQUAD_CAP` (two separate int objects with the same value are not guaranteed identical, and here they are separate definitions).
+Expected: FAIL with `AttributeError: module 'rehoboam.auto_trader' has no attribute 'available_squad_slots'` — the name does not exist there until Step 3 imports it.
 
 - [ ] **Step 3: Replace the duplicate with a delegation**
 

--- a/docs/superpowers/plans/2026-08-26-reh-85-capital-pacing.md
+++ b/docs/superpowers/plans/2026-08-26-reh-85-capital-pacing.md
@@ -804,9 +804,11 @@ Expected: FAIL — `TypeError: calculate_ep_bid() got an unexpected keyword argu
 
 In `rehoboam/bidding_strategy.py`, add to the end of the `calculate_ep_bid` parameter list (after `is_dgw: bool = False`):
 
-```python
-pacing: "PacingContext | None" = (None,)
+```text
+pacing: PacingContext | None = None,
 ```
+
+(Fenced as `text`, not `python`, deliberately: the repo's mdformat pre-commit hook runs black over python blocks, and black parses a bare `name: T = None,` fragment as a statement and rewrites it to `= (None,)` — a tuple default. That corruption is what the Task 5 implementer hit and correctly worked around. No quotes are needed on the annotation: `bidding_strategy.py` already has `from __future__ import annotations`, and ruff's UP037 removes them.)
 
 Add the import at the top of the file:
 

--- a/docs/superpowers/plans/2026-08-26-reh-85-capital-pacing.md
+++ b/docs/superpowers/plans/2026-08-26-reh-85-capital-pacing.md
@@ -1,0 +1,1399 @@
+# Capital Pacing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop one signing from consuming the season's capital, by reserving enough budget to make the moves the bot still needs.
+
+**Architecture:** A new pure module `rehoboam/services/pacing.py` computes a euro *reserve* from the squad slots still to fill and a *measured* median move price. `SmartBidding.calculate_ep_bid` accepts an optional `PacingContext` and applies one extra `min()` immediately after the REH-99 ceiling. Nothing else in the bidding stack changes: because the existing code already turns a cap below the asking price into `recommended_bid = 0`, "cap, don't refuse" needs no new branch, and because trade pairs already pass a synthetic `SellPlan` carrying the sale proceeds, they get net-cost pacing with no special case.
+
+**Tech Stack:** Python 3.12, Pydantic `Settings`, SQLite via `BidLearner`, pytest, `uv` for everything.
+
+**Spec:** `docs/superpowers/specs/2026-08-26-reh-85-capital-pacing-design.md`
+
+## Global Constraints
+
+- Every tunable is a `Settings` field, re-tunable from `.env` without a deploy.
+- Defaults: `pacing_enabled=True`, `pacing_in_season_min_moves=2`, `pacing_window_days=90`, `pacing_median_floor_eur=3_000_000`.
+- The squad cap is **15**, and an open offer counts as a filled slot.
+- Pacing **never** applies to emergency squad fill (an empty slot is -100) or to the compliance re-bid (mandatory).
+- TDD throughout: write the failing test, watch it fail, minimal implementation, watch it pass, commit.
+- Run `uv run pytest -q` before every commit. Formatting is enforced by pre-commit; do not run `black` on whole files manually.
+- Baseline to beat: **26,391** on `replay-season --with-competition`; 26,960 on the plain configuration.
+
+______________________________________________________________________
+
+### Task 1: The pure pacing module
+
+**Files:**
+
+- Create: `rehoboam/services/pacing.py`
+- Test: `tests/test_pacing.py`
+
+**Interfaces:**
+
+- Consumes: nothing.
+
+- Produces: `SQUAD_CAP: int`, `available_squad_slots(squad_size: int, open_bid_count: int, cap: int = SQUAD_CAP) -> int`, `median_move_price(prices: Sequence[int], *, floor_eur: int) -> int`, `capital_reserve(*, slots_to_fill: int, in_season_min_moves: int, median_move: int) -> int`, and the frozen dataclass `PacingContext(reserve: int, open_offers: int)` with method `max_bid(self, budget_ceiling: int) -> int`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_pacing.py`:
+
+```python
+"""Reserve the ability to keep buying (REH-85).
+
+The bot committed EUR 71m of an EUR 80m ceiling to one player and then made
+four more buys all season, finishing on EUR 500,000. The champions each made
+one EUR 60-65m signing AND roughly 25 more purchases. The difference is not
+the size of a bid; it is what the bid leaves behind.
+"""
+
+import pytest
+
+from rehoboam.services.pacing import (
+    PacingContext,
+    available_squad_slots,
+    capital_reserve,
+    median_move_price,
+)
+
+
+class TestMedianMovePrice:
+    def test_returns_the_median_of_the_observed_prices(self):
+        assert (
+            median_move_price([1_000_000, 5_000_000, 9_000_000], floor_eur=0)
+            == 5_000_000
+        )
+
+    def test_even_count_takes_the_lower_of_the_two_middles(self):
+        # Deliberately not an average: a reserve must be a price someone
+        # actually paid, not an interpolation between two that nobody did.
+        assert median_move_price([2_000_000, 4_000_000], floor_eur=0) == 2_000_000
+
+    def test_empty_population_falls_back_to_the_floor(self):
+        # A thin window must not collapse the reserve to zero, which would
+        # silently disable pacing exactly when there is least evidence.
+        assert median_move_price([], floor_eur=3_000_000) == 3_000_000
+
+    def test_floor_wins_when_the_measured_median_is_below_it(self):
+        assert median_move_price([500_000, 600_000], floor_eur=3_000_000) == 3_000_000
+
+
+class TestAvailableSquadSlots:
+    def test_open_bids_count_as_filled(self):
+        # Kickbase counts a pending offer toward the 15-player cap.
+        assert available_squad_slots(squad_size=11, open_bid_count=1) == 3
+
+    def test_full_squad_has_no_slots(self):
+        assert available_squad_slots(squad_size=15, open_bid_count=0) == 0
+
+    def test_over_committed_squad_does_not_report_negative_room(self):
+        assert available_squad_slots(squad_size=15, open_bid_count=2) == -2
+
+
+class TestCapitalReserve:
+    def test_reserves_one_median_move_per_unfilled_slot(self):
+        assert (
+            capital_reserve(
+                slots_to_fill=3, in_season_min_moves=2, median_move=10_800_000
+            )
+            == 32_400_000
+        )
+
+    def test_full_squad_falls_back_to_the_in_season_minimum(self):
+        # At 15/15 there are no slots to fill, but the bot must still be able
+        # to replace a player mid-season.
+        assert (
+            capital_reserve(
+                slots_to_fill=0, in_season_min_moves=2, median_move=10_800_000
+            )
+            == 21_600_000
+        )
+
+    def test_negative_slots_never_shrink_the_reserve_below_the_minimum(self):
+        assert (
+            capital_reserve(
+                slots_to_fill=-2, in_season_min_moves=2, median_move=10_800_000
+            )
+            == 21_600_000
+        )
+
+
+class TestPacingContext:
+    def test_max_bid_is_the_ceiling_less_open_offers_and_reserve(self):
+        ctx = PacingContext(reserve=32_400_000, open_offers=0)
+        assert ctx.max_bid(budget_ceiling=62_307_522) == 29_907_522
+
+    def test_open_offers_are_already_spent(self):
+        # Kickbase's reported budget does not deduct pending offers, so two
+        # bids sized against the same nominal budget can both land.
+        ctx = PacingContext(reserve=10_000_000, open_offers=5_000_000)
+        assert ctx.max_bid(budget_ceiling=50_000_000) == 35_000_000
+
+    def test_max_bid_never_goes_negative(self):
+        ctx = PacingContext(reserve=50_000_000, open_offers=0)
+        assert ctx.max_bid(budget_ceiling=10_000_000) == 0
+
+    def test_the_unwind_sequence_from_the_spec(self):
+        """Section 2 of the design doc, as executable arithmetic.
+
+        The point of deriving the reserve from slots-to-fill rather than a
+        constant N is that it unwinds. A constant 3 moves would leave the
+        reserve at EUR 32.4m while the budget fell, capping the second buy
+        near EUR 4.8m and freezing the bot one purchase later.
+        """
+        median = 10_800_000
+        budget = 62_307_522
+        caps = []
+        for slots in (3, 2, 1):
+            reserve = capital_reserve(
+                slots_to_fill=slots, in_season_min_moves=2, median_move=median
+            )
+            cap = PacingContext(reserve=reserve, open_offers=0).max_bid(budget)
+            caps.append(cap)
+            budget -= cap  # spend the whole cap, the worst case for the next step
+        assert caps[0] == 29_907_522
+        assert all(c > 0 for c in caps), "the reserve must never freeze the next buy"
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/test_pacing.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'rehoboam.services.pacing'`
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `rehoboam/services/pacing.py`:
+
+```python
+"""How much budget a buy must leave behind (REH-85).
+
+`bidding_strategy.max_bid_fraction` asks what fraction of the *current* budget
+a signing justifies — a single-decision question with a defensible answer.
+Nothing asked the sequential one: what does this signing leave the bot able to
+do for the next thirty matchdays? A competition-modelled replay answered it —
+EUR 71m on one player, then five buys all season and EUR 500,000 left, with
+every declined candidate rated `must_have` by the bot's own tiering.
+
+Measured against `manager_transfers`, the champions each made ONE signing of
+EUR 60-65m *and* roughly 25 further purchases. So the rule here constrains what
+a buy leaves behind, never how large it is. A hard per-transaction cap near
+their EUR 11m mean — the ticket's first suggestion — would have banned both of
+their biggest signings; that mean is an artefact of a heavily skewed
+distribution.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+#: Kickbase's hard squad-size limit, including open (unresolved) bids.
+SQUAD_CAP = 15
+
+
+def available_squad_slots(
+    squad_size: int, open_bid_count: int, cap: int = SQUAD_CAP
+) -> int:
+    """Slots left under the squad cap, counting open bids as committed.
+
+    Kickbase counts pending offers toward the 15-player cap before they
+    resolve — a squad at 13 with 2 open bids has zero room for a further bid,
+    not two. May return a negative number when over-committed; callers that
+    need a floor apply their own.
+    """
+    return cap - squad_size - open_bid_count
+
+
+def median_move_price(prices: Sequence[int], *, floor_eur: int) -> int:
+    """What one further purchase costs in this league, in euros.
+
+    The median rather than the mean, because the population is heavily skewed:
+    the champions' buys have a median near EUR 10m and a maximum of EUR 65m, and
+    a mean would price a "move" at something nobody routinely pays.
+
+    On an even count this takes the lower of the two middle values rather than
+    averaging them, so the result is always a price someone actually paid.
+
+    `floor_eur` guards the thin-window case. A near-empty window would otherwise
+    produce a reserve of nearly zero, which disables pacing silently — exactly
+    when there is least evidence to justify spending freely.
+    """
+    if not prices:
+        return floor_eur
+    ordered = sorted(int(p) for p in prices)
+    median = ordered[(len(ordered) - 1) // 2]
+    return max(median, floor_eur)
+
+
+def capital_reserve(
+    *, slots_to_fill: int, in_season_min_moves: int, median_move: int
+) -> int:
+    """Euros that must survive this buy, so the bot can keep operating.
+
+    `slots_to_fill` rather than a constant is the load-bearing choice. A
+    constant N keeps the reserve fixed while the budget falls, so the bot
+    freezes one purchase later than it does today rather than not at all.
+    Deriving it from unfilled slots makes the reserve unwind as the squad
+    completes, and `in_season_min_moves` is what remains at 15/15 so a full
+    squad can still replace a player.
+    """
+    moves = max(slots_to_fill, in_season_min_moves)
+    return max(0, moves) * max(0, median_move)
+
+
+@dataclass(frozen=True)
+class PacingContext:
+    """What pacing needs that the bidder itself cannot know.
+
+    Built once per session by the caller, which is the only layer that sees the
+    squad, the open offers and the learning DB. `SmartBidding` stays ignorant of
+    all three and just applies the number.
+    """
+
+    reserve: int
+    open_offers: int
+
+    def max_bid(self, budget_ceiling: int) -> int:
+        """The largest bid that still leaves the reserve intact.
+
+        `budget_ceiling` already includes any sell-plan recovery, which is why
+        trade pairs need no special case: `trader.py` gives a pair a synthetic
+        sell plan whose `total_recovery` is the sale proceeds, so subtracting
+        the reserve from the ceiling paces the pair on its NET cost. A pair
+        recycles capital rather than consuming it, and pacing it on the gross
+        bid would freeze pair trading at 15/15 — the one mechanism a full squad
+        has to improve itself.
+        """
+        return max(0, int(budget_ceiling) - int(self.open_offers) - int(self.reserve))
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/test_pacing.py -q`
+Expected: PASS, 14 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rehoboam/services/pacing.py tests/test_pacing.py
+git commit -m "feat(pacing): reserve arithmetic for season capital (REH-85)"
+```
+
+______________________________________________________________________
+
+### Task 2: Remove the duplicate slot definition
+
+**Files:**
+
+- Modify: `rehoboam/auto_trader.py` (the `SQUAD_CAP` constant and `_available_squad_slots`, around lines 75-90 before Task 1's changes)
+- Test: `tests/test_pacing.py` (append)
+
+**Interfaces:**
+
+- Consumes: `SQUAD_CAP`, `available_squad_slots` from Task 1.
+- Produces: `auto_trader._available_squad_slots` keeps its name and signature so existing callers and tests are untouched.
+
+`auto_trader` already defines this exact arithmetic. Two definitions of a safety-relevant number is how REH-99's 8%/20% split happened, so make `auto_trader` delegate rather than letting the copies drift.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_pacing.py`:
+
+```python
+def test_auto_trader_slot_helper_delegates_to_the_pacing_module():
+    """One definition of the squad cap, not two.
+
+    REH-99 was caused by two constants for one concept living in different
+    modules and drifting apart. This asserts the copies cannot.
+    """
+    from rehoboam import auto_trader
+    from rehoboam.services import pacing
+
+    assert auto_trader.SQUAD_CAP is pacing.SQUAD_CAP
+    for squad, bids in ((11, 1), (15, 0), (13, 2), (15, 2)):
+        assert auto_trader._available_squad_slots(
+            squad, bids
+        ) == pacing.available_squad_slots(squad, bids)
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `uv run pytest tests/test_pacing.py::test_auto_trader_slot_helper_delegates_to_the_pacing_module -q`
+Expected: FAIL with `AssertionError` on `auto_trader.SQUAD_CAP is pacing.SQUAD_CAP` (two separate int objects with the same value are not guaranteed identical, and here they are separate definitions).
+
+- [ ] **Step 3: Replace the duplicate with a delegation**
+
+In `rehoboam/auto_trader.py`, delete the `SQUAD_CAP = 15` line and the whole body of `_available_squad_slots`, and replace both with:
+
+```python
+# One definition of the squad cap, in `services/pacing`. Two copies of one
+# safety-relevant number in different modules is how REH-99's 8%/20% split
+# happened; the name is kept here because callers and tests already use it.
+SQUAD_CAP = pacing_squad_cap
+
+
+def _available_squad_slots(
+    squad_size: int, open_bid_count: int, cap: int = SQUAD_CAP
+) -> int:
+    """Slots left under Kickbase's squad cap, counting open bids as committed.
+
+    Kickbase counts pending offers toward the 15-player cap before they even
+    resolve — a squad at 13 with 2 open bids has zero room for a further
+    bid, not two. Positive means room for another bid; zero or negative
+    means none.
+    """
+    return available_squad_slots(squad_size, open_bid_count, cap)
+```
+
+Add to the imports at the top of `rehoboam/auto_trader.py`, beside the existing `from .services.safety_gate import BuyGate, club_counts`:
+
+```python
+from .services.pacing import SQUAD_CAP as pacing_squad_cap
+from .services.pacing import available_squad_slots
+```
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `uv run pytest -q`
+Expected: PASS. Existing callers of `_available_squad_slots` are unchanged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rehoboam/auto_trader.py tests/test_pacing.py
+git commit -m "refactor(pacing): one definition of the squad cap (REH-85)"
+```
+
+______________________________________________________________________
+
+### Task 3: Read the measured move price from the learning DB
+
+**Files:**
+
+- Modify: `rehoboam/bid_learner.py` (add a reader beside the other read methods)
+- Test: `tests/test_pacing_prices.py`
+
+**Interfaces:**
+
+- Consumes: nothing from earlier tasks.
+- Produces: `BidLearner.recent_buy_prices(window_days: int) -> list[int]`.
+
+`manager_transfers` stores `transfer_type = 1` for a buy and `2` for a sell — verified against our own manager `3616202`, whose type-1 total of EUR 69,831,333 and type-2 total of EUR 139,638,056 match REH-72 §5 exactly. `transfer_dt` is an ISO-8601 string such as `2026-08-25T14:02:11Z`, so a lexicographic comparison against an ISO cutoff is correct and needs no date parsing.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_pacing_prices.py`:
+
+```python
+"""The measured price of one further move (REH-85).
+
+A "move" costs EUR 6.03m across the whole `manager_transfers` table but
+EUR 10.8m in the 2026/27 pre-season. A hardcoded euro figure would be wrong
+within one transfer window, which is the same lesson REH-99 learned about the
+overbid cap: measure the population, and re-measure it.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from rehoboam.bid_learner import BidLearner
+
+
+@pytest.fixture
+def learner(tmp_path):
+    return BidLearner(db_path=tmp_path / "bid_learning.db")
+
+
+def _iso(days_ago: float) -> str:
+    return time.strftime(
+        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time() - days_ago * 86400)
+    )
+
+
+def _row(
+    price: int, days_ago: float, transfer_type: int = 1, player_id: str = "p"
+) -> dict:
+    return {
+        "league_id": "L",
+        "manager_id": "m1",
+        "transfer_dt": _iso(days_ago),
+        "player_id": f"{player_id}{price}",
+        "player_name": "Test",
+        "transfer_type": transfer_type,
+        "transfer_price": price,
+    }
+
+
+def test_returns_buy_prices_inside_the_window(learner):
+    learner.record_manager_transfers([_row(5_000_000, 10), _row(9_000_000, 20)])
+    assert sorted(learner.recent_buy_prices(window_days=90)) == [5_000_000, 9_000_000]
+
+
+def test_excludes_sells(learner):
+    """Type 2 is a sale. Pricing a move off sale proceeds would be wrong."""
+    learner.record_manager_transfers(
+        [_row(5_000_000, 10), _row(80_000_000, 10, transfer_type=2)]
+    )
+    assert learner.recent_buy_prices(window_days=90) == [5_000_000]
+
+
+def test_excludes_rows_outside_the_window(learner):
+    learner.record_manager_transfers([_row(5_000_000, 10), _row(9_000_000, 200)])
+    assert learner.recent_buy_prices(window_days=90) == [5_000_000]
+
+
+def test_prices_are_absolute(learner):
+    """The feed signs a buy negative in some payloads; a reserve is a magnitude."""
+    learner.record_manager_transfers([_row(-7_000_000, 5)])
+    assert learner.recent_buy_prices(window_days=90) == [7_000_000]
+
+
+def test_empty_table_returns_empty_list_not_an_error(learner):
+    assert learner.recent_buy_prices(window_days=90) == []
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/test_pacing_prices.py -q`
+Expected: FAIL — `AttributeError: 'BidLearner' object has no attribute 'recent_buy_prices'`
+
+- [ ] **Step 3: Add the reader**
+
+In `rehoboam/bid_learner.py`, add this method to `BidLearner` immediately after `record_manager_transfers`:
+
+```python
+def recent_buy_prices(self, window_days: int) -> list[int]:
+    """Purchase prices across the league in the trailing window, in euros.
+
+    The population behind REH-85's reserve: what one further move actually
+    costs here. `transfer_type = 1` is a buy and `2` is a sale — verified
+    against manager 3616202, whose type-1 total of EUR 69,831,333 and
+    type-2 total of EUR 139,638,056 match REH-72 §5.
+
+    Prices are returned as magnitudes because the transfer feed signs a
+    purchase negative in some payloads and a reserve is a size, not a
+    direction. `transfer_dt` is ISO-8601, so the cutoff compares
+    lexicographically without parsing.
+    """
+    cutoff = time.strftime(
+        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time() - window_days * 86400)
+    )
+    with sqlite3.connect(self.db_path) as conn:
+        rows = conn.execute(
+            """
+                SELECT ABS(transfer_price)
+                FROM manager_transfers
+                WHERE transfer_type = 1
+                  AND transfer_price IS NOT NULL
+                  AND transfer_dt >= ?
+                """,
+            (cutoff,),
+        ).fetchall()
+    return [int(r[0]) for r in rows]
+```
+
+`bid_learner.py` already imports both `sqlite3` and `time` at module level (lines 4-5), and every method in the file opens its own `with sqlite3.connect(self.db_path) as conn:` — there is no shared `_connect` helper. Match that pattern; do not introduce a second one.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/test_pacing_prices.py -q`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rehoboam/bid_learner.py tests/test_pacing_prices.py
+git commit -m "feat(pacing): read the measured move price from manager_transfers (REH-85)"
+```
+
+______________________________________________________________________
+
+### Task 4: Settings fields
+
+**Files:**
+
+- Modify: `rehoboam/config.py` (add four fields to `Settings`, beside `overbid_floor_eur`)
+- Modify: `.env.example`
+- Test: `tests/test_pacing.py` (append)
+
+**Interfaces:**
+
+- Consumes: nothing.
+
+- Produces: `Settings.pacing_enabled: bool`, `Settings.pacing_in_season_min_moves: int`, `Settings.pacing_window_days: int`, `Settings.pacing_median_floor_eur: int`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_pacing.py`:
+
+```python
+class TestPacingSettings:
+    def test_defaults_match_the_design(self, monkeypatch):
+        monkeypatch.setenv("KICKBASE_EMAIL", "test@example.com")
+        monkeypatch.setenv("KICKBASE_PASSWORD", "test")
+        from rehoboam.config import Settings
+
+        s = Settings()
+        assert s.pacing_enabled is True
+        assert s.pacing_in_season_min_moves == 2
+        assert s.pacing_window_days == 90
+        assert s.pacing_median_floor_eur == 3_000_000
+
+    def test_every_knob_is_overridable_from_the_environment(self, monkeypatch):
+        """Re-tunable mid-season without a deploy — the REH-99 requirement."""
+        monkeypatch.setenv("KICKBASE_EMAIL", "test@example.com")
+        monkeypatch.setenv("KICKBASE_PASSWORD", "test")
+        monkeypatch.setenv("PACING_ENABLED", "false")
+        monkeypatch.setenv("PACING_IN_SEASON_MIN_MOVES", "4")
+        from rehoboam.config import Settings
+
+        s = Settings()
+        assert s.pacing_enabled is False
+        assert s.pacing_in_season_min_moves == 4
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/test_pacing.py::TestPacingSettings -q`
+Expected: FAIL — `AttributeError: 'Settings' object has no attribute 'pacing_enabled'`
+
+- [ ] **Step 3: Add the fields**
+
+In `rehoboam/config.py`, inside `class Settings`, next to `overbid_floor_eur`:
+
+```python
+    pacing_enabled: bool = Field(
+        default=True,
+        description=(
+            "REH-85: reserve enough budget after each buy to make the moves still "
+            "needed. One switch, so the whole behaviour can be reverted from .env "
+            "without a deploy."
+        ),
+    )
+    pacing_in_season_min_moves: int = Field(
+        default=2,
+        description=(
+            "Moves the reserve protects once the squad is full at 15/15, where "
+            "there are no slots left to fill. A guess until the replay sweep "
+            "settles it — see the REH-85 design doc."
+        ),
+    )
+    pacing_window_days: int = Field(
+        default=90,
+        description=(
+            "Trailing window over manager_transfers used to measure what one "
+            "further move costs. A move cost EUR 6.03m league-wide but EUR 10.8m "
+            "in the 2026/27 pre-season, so this is measured, not hardcoded."
+        ),
+    )
+    pacing_median_floor_eur: int = Field(
+        default=3_000_000,
+        description=(
+            "Floor under the measured median move price. A thin window would "
+            "otherwise yield a near-zero reserve, silently disabling pacing "
+            "exactly when there is least evidence."
+        ),
+    )
+```
+
+Add the same four keys to `.env.example` with their defaults and a one-line comment each.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/test_pacing.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rehoboam/config.py .env.example tests/test_pacing.py
+git commit -m "feat(pacing): settings knobs, re-tunable from .env (REH-85)"
+```
+
+______________________________________________________________________
+
+### Task 5: Apply the cap in the bidder
+
+**Files:**
+
+- Modify: `rehoboam/bidding_strategy.py` (the `calculate_ep_bid` signature, and the block right after the REH-99 ceiling near line 445)
+- Test: `tests/test_pacing_bidding.py`
+
+**Interfaces:**
+
+- Consumes: `PacingContext` from Task 1.
+- Produces: `calculate_ep_bid(..., pacing: PacingContext | None = None)`. `None` means pacing is off, and every existing caller keeps working unchanged.
+
+Placement matters and is not arbitrary. `bidding_strategy.py:434` reads `ep_max_bid = max(ep_max_bid, asking_price + overbid_amount)` — the Kimmich fix of 2026-08-24, which deliberately floors the EP cap at the asking price so a wanted player is not priced out of his own auction. A pacing cap applied *before* that line would be floored straight back off. Apply it immediately after the REH-99 ceiling, which is the last thing that lowers a bid.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_pacing_bidding.py`:
+
+```python
+"""Pacing inside the live bidding path (REH-85).
+
+These drive the real `SmartBidding.calculate_ep_bid`, because the whole defect
+was that a cap existed in one place and the number that executed came from
+another.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rehoboam.bidding_strategy import SmartBidding
+from rehoboam.services.bid_ceiling import BidCeilingPolicy, Tier
+from rehoboam.services.pacing import PacingContext
+
+CEILING = BidCeilingPolicy(
+    floor_eur=250_000,
+    tier_pcts={
+        Tier.MARGINAL: 8.0,
+        Tier.SOLID: 15.0,
+        Tier.STRONG: 25.0,
+        Tier.MUST_HAVE: 35.0,
+    },
+)
+
+
+@pytest.fixture
+def bidding():
+    return SmartBidding(
+        bid_learner=None, activity_feed_learner=None, ceiling_policy=CEILING
+    )
+
+
+def _bid(bidding, *, asking, mv, gain, budget, pacing=None):
+    return bidding.calculate_ep_bid(
+        asking_price=asking,
+        market_value=mv,
+        expected_points=80.0,
+        marginal_ep_gain=gain,
+        confidence=0.8,
+        current_budget=budget,
+        sell_plan=None,
+        pacing=pacing,
+    ).recommended_bid
+
+
+def test_without_pacing_the_bid_is_unchanged(bidding):
+    """None must be a true no-op, or every existing caller changes behaviour."""
+    assert (
+        _bid(bidding, asking=10_000_000, mv=10_000_000, gain=90.0, budget=62_307_522)
+        > 0
+    )
+
+
+def test_a_signing_that_would_break_the_reserve_is_not_bid_on(bidding):
+    """Tah: EUR 44.1m asking against a EUR 32.4m reserve on a EUR 62.3m budget.
+
+    The cap lands below the asking price, and the existing
+    `if recommended_bid < asking_price: recommended_bid = 0` turns that into a
+    skip. Pacing therefore needs no refusal path of its own.
+    """
+    paced = _bid(
+        bidding,
+        asking=44_068_628,
+        mv=37_028_628,
+        gain=90.0,
+        budget=62_307_522,
+        pacing=PacingContext(reserve=32_400_000, open_offers=0),
+    )
+    assert paced == 0
+
+
+def test_a_signing_that_fits_the_reserve_still_happens(bidding):
+    """Asllani: EUR 25.1m leaves EUR 37.2m against a EUR 32.4m reserve."""
+    paced = _bid(
+        bidding,
+        asking=25_058_860,
+        mv=23_708_860,
+        gain=90.0,
+        budget=62_307_522,
+        pacing=PacingContext(reserve=32_400_000, open_offers=0),
+    )
+    assert paced >= 25_058_860
+
+
+def test_pacing_never_raises_a_bid(bidding):
+    """It is a cap. It composes with the REH-99 ceiling; it never competes."""
+    unpaced = _bid(
+        bidding, asking=5_000_000, mv=5_000_000, gain=90.0, budget=62_307_522
+    )
+    paced = _bid(
+        bidding,
+        asking=5_000_000,
+        mv=5_000_000,
+        gain=90.0,
+        budget=62_307_522,
+        pacing=PacingContext(reserve=32_400_000, open_offers=0),
+    )
+    assert paced <= unpaced
+
+
+def test_open_offers_reduce_what_may_be_committed(bidding):
+    """A EUR 30m open offer plus a EUR 32.4m reserve leaves nothing spendable."""
+    paced = _bid(
+        bidding,
+        asking=25_058_860,
+        mv=23_708_860,
+        gain=90.0,
+        budget=62_307_522,
+        pacing=PacingContext(reserve=32_400_000, open_offers=30_000_000),
+    )
+    assert paced == 0
+
+
+def test_a_trade_pair_is_paced_on_its_net_cost(bidding):
+    """The synthetic sell plan is what makes this work with no special case.
+
+    `trader.py` gives a pair a SellPlan whose total_recovery is the sale
+    proceeds, so budget_ceiling already includes them. A pair that looks
+    unaffordable gross becomes affordable net — which is correct, because a
+    pair recycles capital rather than consuming it.
+    """
+    from rehoboam.scoring.models import SellPlan
+
+    plan = SellPlan(
+        players_to_sell=[],
+        total_recovery=20_000_000,
+        net_budget_after=0,
+        is_viable=True,
+        ep_impact=0.0,
+        reasoning="test",
+    )
+    gross_only = bidding.calculate_ep_bid(
+        asking_price=25_000_000,
+        market_value=25_000_000,
+        expected_points=80.0,
+        marginal_ep_gain=90.0,
+        confidence=0.8,
+        current_budget=40_000_000,
+        sell_plan=None,
+        pacing=PacingContext(reserve=32_400_000, open_offers=0),
+    ).recommended_bid
+    with_pair = bidding.calculate_ep_bid(
+        asking_price=25_000_000,
+        market_value=25_000_000,
+        expected_points=80.0,
+        marginal_ep_gain=90.0,
+        confidence=0.8,
+        current_budget=40_000_000,
+        sell_plan=plan,
+        pacing=PacingContext(reserve=32_400_000, open_offers=0),
+    ).recommended_bid
+    assert gross_only == 0
+    assert with_pair >= 25_000_000
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/test_pacing_bidding.py -q`
+Expected: FAIL — `TypeError: calculate_ep_bid() got an unexpected keyword argument 'pacing'`
+
+- [ ] **Step 3: Add the parameter and the cap**
+
+In `rehoboam/bidding_strategy.py`, add to the end of the `calculate_ep_bid` parameter list (after `is_dgw: bool = False`):
+
+```python
+pacing: "PacingContext | None" = (None,)
+```
+
+Add the import at the top of the file:
+
+```python
+from rehoboam.services.pacing import PacingContext
+```
+
+Add to the docstring's `Args:` block:
+
+```
+            pacing: REH-85 capital pacing. When given, caps the bid so the
+                reserve survives it — the budget needed to make the moves the
+                squad still requires. None disables pacing entirely.
+```
+
+Then, immediately after the existing REH-99 ceiling block (the `if self.ceiling_policy is not None and market_value > 0:` block) and **before** the `if recommended_bid < asking_price:` line, insert:
+
+```python
+        # REH-85: leave enough behind to keep buying. Applied here, after the
+        # REH-99 ceiling, because `ep_max_bid` is deliberately floored at the
+        # asking price a few lines above (the Kimmich fix) — a cap applied
+        # before that floor would simply be lifted back off.
+        #
+        # This caps rather than refuses. Where the cap falls below the asking
+        # price the block below turns it into recommended_bid = 0, so pacing
+        # needs no refusal path competing with the ceiling and the safety gate.
+        if pacing is not None:
+            pace_cap = pacing.max_bid(budget_ceiling)
+            if recommended_bid > pace_cap:
+                logger.info(
+                    "ep-bid paced player=%s bid=%d -> %d (reserve=%d open_offers=%d)",
+                    player_id,
+                    recommended_bid,
+                    pace_cap,
+                    pacing.reserve,
+                    pacing.open_offers,
+                )
+                recommended_bid = pace_cap
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/test_pacing_bidding.py -q && uv run pytest -q`
+Expected: PASS both. Every existing caller passes `pacing=None` implicitly and is unaffected.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rehoboam/bidding_strategy.py tests/test_pacing_bidding.py
+git commit -m "feat(pacing): cap the bid so the reserve survives it (REH-85)"
+```
+
+______________________________________________________________________
+
+### Task 6: Build the context once per session and pass it
+
+**Files:**
+
+- Modify: `rehoboam/trader.py` (`get_ep_recommendations`, around lines 218-235 and both `calculate_ep_bid` call sites at 598 and 631)
+- Test: `tests/test_pacing_session.py`
+
+**Interfaces:**
+
+- Consumes: `capital_reserve`, `median_move_price`, `available_squad_slots`, `PacingContext` from Task 1; `BidLearner.recent_buy_prices` from Task 3; the `Settings` fields from Task 4.
+- Produces: `Trader._build_pacing_context(squad_size: int, my_bids: list) -> PacingContext | None`, returning `None` when `settings.pacing_enabled` is False.
+
+`get_ep_recommendations` does not currently fetch open bids, so add one `self.api.get_my_bids(league)` call beside the existing `get_team_info` call. It is needed twice over: open offers are euros already committed, and open bids occupy squad slots.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_pacing_session.py`:
+
+```python
+"""Building the pacing context from live session state (REH-85)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from rehoboam.config import Settings
+from rehoboam.trader import Trader
+
+
+@pytest.fixture
+def settings(monkeypatch):
+    monkeypatch.setenv("KICKBASE_EMAIL", "test@example.com")
+    monkeypatch.setenv("KICKBASE_PASSWORD", "test")
+    return Settings()
+
+
+@pytest.fixture
+def trader(settings):
+    learner = MagicMock()
+    learner.recent_buy_prices.return_value = [10_800_000] * 9
+    return Trader(api=MagicMock(), settings=settings, bid_learner=learner)
+
+
+def _bid(amount):
+    return SimpleNamespace(user_offer_price=amount)
+
+
+def test_reserve_covers_every_unfilled_slot(trader):
+    """11 players + 1 open bid = 12/15, so 3 slots at EUR 10.8m each."""
+    ctx = trader._build_pacing_context(squad_size=11, my_bids=[_bid(40_717_295)])
+    assert ctx is not None
+    assert ctx.reserve == 32_400_000
+
+
+def test_open_offers_are_carried_into_the_context(trader):
+    ctx = trader._build_pacing_context(squad_size=11, my_bids=[_bid(40_717_295)])
+    assert ctx.open_offers == 40_717_295
+
+
+def test_full_squad_falls_back_to_the_in_season_minimum(trader):
+    ctx = trader._build_pacing_context(squad_size=15, my_bids=[])
+    assert ctx.reserve == 21_600_000
+
+
+def test_disabled_setting_returns_no_context(trader, settings):
+    settings.pacing_enabled = False
+    assert trader._build_pacing_context(squad_size=11, my_bids=[]) is None
+
+
+def test_a_learner_failure_disables_pacing_rather_than_breaking_the_session(settings):
+    """Best-effort learning: a DB problem must never block the EP pipeline."""
+    learner = MagicMock()
+    learner.recent_buy_prices.side_effect = RuntimeError("db gone")
+    t = Trader(api=MagicMock(), settings=settings, bid_learner=learner)
+    assert t._build_pacing_context(squad_size=11, my_bids=[]) is None
+
+
+def test_no_learner_at_all_disables_pacing(settings):
+    t = Trader(api=MagicMock(), settings=settings, bid_learner=None)
+    assert t._build_pacing_context(squad_size=11, my_bids=[]) is None
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/test_pacing_session.py -q`
+Expected: FAIL — `AttributeError: 'Trader' object has no attribute '_build_pacing_context'`
+
+- [ ] **Step 3: Add the builder and wire both call sites**
+
+Add this method to `Trader` in `rehoboam/trader.py`, immediately before `get_ep_recommendations`:
+
+```python
+def _build_pacing_context(self, squad_size: int, my_bids: list):
+    """The REH-85 reserve for this session, or None when pacing is off.
+
+    Built once per run rather than per candidate: the median move price is
+    a league-level measurement, and recomputing it inside the candidate
+    loop would hit the DB once per listing for an identical answer.
+
+    Returns None — pacing disabled — rather than raising when the learning
+    DB cannot be read. Pacing is a spending restraint, and the established
+    rule in this codebase is that a learning-side failure never blocks the
+    EP pipeline. A restraint that cannot be measured is not applied.
+    """
+    from .services.pacing import (
+        PacingContext,
+        available_squad_slots,
+        capital_reserve,
+        median_move_price,
+    )
+
+    if not getattr(self.settings, "pacing_enabled", True):
+        return None
+    if self.bid_learner is None:
+        return None
+    try:
+        prices = self.bid_learner.recent_buy_prices(
+            window_days=int(self.settings.pacing_window_days)
+        )
+    except Exception:
+        logger.exception("pacing: could not read recent buy prices — pacing disabled")
+        return None
+
+    median_move = median_move_price(
+        prices, floor_eur=int(self.settings.pacing_median_floor_eur)
+    )
+    open_offers = sum(int(getattr(b, "user_offer_price", 0) or 0) for b in my_bids)
+    slots_to_fill = available_squad_slots(squad_size, len(my_bids))
+    reserve = capital_reserve(
+        slots_to_fill=slots_to_fill,
+        in_season_min_moves=int(self.settings.pacing_in_season_min_moves),
+        median_move=median_move,
+    )
+    logger.info(
+        "pacing session median_move=%d slots_to_fill=%d reserve=%d open_offers=%d n_prices=%d",
+        median_move,
+        slots_to_fill,
+        reserve,
+        open_offers,
+        len(prices),
+    )
+    return PacingContext(reserve=reserve, open_offers=open_offers)
+```
+
+In `get_ep_recommendations`, beside the existing `team_info = self.api.get_team_info(league)` line, add:
+
+```python
+        # Open bids are needed twice over for REH-85: they are euros already
+        # committed, and Kickbase counts them toward the 15-player cap.
+        try:
+            my_bids = self.api.get_my_bids(league)
+        except Exception:
+            logger.exception("pacing: could not read open bids — pacing disabled this run")
+            my_bids = None
+        pacing = (
+            None if my_bids is None else self._build_pacing_context(squad_size, my_bids)
+        )
+```
+
+Then add `pacing=pacing,` to **both** `self.bidding.calculate_ep_bid(...)` calls — the plain-buy one and the trade-pair one.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `uv run pytest tests/test_pacing_session.py -q && uv run pytest -q`
+Expected: PASS both.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rehoboam/trader.py tests/test_pacing_session.py
+git commit -m "feat(pacing): build the reserve once per session and apply it (REH-85)"
+```
+
+______________________________________________________________________
+
+### Task 7: Prove emergency fill is exempt
+
+**Files:**
+
+- Test: `tests/test_pacing_session.py` (append)
+
+**Interfaces:**
+
+- Consumes: everything above. No production change is expected — this task exists to prove that, and to fail loudly if the exemption is ever lost.
+
+Emergency squad fill reads `rec.recommended_bid` off recommendations produced by `get_ep_recommendations`, which are now paced. If pacing zeroed those bids, the fill loop's `if not rec.recommended_bid or rec.recommended_bid <= 0: continue` would skip every candidate and leave a slot empty at **-100**. Emergency fill runs when the squad cannot field eleven, so `slots_to_fill` is large and the reserve is correspondingly large — which is precisely when pacing bites hardest.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_pacing_session.py`:
+
+```python
+def test_emergency_fill_is_not_starved_by_the_reserve(tmp_path, monkeypatch):
+    """An empty lineup slot is -100; that outranks pacing.
+
+    A short squad has many slots to fill, so its reserve is at its largest
+    exactly when it most needs to buy. If pacing ever reaches this path it will
+    zero the bids and the fill loop will skip every candidate.
+    """
+    from unittest.mock import MagicMock
+
+    from rehoboam.auto_trader import AutoTrader
+    from rehoboam.config import Settings
+
+    monkeypatch.setenv("KICKBASE_EMAIL", "test@example.com")
+    monkeypatch.setenv("KICKBASE_PASSWORD", "test")
+    monkeypatch.chdir(tmp_path)
+
+    api = MagicMock()
+    api.buy_player = MagicMock(return_value=None)
+    trader = AutoTrader(api=api, settings=Settings(), dry_run=False)
+    trader.learner = MagicMock()
+    trader.learner.was_recently_sold.return_value = False
+
+    squad = [
+        SimpleNamespace(
+            id=f"s{i}",
+            first_name="X",
+            last_name=f"P{i}",
+            position="Defender",
+            price=1_000_000,
+            market_value=1_000_000,
+            team_id=f"club{i}",
+        )
+        for i in range(9)
+    ]
+    target = SimpleNamespace(
+        id="fill",
+        first_name="Fill",
+        last_name="Target",
+        position="Forward",
+        price=4_000_000,
+        market_value=4_000_000,
+        team_id="club99",
+    )
+    ctx = SimpleNamespace(
+        ep_result={
+            "buy_recs": [
+                SimpleNamespace(
+                    player=target,
+                    recommended_bid=4_000_000,
+                    marginal_ep_gain=10.0,
+                    sell_plan=None,
+                )
+            ],
+            "trade_pairs": [],
+            "squad_scores": [],
+            "market_players": {"fill": target},
+        },
+        my_bid_amounts={},
+        my_bids=[],
+        squad=squad,
+        current_budget=50_000_000,
+        flip_budget=50_000_000,
+        executed_trade_count=0,
+        matchday_phase=SimpleNamespace(days_until_match=None),
+    )
+
+    results = trader._run_emergency_squad_fill(
+        league=SimpleNamespace(id="L"), ctx=ctx, fresh_squad=squad, slots_short=1
+    )
+    assert any(
+        r.success for r in results
+    ), "the slot must be filled despite the reserve"
+    assert api.buy_player.call_count == 1
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `uv run pytest tests/test_pacing_session.py::test_emergency_fill_is_not_starved_by_the_reserve -q`
+Expected: PASS immediately. Emergency fill uses `rec.recommended_bid` as sized, and pacing is applied in `calculate_ep_bid`, not in the fill loop.
+
+**If it FAILS**, pacing is reaching emergency fill and that is a real defect. Fix it by having `_run_emergency_squad_fill` fall back to `rec.player.price` when `rec.recommended_bid` is zero, and add a comment naming the -100 penalty as the reason. Do not weaken the reserve.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_pacing_session.py
+git commit -m "test(pacing): emergency fill is exempt from the reserve (REH-85)"
+```
+
+______________________________________________________________________
+
+### Task 8: Make pacing visible in the replay
+
+**Files:**
+
+- Modify: `rehoboam/replay/driver.py` (`make_ep_bid_fn`, lines 394-460)
+- Modify: `rehoboam/replay/engine.py` (the `bid_fn(...)` call around line 494)
+- Test: `tests/test_pacing_replay.py`
+
+**Interfaces:**
+
+- Consumes: `PacingContext`, `capital_reserve`, `median_move_price`, `available_squad_slots` from Task 1.
+- Produces: the replay `bid_fn` signature gains a sixth positional argument — `bid(player_id: str, price: int, at: float, gain: float, budget: int, squad_size: int) -> int`.
+
+The replay is where the failure is visible, so it must exercise pacing or the measurement is meaningless. The replay has no `manager_transfers` for the season it replays, but it does have the real transacted prices of every listing — which *is* the league's buy-price population for that season. Measure the median from those, with the same pure function, so the harness and live agree.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_pacing_replay.py`:
+
+```python
+"""The replay must exercise pacing, or the measurement means nothing (REH-85)."""
+
+from __future__ import annotations
+
+import inspect
+
+from rehoboam.replay.driver import make_ep_bid_fn
+
+
+def test_bid_fn_takes_squad_size():
+    """Pacing needs slots-to-fill, which needs the squad size."""
+    fn = make_ep_bid_fn(
+        mv_fn=lambda pid, at: 10_000_000,
+        score_fn=lambda pid, at: 80.0,
+        median_move=10_800_000,
+        in_season_min_moves=2,
+    )
+    assert len(inspect.signature(fn).parameters) == 6
+
+
+def test_a_short_squad_is_capped_below_an_unaffordable_signing():
+    """9 players = 6 slots to fill = a EUR 64.8m reserve on EUR 80m."""
+    fn = make_ep_bid_fn(
+        mv_fn=lambda pid, at: 40_000_000,
+        score_fn=lambda pid, at: 80.0,
+        median_move=10_800_000,
+        in_season_min_moves=2,
+    )
+    assert fn("p1", 44_000_000, 0.0, 90.0, 80_000_000, 9) == 0
+
+
+def test_an_affordable_signing_still_goes_through():
+    fn = make_ep_bid_fn(
+        mv_fn=lambda pid, at: 5_000_000,
+        score_fn=lambda pid, at: 80.0,
+        median_move=10_800_000,
+        in_season_min_moves=2,
+    )
+    assert fn("p1", 5_000_000, 0.0, 90.0, 80_000_000, 9) >= 5_000_000
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/test_pacing_replay.py -q`
+Expected: FAIL — `TypeError: make_ep_bid_fn() got an unexpected keyword argument 'median_move'`
+
+- [ ] **Step 3: Wire pacing through the replay**
+
+In `rehoboam/replay/driver.py`, change `make_ep_bid_fn`'s signature to:
+
+```python
+def make_ep_bid_fn(
+    *,
+    mv_fn: Callable[[str, float], int | None],
+    score_fn: Callable[[str, float], float],
+    median_move: int,
+    in_season_min_moves: int,
+) -> Callable[[str, int, float, float, int, int], int]:
+```
+
+and replace its inner `bid` function with:
+
+```python
+def bid(
+    player_id: str, price: int, at: float, gain: float, budget: int, squad_size: int
+) -> int:
+    # REH-85: the reserve the live bot applies. Without it the harness
+    # measures a bidder nobody deploys — the same reason the tiers and the
+    # REH-99 ceiling are read from the shipped defaults above.
+    reserve = capital_reserve(
+        slots_to_fill=available_squad_slots(squad_size, 0),
+        in_season_min_moves=in_season_min_moves,
+        median_move=median_move,
+    )
+    rec = bidding.calculate_ep_bid(
+        asking_price=price,
+        market_value=mv_fn(player_id, at) or price,
+        expected_points=score_fn(player_id, at),
+        marginal_ep_gain=gain,
+        confidence=0.8,
+        current_budget=budget,
+        sell_plan=None,
+        trend_change_pct=0.0,
+        pacing=PacingContext(reserve=reserve, open_offers=0),
+    )
+    return int(rec.recommended_bid)
+```
+
+Add to `driver.py`'s imports:
+
+```python
+from rehoboam.services.pacing import (
+    PacingContext,
+    available_squad_slots,
+    capital_reserve,
+    median_move_price,
+)
+```
+
+At the `make_ep_bid_fn(...)` construction site near line 262, pass the two new arguments. Use the file's existing `_shipped_default` helper (line 173) rather than reaching into `Settings.model_fields` — `Settings` is only imported inside functions here, deliberately, so the replay stays runnable without KICKBASE credentials. It returns a float, so wrap the two integer knobs in `int(...)`:
+
+```python
+bid_fn = (
+    (
+        make_ep_bid_fn(
+            mv_fn=corpus.market_value_at,
+            score_fn=score_fn,
+            median_move=median_move_price(
+                [
+                    int(row["price"])
+                    for row in corpus.transfers_between(
+                        0.0, matchdays[0].kickoff - DECISION_LEAD_SECONDS
+                    )
+                ],
+                floor_eur=int(_shipped_default("pacing_median_floor_eur")),
+            ),
+            in_season_min_moves=int(_shipped_default("pacing_in_season_min_moves")),
+        )
+        if with_competition
+        else None
+    ),
+)
+```
+
+**Two traps here, both easy to fall into.**
+
+First, **leakage**. The upper bound is the first matchday's decision moment, not the end of the season. `matches_before` and `ReplayMarket.available_before` both treat this as a hard boundary — "a leak boundary, not a convenience filter" — and letting a season's later prices set an early-season constant would breach it even though the constant is only a scalar.
+
+Second, **two different tables both called "transfers"**. `corpus.transfers_between` reads the corpus's `player_transfers`, where **`transfer_type=2` is the type carrying a real price** and is already the parameter's default. That is NOT the same encoding as `manager_transfers` in the learning DB, where **type 1 is a buy** (Task 3). Do not copy the type filter from one to the other. Take `transfers_between`'s default and pass no `transfer_type`.
+
+`DECISION_LEAD_SECONDS` (engine.py:31, value 3600.0) is **not** currently imported by `driver.py`. Add it to the existing `from rehoboam.replay.engine import (...)` block at driver.py:18, which today lists `Matchday, SeasonResult, run_season, shipped_min_ep_gain` — do not create a second import line. `matchdays` is already in scope at the construction site, since it is passed to `run_season` a few lines above.
+
+In `rehoboam/replay/engine.py`, update the single call site to pass the squad size:
+
+```python
+our_bid = bid_fn(
+    listing.player_id, listing.price, decide_at, gain, state.budget, state.squad_size
+)
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `uv run pytest tests/test_pacing_replay.py -q && uv run pytest -q`
+Expected: PASS both.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rehoboam/replay/driver.py rehoboam/replay/engine.py tests/test_pacing_replay.py
+git commit -m "feat(pacing): exercise the reserve in the season replay (REH-85)"
+```
+
+______________________________________________________________________
+
+### Task 9: Measure it
+
+**Files:**
+
+- Create: `docs/superpowers/specs/2026-08-26-reh-85-capital-pacing-results.md`
+
+**Interfaces:**
+
+- Consumes: the finished feature.
+- Produces: the results document, and a go/no-go recommendation.
+
+Points alone would hide the failure being fixed. "Five buys and EUR 500,000 left" scores similarly to "several mid buys and EUR 500,000 left", and only one of those is fixed — so buy count and terminal budget are reported alongside the total.
+
+- [ ] **Step 1: Record the baseline before any sweep**
+
+```bash
+uv run rehoboam replay-season --with-competition 2>&1 | tee /tmp/reh85-baseline.txt
+```
+
+Expected: a total near **26,391**. If it differs by more than a few points, stop and investigate before sweeping — the baseline has moved and every comparison below would be against the wrong number.
+
+- [ ] **Step 2: Sweep `pacing_in_season_min_moves`**
+
+Run the replay once per value, overriding via the environment:
+
+```bash
+for n in 0 1 2 3 4 6; do
+  echo "=== in_season_min_moves=$n ==="
+  PACING_IN_SEASON_MIN_MOVES=$n uv run rehoboam replay-season --with-competition
+done 2>&1 | tee /tmp/reh85-sweep.txt
+```
+
+`0` is the control: the reserve then protects only unfilled slots. Compare against the disabled case too:
+
+```bash
+PACING_ENABLED=false uv run rehoboam replay-season --with-competition
+```
+
+- [ ] **Step 3: Write the results document**
+
+Create `docs/superpowers/specs/2026-08-26-reh-85-capital-pacing-results.md` with:
+
+- The sweep as a table: `in_season_min_moves`, total points, delta vs 26,391, **buy count**, **terminal budget**.
+
+- An explicit statement of whether buy count rose. If it did not, the reserve converted one lockout into another and the sell side (the deferred half) is the next ticket — say so plainly rather than shipping on a points delta.
+
+- The REH-71 caution restated: treat any delta below 6,162 points with suspicion unless it replicates.
+
+- A recommended default for `pacing_in_season_min_moves`, with the reasoning.
+
+- [ ] **Step 4: Live smoke test**
+
+```bash
+uv run rehoboam auto --dry-run
+```
+
+Confirm the `pacing session median_move=... reserve=... open_offers=...` line appears in the output and that its numbers match the live squad. Record them in the results document.
+
+- [ ] **Step 5: Commit and open the PR**
+
+```bash
+git add docs/superpowers/specs/2026-08-26-reh-85-capital-pacing-results.md
+git commit -m "docs(pacing): replay sweep results and recommended default (REH-85)"
+git push -u origin marcobraun2013/reh-85-capital-pacing
+gh pr create --title "feat(bidding): pace season capital — reserve the ability to keep buying (REH-85)"
+```
+
+The PR body must state the measured sweep, the buy-count outcome, and the live-smoke numbers. If buy count did not improve, say so in the PR body rather than in a follow-up.
+
+______________________________________________________________________
+
+## Self-Review
+
+**Spec coverage.** Design §1 the rule → Tasks 1, 5. §2 the unwind → Task 1's `test_the_unwind_sequence_from_the_spec`. §3 where it applies: plain buys and pairs → Task 6; emergency fill exemption → Task 7; compliance re-bid → untouched by construction, since it never calls `calculate_ep_bid`. §4 open offers → Tasks 1, 6. §5 caps not refuses → Task 5. §6 no proposal that pacing would refuse → satisfied by construction: `_propose_buy` renders `rec.recommended_bid`, which is paced at source in Task 6. §7 configuration → Task 4. Verification §1-5 → Tasks 1-8 for units, Task 9 for the replay, sweep and live smoke.
+
+**Placeholder scan.** No TBD/TODO. Every code step carries real code. Two steps name a conditional fallback (Task 3's connection helper, Task 8's listings accessor) — both are "match the file you are in", not deferred decisions, and both name the exact alternative.
+
+**Type consistency.** `PacingContext(reserve, open_offers)` and `.max_bid(budget_ceiling)` are used identically in Tasks 1, 5, 6 and 8. `capital_reserve(slots_to_fill=, in_season_min_moves=, median_move=)` matches across Tasks 1, 6 and 8. `median_move_price(prices, floor_eur=)` matches across Tasks 1, 6 and 8. `available_squad_slots(squad_size, open_bid_count, cap=)` matches across Tasks 1, 2, 6 and 8. `recent_buy_prices(window_days=)` matches between Tasks 3 and 6.
+
+**One risk the plan cannot remove.** Task 8 changes a function signature used by the replay engine, and the replay is the instrument this feature is judged by. If Task 8 is wrong, Task 9 measures the wrong thing while looking healthy. Task 8's tests assert the cap actually zeroes an unaffordable bid rather than merely that the argument was accepted.

--- a/docs/superpowers/plans/2026-08-26-reh-85-capital-pacing.md
+++ b/docs/superpowers/plans/2026-08-26-reh-85-capital-pacing.md
@@ -238,7 +238,7 @@ def capital_reserve(
     completes, and `in_season_min_moves` is what remains at 15/15 so a full
     squad can still replace a player.
     """
-    moves = max(slots_to_fill, in_season_min_moves)
+    moves = slots_to_fill if slots_to_fill > 0 else in_season_min_moves
     return max(0, moves) * max(0, median_move)
 
 

--- a/docs/superpowers/specs/2026-08-26-reh-85-capital-pacing-design.md
+++ b/docs/superpowers/specs/2026-08-26-reh-85-capital-pacing-design.md
@@ -109,7 +109,7 @@ caps already there:
 
 ```
 median_move  = median(league buy prices over a trailing window)
-moves_wanted = max(squad_slots_to_fill, in_season_min_moves)
+moves_wanted = squad_slots_to_fill if squad_slots_to_fill > 0 else in_season_min_moves
 reserve      = moves_wanted * median_move
 pace_max_bid = (budget - open_offers) - reserve
 
@@ -121,6 +121,13 @@ obvious formulation and it is wrong: with a fixed 3 moves at EUR 10.8m the
 reserve stays EUR 32.4m while the budget falls, so the second buy is capped near
 EUR 4.8m and the bot freezes one purchase later than before. Deriving it from
 unfilled slots makes the reserve unwind as the squad completes.
+
+**Corrected 2026-08-26 during implementation.** This line originally read
+`max(squad_slots_to_fill, in_season_min_moves)`, which contradicts the table in
+§2 below and freezes the last slot: at 14/15 `max(1, 2)` reserves two moves, the
+budget by then *is* two moves, and the permitted bid is exactly zero. While
+slots remain, the slots govern; `in_season_min_moves` is the floor only once
+there are none. The table was right and the formula was wrong.
 
 `squad_slots_to_fill` is measured **to the 15-player cap, counting open offers as
 filled** — the same quantity `_available_squad_slots` already computes, and for

--- a/docs/superpowers/specs/2026-08-26-reh-85-capital-pacing-design.md
+++ b/docs/superpowers/specs/2026-08-26-reh-85-capital-pacing-design.md
@@ -109,7 +109,8 @@ caps already there:
 
 ```
 median_move  = median(league buy prices over a trailing window)
-moves_wanted = squad_slots_to_fill if squad_slots_to_fill > 0 else in_season_min_moves
+moves_after   = max(squad_slots_to_fill - 1, 0)
+moves_wanted  = moves_after if squad_slots_to_fill > 0 else in_season_min_moves
 reserve      = moves_wanted * median_move
 pace_max_bid = (budget - open_offers) - reserve
 
@@ -137,18 +138,38 @@ but has no cover, which is the position we are in today.
 
 ### 2. How it unwinds
 
-Live state on 2026-08-26 — budget EUR 62,307,522, squad 11 players + 1 open
-offer, `median_move` EUR 10.8m:
+**Corrected 2026-08-26 after a live dry-run.** The rule originally reserved
+`slots_to_fill` moves. That over-counts by one: **the buy being evaluated
+fills one of the slots being reserved for**, so the money that must survive
+it funds `slots_to_fill - 1` further moves. Every row of the table below was
+wrong by one move, and the effect is not cosmetic — at 12/15 it capped a
+signing at EUR 29.9m where the corrected rule permits EUR 40.3m, the
+difference between blocking and allowing exactly the one-big-signing shape
+the champions' data shows.
 
-| step                | squad | budget    | reserve              | max spend |
-| ------------------- | ----- | --------- | -------------------- | --------: |
-| now                 | 12/15 | EUR 62.3m | 3 x 10.8 = EUR 32.4m | EUR 29.9m |
-| after a EUR 25m buy | 13/15 | EUR 37.2m | EUR 21.6m            | EUR 15.6m |
-| after a EUR 15m buy | 14/15 | EUR 21.6m | EUR 10.8m            | EUR 10.8m |
-| after a EUR 10m buy | 15/15 | EUR 10.8m | in-season floor      |         — |
+Live state on 2026-08-26 — budget EUR 62,307,522, squad 11 players,
+`median_move` EUR 10,996,594 as measured from `manager_transfers`. Open
+offers excluded here to isolate the reserve; see below for their effect:
 
-Several mid-sized buys instead of one that ends the season — the champions'
-observed shape.
+| step                  | squad | budget    | slots | reserve (moves after)    | max spend |
+| --------------------- | ----- | --------- | ----: | ------------------------ | --------: |
+| now                   | 12/15 | EUR 62.3m |     3 | 2 x 11.0 = EUR 22.0m     | EUR 40.3m |
+| after a EUR 40.3m buy | 13/15 | EUR 22.0m |     2 | 1 x 11.0 = EUR 11.0m     | EUR 11.0m |
+| after a EUR 11.0m buy | 14/15 | EUR 11.0m |     1 | 0 — fill the last slot   | EUR 11.0m |
+| after a EUR 11.0m buy | 15/15 | EUR 0     |     0 | in-season floor, 2 moves |     EUR 0 |
+
+One large signing followed by smaller ones, then a stop — the champions'
+observed shape, rather than the uniformly mid-sized buys the off-by-one forced.
+
+**The last slot reserves nothing deliberately.** Completing the squad outranks
+holding replacement money; the same judgement settled the earlier boundary
+question. Once the squad is full, `in_season_min_moves` becomes the floor.
+
+**Open offers bite hard, and that is intended.** With the live EUR 40,717,295
+offer on Raum outstanding, spendable budget is EUR 21,590,227 against a
+EUR 22.0m reserve, so the permitted bid is **zero** — the bot buys nothing until
+that offer resolves. That is the rule reporting that one unresolved offer has
+consumed the capacity three empty squad slots still need.
 
 ### 3. Where it does and does not apply
 

--- a/docs/superpowers/specs/2026-08-26-reh-85-capital-pacing-design.md
+++ b/docs/superpowers/specs/2026-08-26-reh-85-capital-pacing-design.md
@@ -1,0 +1,252 @@
+# Pace the season's capital: reserve the ability to keep buying
+
+Date: 2026-08-26
+Status: design, approved in conversation, not yet planned
+Ticket: https://linear.app/jovily/issue/REH-85
+Related: REH-69 (fixed the gradient, not the pacing), REH-72 (the analysis),
+REH-97 (the same disease from the ranking side), REH-99 (the bid ceiling this
+composes with)
+
+______________________________________________________________________
+
+## Why
+
+`bidding_strategy.py:315` reads `ep_max_bid = int(budget_ceiling * bid_fraction)`,
+where `bid_fraction` ramps to 0.8. That asks **"what fraction of my current
+budget does this signing justify?"** — a single-decision question with a
+defensible answer. Nothing anywhere asks the sequential question: *what does this
+signing leave me able to do for the next thirty matchdays?*
+
+REH-72 §6 caught the consequence in a competition-modelled replay, through the
+live `SmartBidding.calculate_ep_bid` path:
+
+```
+bid=71008000  ceiling=80000000   <- first buy: EUR 71m on ONE player
+              ceiling=4687915    <- and thereafter, all season:
+bid=0  ep_gain=+85.8  ask=15678910  ceiling=4687915
+bid=0  ep_gain=+81.3  ask=18777777  ceiling=4687915
+```
+
+Five buys, final budget EUR 500,000. Every declined candidate was rated
+`must_have` by the bot's own tiering. It did not misjudge them; it had no money
+left.
+
+REH-69 predicted this in its own comment — *"the bot would commit 80% of budget
+to the first qualifying candidate and be unable to afford the one that mattered
+next week"* — and fixed only the gradient. A +43 and a +195 are now sized
+differently, but a large gain still consumes the budget, because the ramp tops
+out at a fraction of *whatever is available* rather than at anything sequential.
+
+## What the evidence actually says
+
+The ticket proposes as a first cut "a hard per-transaction ceiling near the
+winners' observed mean (~EUR 11m per buy)". **Measured against
+`manager_transfers`, that would have banned both champions' biggest signing.**
+The mean is an artefact of a heavily skewed distribution:
+
+| manager          | buys |    median |       p75 |           max | >EUR 20m | >EUR 40m |
+| ---------------- | ---: | --------: | --------: | ------------: | -------: | -------: |
+| 3199978 (winner) |   30 | EUR 10.0m | EUR 12.5m | **EUR 65.0m** |        4 |        1 |
+| 1907519 (winner) |   24 |  EUR 6.8m | EUR 14.5m | **EUR 60.0m** |        3 |        1 |
+| 3616202 (ours)   |   20 |  EUR 3.2m |  EUR 5.4m |     EUR 38.3m |        1 |        0 |
+
+Each champion made **one enormous buy and roughly 25 more purchases**. We made
+one large buy and then stopped. The distinguishing behaviour is not the size of
+a single bid; it is retaining the capacity to keep operating afterwards.
+
+Nor is concentration a late-season artefact. The large buys, dated:
+
+| manager | date           | player       |              price |
+| ------- | -------------- | ------------ | -----------------: |
+| 1907519 | 2026-05-05     | Castello Jr. |     EUR 60,000,000 |
+| 3199978 | **2026-08-25** | **Kimmich**  | **EUR 65,000,065** |
+| 1907519 | 2026-08-25     | Uzun         |     EUR 32,750,000 |
+
+The champion spent EUR 65m **the day before this design was written**, three days
+before MD1, and has made 11 buys this month. We have made 2. Whatever the rule
+is, it must not simply forbid a decisive opening signing.
+
+### The price of a "move" drifts, so it must be measured
+
+| population                       | buys |    median |       p75 |
+| -------------------------------- | ---: | --------: | --------: |
+| all leagues, whole table         |  254 | EUR 6.03m | EUR 11.7m |
+| 2026/27 pre-season (since Aug 1) |   45 | EUR 10.8m | EUR 16.8m |
+
+A hardcoded euro figure would be wrong within one transfer window. This is the
+same lesson REH-99 learned about the overbid cap: measure the population, and
+re-measure it.
+
+## Goals
+
+1. A large signing stays legal. The rule constrains what a buy may *leave
+   behind*, never its absolute size.
+1. After any discretionary buy, the bot retains enough budget to make the moves
+   it still needs.
+1. The constraint self-calibrates as league prices drift.
+1. Every parameter is a `Settings` field, re-tunable from `.env` without a
+   deploy.
+
+## Non-goals
+
+- **The sell side.** The champions sustain their tempo by recycling — buying
+  EUR 130–227m and selling EUR 123–203m per season while staying near
+  cash-neutral. Changing when the bot sells overlaps REH-63, REH-71, REH-43 and
+  REH-57, each needing its own replay measurement. Deferred deliberately, and
+  the honest consequence is recorded under Risks.
+- **Tuning `min_ep_gain`.** Swept in REH-72 §6 and monotonically worse (26,960
+  at the shipped 40.0; 25,646 at 20; 23,628 at 5). It is not the lever.
+- **Ranking by EP-per-euro.** That is REH-97, the same disease approached from
+  the ranking side rather than the sizing side. Kept separate so each is
+  measurable alone.
+
+## Design
+
+### 1. The rule
+
+One additional cap inside `SmartBidding.calculate_ep_bid`, composed with the
+caps already there:
+
+```
+median_move  = median(league buy prices over a trailing window)
+moves_wanted = max(squad_slots_to_fill, in_season_min_moves)
+reserve      = moves_wanted * median_move
+pace_max_bid = (budget - open_offers) - reserve
+
+bid = min(existing ep_max_bid, REH-99 ceiling, pace_max_bid)
+```
+
+`moves_wanted` is **the moves still wanted, not a constant**. A constant is the
+obvious formulation and it is wrong: with a fixed 3 moves at EUR 10.8m the
+reserve stays EUR 32.4m while the budget falls, so the second buy is capped near
+EUR 4.8m and the bot freezes one purchase later than before. Deriving it from
+unfilled slots makes the reserve unwind as the squad completes.
+
+`squad_slots_to_fill` is measured **to the 15-player cap, counting open offers as
+filled** — the same quantity `_available_squad_slots` already computes, and for
+the same reason: Kickbase counts a pending offer toward the cap. Measuring to
+eleven instead would reserve nothing for a squad that can field a legal eleven
+but has no cover, which is the position we are in today.
+
+### 2. How it unwinds
+
+Live state on 2026-08-26 — budget EUR 62,307,522, squad 11 players + 1 open
+offer, `median_move` EUR 10.8m:
+
+| step                | squad | budget    | reserve              | max spend |
+| ------------------- | ----- | --------- | -------------------- | --------: |
+| now                 | 12/15 | EUR 62.3m | 3 x 10.8 = EUR 32.4m | EUR 29.9m |
+| after a EUR 25m buy | 13/15 | EUR 37.2m | EUR 21.6m            | EUR 15.6m |
+| after a EUR 15m buy | 14/15 | EUR 21.6m | EUR 10.8m            | EUR 10.8m |
+| after a EUR 10m buy | 15/15 | EUR 10.8m | in-season floor      |         — |
+
+Several mid-sized buys instead of one that ends the season — the champions'
+observed shape.
+
+### 3. Where it does and does not apply
+
+| path                     | pacing applies  | why                                                               |
+| ------------------------ | --------------- | ----------------------------------------------------------------- |
+| plain squad-improvement  | yes             | the discretionary buy this is about                               |
+| trade pairs              | yes, on **net** | a pair sells before it bids, so it consumes only `bid - proceeds` |
+| profit flips             | yes             | discretionary, and a flip is capital parked rather than deployed  |
+| **emergency squad fill** | **no**          | an empty lineup slot is **-100**, which outranks pacing           |
+| compliance re-bid        | no              | mandatory; its only legal alternatives are raise or cancel        |
+
+The emergency-fill exemption mirrors the REH-100 refusal policy: that path fails
+toward *fielding someone*.
+
+**Pairs are paced on net cost, and this is load-bearing.** A pair is forced to
+sell before it bids, because at 15/15 the sell is what frees the slot. Applying
+the reserve to the gross bid would therefore freeze pair trading exactly when it
+is the only move available: at 15/15 `moves_wanted` falls to
+`in_season_min_moves`, the budget is by then small, and no gross bid could clear
+the reserve. Pacing the net cost states the truth — a pair recycles capital
+rather than consuming it — and keeps the one mechanism that lets a full squad
+improve. It is also the same net figure `_run_trade_phase` already tests against
+`flip_budget`.
+
+### 4. Open offers count as spent
+
+`budget - open_offers`, not `budget`. Kickbase's reported budget does not deduct
+pending offers, so two bids sized against the same nominal budget can both land.
+`notify/approval.py` already makes exactly this subtraction, and
+`_compute_flip_budget` subtracts `pending_bid_total` for the same reason.
+
+### 5. It caps, it does not refuse
+
+`pace_max_bid` enters the existing `min(...)`. Where the cap falls below the
+asking price the buy is skipped as a natural consequence, but pacing never
+introduces a second, competing refusal path alongside REH-99's ceiling and
+REH-100's gate. One number, computed once, composed with the others.
+
+### 6. A proposal that pacing would refuse is not proposed
+
+Plain squad-improvement buys became proposals on 2026-08-24. REH-99's lesson was
+that offering a buy which the gate then refuses makes the Approve button
+unusable. Pacing therefore applies at sizing time, before `_propose_buy`
+renders, so no proposal reaches Telegram that pacing would block.
+
+### 7. Configuration
+
+| field                        | first value | rationale                                   |
+| ---------------------------- | ----------- | ------------------------------------------- |
+| `pacing_enabled`             | true        | one switch to revert without a deploy       |
+| `pacing_in_season_min_moves` | 2           | the reserve once the squad is at 15/15      |
+| `pacing_window_days`         | 90          | trailing window for `median_move`           |
+| `pacing_median_floor_eur`    | 3,000,000   | a thin window must not collapse the reserve |
+
+`median_move` is read from `manager_transfers` (`transfer_type = 1`), the same
+table this design's evidence comes from. It currently holds 565 rows spanning
+2026-01-03 to 2026-08-26, so the trailing window is populated today — but the
+table's freshness is REH-74's concern, and a stale table degrades this feature
+silently. That is what `pacing_median_floor_eur` is defending against. When the window holds too few rows,
+`pacing_median_floor_eur` applies — the failure mode of a near-empty window is a
+reserve of nearly zero, which silently disables the feature.
+
+## Verification
+
+1. **Unit tests** for the reserve arithmetic: the unwind sequence in §2, the
+   constant-N failure it replaces, open-offer subtraction, the emergency-fill
+   exemption, and the thin-window floor.
+1. **`replay-season --with-competition`**, the configuration where the failure is
+   visible. Baseline to beat: **26,391**. The plain-configuration baseline is
+   26,960.
+1. **Buy count and terminal budget** reported alongside points. The failure being
+   fixed is "5 buys, EUR 500,000 left"; a variant that scores similarly while
+   still ending on 5 buys has not fixed it, and points alone would hide that.
+1. **A sweep** of `pacing_in_season_min_moves` and `pacing_window_days`,
+   published as a table rather than a single number.
+1. **Live `auto --dry-run`** before merge, per the standing rule for changes that
+   touch the bidding path.
+
+Per REH-71's recorded faithfulness decision, treat any single replay delta below
+6,162 points with suspicion unless it replicates.
+
+## Risks
+
+- **Buy-side-only pacing cannot reproduce the champions' tempo.** They sustain
+  25+ purchases a season by recycling capital, which is out of scope here. This
+  design prevents the lockout; it does not by itself produce their volume. If the
+  replay shows the reserve merely converting "one huge buy then nothing" into
+  "several mid buys then nothing", the sell side is the next ticket and this
+  measurement will say so.
+- **It restricts exactly the signing the champion just made.** On today's
+  numbers the live EUR 40,717,295 bid on Raum would be refused (it leaves
+  EUR 21.6m against a EUR 32.4m reserve), as would Tah (EUR 44.1m) and Undav
+  (EUR 54.4m); Asllani (EUR 25.1m) passes. This is the rule working as intended,
+  and it is also the strongest argument for measuring
+  `pacing_in_season_min_moves` rather than assuming it.
+- **`manager_transfers` mixes manual and automated trades.** REH-72 §0a retracted
+  every attribution of behaviour to the bot for this reason. It is used here only
+  as a *price* population — what a move costs in this league — which does not
+  depend on who initiated it.
+- **The replay's buy side is an upper bound.** REH-72 §8. The pacing finding does
+  not rest on a points delta but on a logged ceiling collapse and a buy count,
+  both from the live bidding path.
+
+## Out of scope, filed separately if confirmed
+
+- Sell-side recycling to sustain tempo (see Non-goals).
+- Recording provenance on transfers, which would retire the manual/automated
+  ambiguity that forced REH-72 §0a.

--- a/docs/superpowers/specs/2026-08-26-reh-85-capital-pacing-results.md
+++ b/docs/superpowers/specs/2026-08-26-reh-85-capital-pacing-results.md
@@ -233,6 +233,53 @@ outstanding offer consuming spendable budget), confirming the live wiring
 behaves the way the design and the replay both predict, without needing
 today's exact reserve number to match a prior run's.
 
+## Addendum: the final whole-branch review (2026-08-26, after this document was first written)
+
+A whole-branch review found **three Important defects, every one of them invisible
+to the measurements above**. All three were of the same kind — the bot stops
+trading when it should not — and none could cause overspending. Fixed in
+`ebfe5bb`; the sweep numbers were re-measured afterwards and are **unchanged**,
+which is itself the point: the replay could not see any of them.
+
+1. **At 15/15 the reserve froze every trade pair, including budget-positive
+   ones.** `max_bid` demanded "budget after this trade >= reserve"; when the
+   budget was already below the reserve, nothing satisfied it — so a trade
+   selling a EUR 12m player to buy an EUR 8.86m one, netting **+EUR 3.14m into
+   the budget**, was refused. Design section 3 explicitly claimed net-cost pacing
+   prevented this. It did not: at 15/15 the budget is small *by construction*
+   (section 2's own unwind table ends at "15/15, budget EUR 0"), and at 15/15
+   plain buys and flips are already blocked by `available_slots <= 0`, so pairs
+   are the only improvement mechanism left.
+   The replay never reached 15/15 (peak 8 buys) and the live smoke ran at 12/15.
+   **The feature spends a season driving the bot toward the one state nothing
+   measured.**
+   Fixed by clamping the effective reserve at the pre-trade spendable budget:
+   `min(reserve, max(0, current_budget - open_offers))`. The rule changes from
+   "refuse unless you can hold the full reserve" to "refuse only if this leaves
+   things worse than now". Verified: the 15/15 pair now yields a cap of
+   EUR 12,000,000, while a healthy EUR 62,307,522 budget still yields
+   EUR 40,707,522 — the clamp does not loosen a reserve that already binds.
+
+1. **Profit flips were never paced**, despite section 3's table saying they were.
+   Flips are sized by `ProfitTrader` and never reach `calculate_ep_bid`. Since
+   `enable_flip_buys` defaults to True, this ran in production: a flip could
+   consume the exact capital the reserve was protecting, in the same session
+   where pacing refused a squad-improvement buy for lack of it. The sweep could
+   not see it either — it ran without `--with-flip-buys`.
+
+1. **An under-strength squad froze buying** exactly when empty slots cost -100
+   points, because the reserve scales with empty slots (8/15 reserves EUR 75.6m).
+   The emergency-fill exemption did not cover it: that path runs only in the
+   locked phase, so two to five days before kickoff such a squad got no
+   autonomous buy *and no proposal*. `is_emergency` was already computed two
+   lines above where the pacing context was built, and was never consulted.
+
+**What this says about the measurement in this document.** The sweep is sound for
+what it covers, and it covers a squad-building regime only. Three separate
+"the bot goes quiet" defects lived entirely outside it. Read the +859 as an
+allocation result from one regime, not as evidence the feature is safe across
+the season — the fixes above, not the sweep, are what make it so.
+
 ## Caveats
 
 - **The replay's buy side is an upper bound**, per the design's own Risks

--- a/docs/superpowers/specs/2026-08-26-reh-85-capital-pacing-results.md
+++ b/docs/superpowers/specs/2026-08-26-reh-85-capital-pacing-results.md
@@ -1,0 +1,267 @@
+# Capital pacing (REH-85): measured results
+
+Date: 2026-08-26
+Status: measured, recommendation below, not yet merged
+Ticket: https://linear.app/jovily/issue/REH-85
+Design: `docs/superpowers/specs/2026-08-26-reh-85-capital-pacing-design.md`
+Branch: `marcobraun2013/reh-85-capital-pacing`, HEAD `ef05f46`
+
+## Verdict up front
+
+Ship the default unchanged. It is a real, harmless, allocation-quality
+improvement (+859 points at the shipped `pacing_window_days=90`) that does not
+touch the sell side and regresses nothing. It does **not** meet the design's
+own acceptance criterion — buy count must rise — at the shipped default: buy
+count is 3 with pacing on, 3 with pacing off, identically. That failure was
+predicted in the design's Risks section, and this measurement confirms it,
+more starkly than predicted (see below). Do not chase the win at
+`pacing_window_days=7`; the mechanism analysis shows it is not a better price
+estimate, it is a proxy knob for reserve size sitting on a thin, noisy sample.
+Reasoning for all of this follows.
+
+## The sweep
+
+All runs `uv run rehoboam replay-season --with-competition`, same local
+`logs/training_corpus.db` / `logs/bid_learning.db`. Baseline for delta is the
+genuinely-unpaced run (`--no-pacing`), not the stale 26,391 figure in the
+original ticket brief — see Task 8's controller note in
+`.superpowers/sdd/2026-08-26-reh-85-capital-pacing/progress.md`: that figure
+predates REH-98/99/100 and produced a false alarm when used as the bar.
+Actual (real) season total, for reference only: 26,172.
+
+| configuration              | points | delta vs no-pacing | buys | sells |   finish | clears REH-71's 6,162 bar? |
+| -------------------------- | -----: | -----------------: | ---: | ----: | -------: | :------------------------- |
+| `--no-pacing`              | 24,141 |                  — |    3 |     0 | 11 of 14 | — (baseline)               |
+| `--pacing-window-days 7`   | 27,957 |             +3,816 |    8 |     5 |  7 of 14 | no                         |
+| `--pacing-window-days 14`  | 27,561 |             +3,420 |    6 |     3 |  7 of 14 | no                         |
+| `--pacing-window-days 30`  | 25,000 |               +859 |    3 |     0 | 10 of 14 | no                         |
+| `--pacing-window-days 60`  | 25,000 |               +859 |    3 |     0 | 10 of 14 | no                         |
+| default (90)               | 25,000 |               +859 |    3 |     0 | 10 of 14 | no                         |
+| `--pacing-window-days 180` | 23,676 |               -465 |    3 |     0 | 11 of 14 | no                         |
+
+`--pacing-min-moves` (`pacing_in_season_min_moves`) is not swept above: it
+governs `capital_reserve`'s floor once `slots_to_fill <= 0`, i.e. a full
+15/15 squad. This replay never reaches 15/15 in any configuration (peak
+buys is 8), so the knob is inert in this instrument by construction — sweeping
+it would reproduce the same row every time. This was diagnosed during Task 8
+(Ruling 9/10 in the ledger) and is why the sweep above varies
+`pacing_window_days` instead.
+
+## The mechanism
+
+Diagnosed by querying `manager_transfers` directly at a mid-season instant
+inside the corpus, independent of any replay run:
+
+| window | rows |    median | reserve at 14 empty slots |
+| -----: | ---: | --------: | ------------------------: |
+|      7 |   76 | 4,999,423 |                64,992,499 |
+|     14 |  140 | 6,521,550 |                84,780,150 |
+|     90 | 1154 | 6,644,985 |                86,384,805 |
+|    180 | 1300 | 6,736,287 |                87,571,731 |
+
+The 7-day window is **not** hitting the EUR 3,000,000 floor — its median is
+genuinely lower than the 90-day median, not floored. So `pacing_window_days`
+behaves as a **proxy knob for reserve size**, not as a better price estimate:
+a shorter window happens to produce a smaller number, which happens to make
+the reserve satisfiable more often, which happens to unlock more buys (and,
+via net-cost pacing on pairs, sells). Nothing about a 7-day window makes it a
+*more accurate* estimate of what a move costs — if anything a 76-row sample is
+noisier than a 1,154-row one.
+
+The substantive finding: at 14 empty slots (the squad's early-season state)
+the reserve is EUR 65-87m against a replay starting budget of roughly EUR 80m.
+The constraint is near-unsatisfiable at season start, so the rule degenerates
+to "buy nothing beyond what a small handful of early low-slot-count
+signings can afford" — which is why buys stay flat at 3 for every window of
+30 days or more. **The reserve is calibrated for topping up a squad that
+already has most of its 15 slots filled, not for building one from an
+under-strength start.**
+
+## Did buy count rise? (the design's own acceptance criterion)
+
+**No, not at the shipped default.** Buy count is 3 with pacing on
+(`pacing_window_days=90`) and 3 with pacing off. Identical. The +859-point
+gain at the default comes entirely from *which* 3 players get bought and
+*how much survives after buying them* — better allocation of the same
+number of moves — not from making more moves.
+
+It did rise at the two short windows: 8 buys at 7 days, 6 at 14 days, both
+against a baseline of 3. But per the mechanism section above, that rise is a
+side effect of the reserve shrinking via a proxy (a lower median from a
+thinner sample), not evidence that the design's mechanism — reserving
+capital sequentially so more moves remain affordable — is what produced it.
+It's closer to "the reserve is smaller, so more things clear it" than "the
+bot paced itself into more purchases."
+
+The design's Risks section predicted exactly this shape of failure:
+
+> If the replay shows the reserve merely converting "one huge buy then
+> nothing" into "several mid buys then nothing", the sell side is the next
+> ticket and this measurement will say so.
+
+**The prediction held, and the shipped default is even flatter than it
+anticipated.** The predicted failure mode was "one huge buy converts into
+several mid buys" — i.e. some tempo gain, just not champion-level tempo. What
+actually happened at the default is that the buy count didn't move at all (3
+→ 3); only the allocation of those 3 improved. The reserve isn't merely
+insufficient to reach the champions' ~25-buy tempo — at its shipped
+configuration it produces no tempo change whatsoever. The sell-side capital
+recycling that the design explicitly deferred (Non-goals: "The sell side ...
+changing when the bot sells overlaps REH-63, REH-71, REH-43 and REH-57")
+remains the real lever for tempo, exactly as the design said it would if this
+measurement came back this way.
+
+Where sells *did* appear (5 at 7 days, 3 at 14 days), it wasn't new work —
+it's the already-built net-cost-on-pairs mechanism (design §3: "a pair sells
+before it bids, so it consumes only `bid - proceeds`") activating because a
+shrunk reserve occasionally clears for a pair when it wouldn't for a gross
+buy. That's the existing design doing what it says on the tin, not evidence
+that a sell-side fix was accidentally delivered.
+
+## REH-71's caution
+
+Per REH-71's recorded faithfulness decision: treat any single replay delta
+below 6,162 points with suspicion unless it replicates.
+
+**None of the deltas in this sweep clear that bar.** The largest, +3,816 at
+`--pacing-window-days 7`, is a single, non-replicated measurement at 62% of
+the threshold. It should be trusted *less* than its size suggests, not more —
+the mechanism section shows it rides a 76-row sample, which is exactly the
+kind of thin, noise-prone population REH-71's caution exists to catch.
+
+The +859 delta at the shipped default is smaller still and also does not
+clear the bar as a single number. It does, however, show something the raw
+threshold check misses: three independent configurations —
+`pacing_window_days` 30, 60, and 90 — land on the *exact same* result
+(25,000 points, 3 buys, 3 sells omitted i.e. 0, finish 10 of 14). That is not
+a repeated run of the identical configuration (true replication in REH-71's
+sense would want that too), but three different inputs converging on one
+output is a meaningful stability signal: the median-move estimate is not
+sensitive to window length once the window is wide enough to average out
+short-term noise, and the resulting behavior is a stable plateau rather than
+a fluke of one particular window setting. It is corroboration of a kind, just
+not the kind REH-71 asked for. The 180-day result (-465, i.e. worse than
+no-pacing) breaks that plateau, which is itself informative: a window wide
+enough to reach back into a different, likely off-season, price regime pulls
+the estimate away from the in-season 30-90 day plateau and produces a
+slightly worse outcome — another data point that `pacing_window_days` is
+functioning as a size knob, not a fidelity knob.
+
+## Recommendation
+
+**Ship the default (`pacing_enabled=true`, `pacing_window_days=90`,
+`pacing_in_season_min_moves=2`, `pacing_median_floor_eur=3,000,000`)
+unchanged.** Reasoning:
+
+- It is safe. It touches only bid sizing on the buy side; the sell path,
+  emergency fill, and compliance re-bid are all explicitly unaffected by
+  construction (design §3), and Task 7 closed the one place pacing would
+  have silently starved emergency fill.
+- It is a real, if modest, improvement: +859 points, and that number is
+  stable across three separate window settings rather than being an artifact
+  of one lucky configuration.
+- It does not require accepting a number that fails REH-71's bar on its own
+  merits and is *also* mechanistically suspect. `--pacing-window-days 7`
+  scores better (+3,816) but the mechanism analysis shows that gain comes
+  from a thin, 76-row sample acting as a proxy for a smaller reserve, not
+  from a better estimate of what a move costs. Shipping it would mean tuning
+  a knob to sit deliberately close to the cliff edge where the reserve
+  starts being satisfiable — exactly the kind of fragile calibration the
+  design's own §"price of a move drifts" section warns against ("A
+  hardcoded euro figure would be wrong within one transfer window"). A
+  window chosen to sit near that edge is nearly as fragile as a hardcoded
+  figure; it will drift out of the favorable zone the next time transfer
+  volume changes, in either direction, and there is no mechanism telling us
+  which way.
+- The principled fix for the diagnosed root cause — a reserve of EUR 65-87m
+  against an ~EUR 80m starting budget being near-unsatisfiable at season
+  start — is not "pick a shorter window," it is to stop sizing the reserve
+  purely off `moves_wanted * median_move` and bound it by what is actually
+  available: something like
+  `reserve = min(moves_wanted * median_move, budget * max_reserve_fraction)`.
+  That directly targets the mechanism (the reserve can ask for more than the
+  bot owns) instead of indirectly shrinking the reserve by cherry-picking a
+  window length. It requires new code and a fresh replay measurement, both
+  out of scope for this measure-and-report task. **Recommend filing it as a
+  fast-follow ticket** rather than reopening this window-tuning cycle in
+  pursuit of a bigger number.
+
+In short: ship what's already on this branch, don't tune the window as a
+substitute for fixing the actual constraint, and file the capital-bounded
+reserve as the next design task since this measurement shows the buy-side
+lockout is fixed only when the squad is nearly full, not while it is being
+built — which is exactly the regime the replay exercises and the regime the
+live bot is in today (12/15, per the live smoke test below).
+
+## Live smoke test — `uv run rehoboam auto --dry-run`
+
+Ran against the live prod-mirrored local state (`logs/bid_learning.db`,
+current league squad). The `pacing session ...` line appears exactly once,
+early in the session, as designed:
+
+```
+2026-08-26 17:07:22 INFO    rehoboam.trader | pacing session median_move=10800000 slots_to_fill=3 reserve=21600000 open_offers=40717295 n_prices=48
+```
+
+- `median_move=10,800,000` — close to, but not identical to, the
+  EUR 10,996,594 quoted in this task's brief from an earlier run; the
+  90-day rolling window recomputes every session, so this is genuine drift,
+  not a discrepancy (`n_prices` moved 47 → 48 too, confirming the window is
+  live).
+- `slots_to_fill=3` — squad is 12/15 (confirmed in the session-context log
+  line: `squad=12/15 budget=62307522 ... pending_bids=1`).
+- `reserve=21,600,000` — `capital_reserve` with 2 moves wanted
+  (`slots_to_fill - 1 = 2`) at the EUR 10.8m median: `2 x 10,800,000`.
+- `open_offers=40,717,295` — the outstanding Raum bid, unchanged since the
+  design doc was written.
+
+Every plain-buy candidate this session was capped to 0
+(`ep-bid paced player=... bid=... -> 0 (reserve=21600000 open_offers=40717295)`, repeated for all 10 recommended buys, including two
+`must_have`-tier candidates). Spendable budget is
+`62,307,522 - 40,717,295 = 21,590,227`, which is EUR 9,773 short of the
+EUR 21,600,000 reserve — so every plain buy is refused. Trade pairs, which
+pace on **net** cost, did clear: two pair candidates capped to nonzero
+(1,877,991 and 2,638,508, both reflecting sell-plan proceeds), but the
+session's Unified Trade Phase reported "No actionable opportunities" for
+other reasons downstream, so nothing executed this run. Session summary:
+0 sells, 0 trades, EUR 0 net change — consistent with a dry run where the
+single open offer is currently consuming the capacity three empty slots
+would otherwise need.
+
+This matches the shape described in this task's brief (an EUR 40.7m
+outstanding offer consuming spendable budget), confirming the live wiring
+behaves the way the design and the replay both predict, without needing
+today's exact reserve number to match a prior run's.
+
+## Caveats
+
+- **The replay's buy side is an upper bound**, per the design's own Risks
+  section (citing REH-72 §8). The pacing finding here does not rest on the
+  points delta alone but on a logged reserve collapse and a buy count, both
+  read from the live bidding path (`SmartBidding.calculate_ep_bid`), the
+  same path the live smoke test exercised.
+- **The replayed squad builds from near-empty** (starting at 0/15, reaching
+  12-15/15 only well into the season in the configurations that buy more).
+  That is precisely the regime in which the mechanism section shows the
+  reserve misbehaves most (14 empty slots against an ~EUR 80m budget). A
+  mid-season bot that is already at or near 15/15 — arguably closer to the
+  live bot's actual state today, 12/15 — sits in a very different part of
+  the reserve's behavior, where `pacing_in_season_min_moves` (untested by
+  this sweep, see above) becomes the operative floor instead of
+  `slots_to_fill`. The replay measures the failure mode that matters at
+  squad-building time; it does not measure, and should not be read as
+  measuring, steady-state mid-season pacing.
+- The two windows that did show a buy-count rise (7, 14 days) are the ones
+  the mechanism analysis flags as least trustworthy, not most — a smaller
+  number of days is not a better estimate, only a smaller and noisier one
+  that happens to produce a smaller reserve.
+
+## Test suite
+
+```
+$ uv run pytest -q
+1272 passed, 1 skipped in 16.68s
+```
+
+No production code or tuning defaults were changed by this task. HEAD is
+still `ef05f46` (Task 8's final commit); this document is the only change.

--- a/docs/superpowers/specs/2026-08-26-reh-85-capital-pacing-results.md
+++ b/docs/superpowers/specs/2026-08-26-reh-85-capital-pacing-results.md
@@ -4,7 +4,7 @@ Date: 2026-08-26
 Status: measured, recommendation below, not yet merged
 Ticket: https://linear.app/jovily/issue/REH-85
 Design: `docs/superpowers/specs/2026-08-26-reh-85-capital-pacing-design.md`
-Branch: `marcobraun2013/reh-85-capital-pacing`, HEAD `ef05f46`
+Branch: `marcobraun2013/reh-85-capital-pacing`, HEAD `6b17311` (smoke re-run post-fix; sweep measured at `ef05f46`)
 
 ## Verdict up front
 
@@ -233,6 +233,10 @@ outstanding offer consuming spendable budget), confirming the live wiring
 behaves the way the design and the replay both predict, without needing
 today's exact reserve number to match a prior run's.
 
+**Superseded as the pre-merge smoke run** — the review fixes in `ebfe5bb`
+changed production code after this run. See "Live smoke test, re-run after
+the review fixes" below for the numbers this branch actually merges on.
+
 ## Addendum: the final whole-branch review (2026-08-26, after this document was first written)
 
 A whole-branch review found **three Important defects, every one of them invisible
@@ -280,6 +284,57 @@ what it covers, and it covers a squad-building regime only. Three separate
 allocation result from one regime, not as evidence the feature is safe across
 the season — the fixes above, not the sweep, are what make it so.
 
+## Live smoke test, re-run after the review fixes — 2026-08-27, HEAD `6b17311`
+
+The smoke test above ran at HEAD `ef05f46`. The review fixes in `ebfe5bb`
+changed four production files (`auto_trader.py`, `trader.py`,
+`bidding_strategy.py`, `services/pacing.py`), so it was re-run before merge:
+
+```
+2026-08-27 09:22:22 INFO rehoboam.trader | pacing session median_move=10800000 slots_to_fill=3 reserve=21600000 open_offers=0 n_prices=50
+2026-08-27 09:22:31 INFO rehoboam.auto_trader | session-context phase=locked days_to_match=1 squad=12/15 budget=21650227 team_value=145278078 flip_budget=0 pending_bids=0
+```
+
+**The EUR 40.7m Raum offer has resolved**, so this run exercises the
+`open_offers=0` path the earlier one could not — a materially different
+branch of `max_bid`, and the reason re-running mattered rather than reusing
+the recorded numbers.
+
+- `median_move` is unchanged at EUR 10,800,000 (`n_prices` 48 → 50, so the
+  rolling window did move; the median simply did not).
+- `slots_to_fill=3`, `reserve=21,600,000` — `2 x 10,800,000`, the same
+  `slots_to_fill - 1` arithmetic as before.
+- Spendable budget is now the full `21,650,227`, leaving headroom of
+  **EUR 50,227** over the reserve.
+
+Every paced line reconciles exactly against `max_bid`:
+
+| candidate                  |    ceiling | sell-plan recovery | paced cap |
+| -------------------------- | ---------: | -----------------: | --------: |
+| plain buy (no sell plan)   | 21,650,227 |                  0 |    50,227 |
+| with a mid sell plan       | 23,808,825 |         +2,158,598 | 2,208,825 |
+| with the largest sell plan | 26,151,720 |         +4,501,493 | 4,551,720 |
+
+22 `ep-bid paced` lines, all reporting the same `reserve=21600000 open_offers=0`, confirming the context is built **once per session** and
+reused rather than recomputed per candidate.
+
+**What this changes about the verdict: nothing, and that is the point.**
+Plain buys are capped at EUR 50,227 instead of the earlier run's 0 — still
+far below any real ask, so the buy-side lockout documented above persists
+under the fixes. The clamp added in `ebfe5bb` does not loosen it here
+(`min(21,600,000, 21,650,227 - 0) = 21,600,000`, unbound), which is the
+intended behaviour: the clamp exists to stop the reserve exceeding what
+exists, not to shrink a reserve the budget can still cover. The session was
+in `phase=locked` (1 day to kickoff) and traded nothing regardless, so this
+confirms wiring and arithmetic, not trading outcomes.
+
+One property worth stating plainly for the fast-follow ticket, visible in
+these numbers: because the reserve scales with **empty slots**, selling a
+player below the median move price makes the next buy *harder*, not easier
+— it adds one slot (+EUR 10.8m of reserve) while adding less than that to
+the budget. That is the same "calibrated for topping up, not building"
+mechanism diagnosed above, in its live form.
+
 ## Caveats
 
 - **The replay's buy side is an upper bound**, per the design's own Risks
@@ -305,10 +360,23 @@ the season — the fixes above, not the sweep, are what make it so.
 
 ## Test suite
 
+At `ef05f46`, when the sweep above was measured:
+
 ```
 $ uv run pytest -q
 1272 passed, 1 skipped in 16.68s
 ```
 
-No production code or tuning defaults were changed by this task. HEAD is
-still `ef05f46` (Task 8's final commit); this document is the only change.
+At `6b17311`, the merge candidate, after the review fixes in `ebfe5bb` added
+12 tests:
+
+```
+$ uv run pytest -q
+1284 passed, 1 skipped in 5.55s
+```
+
+No tuning defaults were changed by the measurement task itself; the sweep
+numbers above are read at `ef05f46`, and `ebfe5bb`'s production changes were
+re-verified by the smoke re-run rather than by re-sweeping (the replay's
+squad-building regime is structurally blind to all three defects it fixed,
+as the addendum explains).

--- a/rehoboam/auto_trader.py
+++ b/rehoboam/auto_trader.py
@@ -9,6 +9,8 @@ from rich.console import Console
 
 from .config import INSTANT_SELL_PCT
 from .services import AutoTradeResult, ExecutionService
+from .services.pacing import SQUAD_CAP as pacing_squad_cap
+from .services.pacing import available_squad_slots
 from .services.safety_gate import BuyGate, club_counts
 
 console = Console()
@@ -127,7 +129,10 @@ def _compute_flip_budget(
     return current_budget + max_debt - pending_bid_total
 
 
-SQUAD_CAP = 15  # Kickbase's hard squad-size limit, including open (unresolved) bids
+# One definition of the squad cap, in `services/pacing`. Two copies of one
+# safety-relevant number in different modules is how REH-99's 8%/20% split
+# happened; the name is kept here because callers and tests already use it.
+SQUAD_CAP = pacing_squad_cap
 
 
 def _available_squad_slots(squad_size: int, open_bid_count: int, cap: int = SQUAD_CAP) -> int:
@@ -135,14 +140,10 @@ def _available_squad_slots(squad_size: int, open_bid_count: int, cap: int = SQUA
 
     Kickbase counts pending offers toward the 15-player cap before they even
     resolve — a squad at 13 with 2 open bids has zero room for a further
-    bid, not two (``len(squad)`` alone would wrongly say two). Positive
-    means room for another bid; zero or negative means none.
-
-    Shared by session-context logging and the trade-phase buy gate so both
-    agree on the same number — a duplicated ad-hoc ``15 - size - bids``
-    calculation in two places is exactly how this kind of drift happens.
+    bid, not two. Positive means room for another bid; zero or negative
+    means none.
     """
-    return cap - squad_size - open_bid_count
+    return available_squad_slots(squad_size, open_bid_count, cap)
 
 
 def _starter_swap_has_recovery_time(days_until_match: int | None, min_days: int) -> bool:

--- a/rehoboam/auto_trader.py
+++ b/rehoboam/auto_trader.py
@@ -1002,6 +1002,20 @@ class AutoTrader:
                     continue
                 if opp.buy_price > ctx.flip_budget:
                     continue
+                # REH-85 Finding 2: a flip is discretionary spend, and design
+                # §3 says pacing applies to it same as a plain buy -- capital
+                # parked in a flip is capital the reserve exists to protect.
+                # `pacing` is None when pacing is off entirely, which must
+                # not skip anything.
+                pacing_ctx = ctx.ep_result.get("pacing")
+                if pacing_ctx is not None:
+                    pace_cap = pacing_ctx.max_bid(ctx.flip_budget, ctx.current_budget)
+                    if opp.buy_price > pace_cap:
+                        console.print(
+                            f"[yellow]Cannot afford flip {opp.player.last_name} — "
+                            f"pacing reserve (€{opp.buy_price:,} > €{pace_cap:,})[/yellow]"
+                        )
+                        continue
 
                 result = self.execution.buy(
                     league,

--- a/rehoboam/auto_trader.py
+++ b/rehoboam/auto_trader.py
@@ -1106,7 +1106,18 @@ class AutoTrader:
         # Tuple sort: (-fills_gap, -marginal_ep_gain) so gap fills sort to front.
         scored = []
         for rec in buy_recs:
-            if not rec.recommended_bid or rec.recommended_bid <= 0:
+            # REH-85 pacing can legitimately size recommended_bid to 0 (its
+            # reserve rule consumed the whole spendable budget). An empty
+            # lineup slot costs -100 pts at kickoff, which outranks the
+            # pacing reserve, so this path is deliberately exempt from it:
+            # fall back to the asking price, which is what the plan
+            # anticipated paying, whenever the paced bid is zero or missing.
+            bid = (
+                rec.recommended_bid
+                if rec.recommended_bid and rec.recommended_bid > 0
+                else rec.player.price
+            )
+            if not bid or bid <= 0:
                 continue
             if rec.player.id in active_bid_ids:
                 continue
@@ -1114,11 +1125,13 @@ class AutoTrader:
                 console.print(f"[dim]Skip {rec.player.last_name} — wash-trade block[/dim]")
                 continue
             # Only plain in-budget candidates — sell plans add execution risk
-            # at kickoff that the emergency path explicitly avoids.
-            if rec.recommended_bid > budget_remaining:
+            # at kickoff that the emergency path explicitly avoids. The
+            # affordability check still applies to the fallback bid — the
+            # exemption is from pacing, not from the budget guard.
+            if bid > budget_remaining:
                 continue
             fills_gap = 1 if rec.player.position in gap_positions else 0
-            scored.append((fills_gap, rec.marginal_ep_gain or 0.0, rec))
+            scored.append((fills_gap, rec.marginal_ep_gain or 0.0, bid, rec))
 
         scored.sort(key=lambda t: (-t[0], -t[1]))
 
@@ -1129,10 +1142,10 @@ class AutoTrader:
             return results
 
         bought = 0
-        for _gap, _ep, rec in scored:
+        for _gap, _ep, bid, rec in scored:
             if bought >= slots_short:
                 break
-            if rec.recommended_bid > budget_remaining:
+            if bid > budget_remaining:
                 continue
 
             # A gate refusal here means "try the next candidate", not "field
@@ -1144,7 +1157,7 @@ class AutoTrader:
             result = self.execution.buy(
                 league,
                 rec.player,
-                rec.recommended_bid,
+                bid,
                 f"Emergency lineup fill (squad short by {slots_short})",
                 current_budget=budget_remaining,
                 days_until_match=ctx.matchday_phase.days_until_match,
@@ -1160,8 +1173,8 @@ class AutoTrader:
             results.append(result)
             if result.success:
                 bought += 1
-                budget_remaining -= rec.recommended_bid
-                self.daily_spend += rec.recommended_bid
+                budget_remaining -= bid
+                self.daily_spend += bid
                 # Track the position so subsequent picks deprioritize the gap.
                 gap_positions.discard(rec.player.position)
 

--- a/rehoboam/bid_learner.py
+++ b/rehoboam/bid_learner.py
@@ -1313,6 +1313,33 @@ class BidLearner:
             conn.commit()
         return len(rows)
 
+    def recent_buy_prices(self, window_days: int) -> list[int]:
+        """Purchase prices across the league in the trailing window, in euros.
+
+        The population behind REH-85's reserve: what one further move actually
+        costs here. `transfer_type = 1` is a buy and `2` is a sale — verified
+        against manager 3616202, whose type-1 total of EUR 69,831,333 and
+        type-2 total of EUR 139,638,056 match REH-72 §5.
+
+        Prices are returned as magnitudes because the transfer feed signs a
+        purchase negative in some payloads and a reserve is a size, not a
+        direction. `transfer_dt` is ISO-8601, so the cutoff compares
+        lexicographically without parsing.
+        """
+        cutoff = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time() - window_days * 86400))
+        with sqlite3.connect(self.db_path) as conn:
+            rows = conn.execute(
+                """
+                SELECT ABS(transfer_price)
+                FROM manager_transfers
+                WHERE transfer_type = 1
+                  AND transfer_price IS NOT NULL
+                  AND transfer_dt >= ?
+                """,
+                (cutoff,),
+            ).fetchall()
+        return [int(r[0]) for r in rows]
+
     def has_matchday_outcome(self, player_id: str, matchday_date: str) -> bool:
         """True if ``matchday_outcomes`` already has a row for this player+date."""
         with sqlite3.connect(self.db_path) as conn:

--- a/rehoboam/bidding_strategy.py
+++ b/rehoboam/bidding_strategy.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .scoring.models import SellPlan
 
+from .services.pacing import PacingContext
+
 try:
     from .activity_feed_learner import ActivityFeedLearner
     from .bid_learner import BidLearner
@@ -209,6 +211,7 @@ class SmartBidding:
         offer_count: int = 0,
         has_aggressive_competitors: bool = False,
         is_dgw: bool = False,
+        pacing: PacingContext | None = None,
     ) -> BidRecommendation:
         """
         Calculate optimal bid driven by expected points (EP) gain rather than market value.
@@ -234,6 +237,9 @@ class SmartBidding:
                 matchday). Averaging across two matches reduces outcome variance,
                 so we have higher confidence in the EP prediction — the bid
                 confidence is floored at 0.9 to reflect that certainty.
+            pacing: REH-85 capital pacing. When given, caps the bid so the
+                reserve survives it — the budget needed to make the moves the
+                squad still requires. None disables pacing entirely.
 
         Returns:
             BidRecommendation — recommended_bid=0 if no improvement warranted
@@ -448,6 +454,27 @@ class SmartBidding:
             recommended_bid = min(
                 recommended_bid, self.ceiling_policy.max_bid(market_value, ep_tier)
             )
+
+        # REH-85: leave enough behind to keep buying. Applied here, after the
+        # REH-99 ceiling, because `ep_max_bid` is deliberately floored at the
+        # asking price a few lines above (the Kimmich fix) — a cap applied
+        # before that floor would simply be lifted back off.
+        #
+        # This caps rather than refuses. Where the cap falls below the asking
+        # price the block below turns it into recommended_bid = 0, so pacing
+        # needs no refusal path competing with the ceiling and the safety gate.
+        if pacing is not None:
+            pace_cap = pacing.max_bid(budget_ceiling)
+            if recommended_bid > pace_cap:
+                logger.info(
+                    "ep-bid paced player=%s bid=%d -> %d (reserve=%d open_offers=%d)",
+                    player_id,
+                    recommended_bid,
+                    pace_cap,
+                    pacing.reserve,
+                    pacing.open_offers,
+                )
+                recommended_bid = pace_cap
 
         # If we still can't afford the asking price (truly out of budget), signal no-bid
         if recommended_bid < asking_price:

--- a/rehoboam/bidding_strategy.py
+++ b/rehoboam/bidding_strategy.py
@@ -465,7 +465,7 @@ class SmartBidding:
         # price the block below turns it into recommended_bid = 0, so pacing
         # needs no refusal path competing with the ceiling and the safety gate.
         if pacing is not None:
-            pace_cap = pacing.max_bid(budget_ceiling)
+            pace_cap = pacing.max_bid(budget_ceiling, current_budget)
             if recommended_bid > pace_cap:
                 logger.info(
                     "ep-bid paced player=%s bid=%d -> %d (reserve=%d open_offers=%d)",

--- a/rehoboam/bidding_strategy.py
+++ b/rehoboam/bidding_strategy.py
@@ -456,9 +456,10 @@ class SmartBidding:
             )
 
         # REH-85: leave enough behind to keep buying. Applied here, after the
-        # REH-99 ceiling, because `ep_max_bid` is deliberately floored at the
-        # asking price a few lines above (the Kimmich fix) — a cap applied
-        # before that floor would simply be lifted back off.
+        # REH-99 ceiling and the market-value floor above, because that floor
+        # unconditionally raises recommended_bid to min(market_value * 1.01,
+        # budget_ceiling) whenever it falls short — a cap applied before it
+        # would simply be lifted back off.
         #
         # This caps rather than refuses. Where the cap falls below the asking
         # price the block below turns it into recommended_bid = 0, so pacing

--- a/rehoboam/cli.py
+++ b/rehoboam/cli.py
@@ -744,6 +744,35 @@ def replay_season(
             "--with-flips alone only models the selling half."
         ),
     ),
+    pacing: bool = typer.Option(
+        True,
+        "--pacing/--no-pacing",
+        help=(
+            "Model capital pacing (REH-85): cap each bid so a reserve for the "
+            "moves still needed survives it. Only bites with --with-competition, "
+            "since an uncapped listing is bought at the real price regardless. "
+            "On by default, matching the shipped pacing_enabled default; "
+            "--no-pacing gives the unpaced comparison run."
+        ),
+    ),
+    pacing_min_moves: int | None = typer.Option(
+        None,
+        "--pacing-min-moves",
+        help=(
+            "Moves the pacing reserve protects once the squad is full at 15/15. "
+            "Defaults to the shipped pacing_in_season_min_moves Settings value; "
+            "override to sweep the knob."
+        ),
+    ),
+    pacing_window_days: int | None = typer.Option(
+        None,
+        "--pacing-window-days",
+        help=(
+            "Trailing window, in days, used to measure the median buy price "
+            "behind the pacing reserve. Defaults to the shipped "
+            "pacing_window_days Settings value; override to sweep the knob."
+        ),
+    ),
 ) -> None:
     """Replay the full bot across 2025/26 and report the counterfactual finish."""
     from rehoboam.replay.driver import run_replay
@@ -775,6 +804,9 @@ def replay_season(
         with_competition=with_competition,
         with_flips=with_flips,
         with_flip_buys=with_flip_buys,
+        pacing_enabled=pacing,
+        pacing_min_moves=pacing_min_moves,
+        pacing_window_days=pacing_window_days,
     )
     console.print(report)
 

--- a/rehoboam/config.py
+++ b/rehoboam/config.py
@@ -371,6 +371,7 @@ class Settings(BaseSettings):
     )
     pacing_in_season_min_moves: int = Field(
         default=2,
+        ge=0,
         description=(
             "Moves the reserve protects once the squad is full at 15/15, where "
             "there are no slots left to fill. A guess until the replay sweep "
@@ -379,6 +380,7 @@ class Settings(BaseSettings):
     )
     pacing_window_days: int = Field(
         default=90,
+        ge=0,
         description=(
             "Trailing window over manager_transfers used to measure what one "
             "further move costs. A move cost EUR 6.03m league-wide but EUR 10.8m "
@@ -387,6 +389,7 @@ class Settings(BaseSettings):
     )
     pacing_median_floor_eur: int = Field(
         default=3_000_000,
+        ge=0,
         description=(
             "Floor under the measured median move price. A thin window would "
             "otherwise yield a near-zero reserve, silently disabling pacing "

--- a/rehoboam/config.py
+++ b/rehoboam/config.py
@@ -361,6 +361,38 @@ class Settings(BaseSettings):
             "EUR 109k gap against a EUR 62M budget."
         ),
     )
+    pacing_enabled: bool = Field(
+        default=True,
+        description=(
+            "REH-85: reserve enough budget after each buy to make the moves still "
+            "needed. One switch, so the whole behaviour can be reverted from .env "
+            "without a deploy."
+        ),
+    )
+    pacing_in_season_min_moves: int = Field(
+        default=2,
+        description=(
+            "Moves the reserve protects once the squad is full at 15/15, where "
+            "there are no slots left to fill. A guess until the replay sweep "
+            "settles it — see the REH-85 design doc."
+        ),
+    )
+    pacing_window_days: int = Field(
+        default=90,
+        description=(
+            "Trailing window over manager_transfers used to measure what one "
+            "further move costs. A move cost EUR 6.03m league-wide but EUR 10.8m "
+            "in the 2026/27 pre-season, so this is measured, not hardcoded."
+        ),
+    )
+    pacing_median_floor_eur: int = Field(
+        default=3_000_000,
+        description=(
+            "Floor under the measured median move price. A thin window would "
+            "otherwise yield a near-zero reserve, silently disabling pacing "
+            "exactly when there is least evidence."
+        ),
+    )
     overbid_pct_marginal: float = Field(
         default=8.0,
         description=(

--- a/rehoboam/replay/driver.py
+++ b/rehoboam/replay/driver.py
@@ -16,6 +16,7 @@ from rehoboam.backtest.snapshot import matches_before
 from rehoboam.enrichment.corpus import TrainingCorpus
 from rehoboam.replay.attribution import LeagueStanding, format_report
 from rehoboam.replay.engine import (
+    DECISION_LEAD_SECONDS,
     Matchday,
     SeasonResult,
     run_season,
@@ -26,6 +27,12 @@ from rehoboam.replay.state import initial_state
 from rehoboam.scoring.v2.adapter import compose_ep, prev_status_from_history
 from rehoboam.scoring.v2.coefficients import load_coefficients
 from rehoboam.services.bid_ceiling import BidCeilingPolicy, Tier
+from rehoboam.services.pacing import (
+    PacingContext,
+    available_squad_slots,
+    capital_reserve,
+    median_move_price,
+)
 
 SEASON = "2025/2026"
 LEAGUE_ID = "1933872"
@@ -260,7 +267,20 @@ def run_replay(
         buy_rank_fn=buy_rank_fn,
         buy_quota=buy_quota,
         bid_fn=(
-            make_ep_bid_fn(mv_fn=corpus.market_value_at, score_fn=score_fn)
+            make_ep_bid_fn(
+                mv_fn=corpus.market_value_at,
+                score_fn=score_fn,
+                median_move=median_move_price(
+                    [
+                        int(row["price"])
+                        for row in corpus.transfers_between(
+                            0.0, matchdays[0].kickoff - DECISION_LEAD_SECONDS
+                        )
+                    ],
+                    floor_eur=int(_shipped_default("pacing_median_floor_eur")),
+                ),
+                in_season_min_moves=int(_shipped_default("pacing_in_season_min_moves")),
+            )
             if with_competition
             else None
         ),
@@ -395,7 +415,9 @@ def make_ep_bid_fn(
     *,
     mv_fn: Callable[[str, float], int | None],
     score_fn: Callable[[str, float], float],
-) -> Callable[[str, int, float, float, int], int]:
+    median_move: int,
+    in_season_min_moves: int,
+) -> Callable[[str, int, float, float, int, int], int]:
     """Bid with the bot's own bidding strategy (REH-68).
 
     Until now the replay bought at the listed price and never called
@@ -443,7 +465,17 @@ def make_ep_bid_fn(
         ceiling_policy=ceiling_policy,
     )
 
-    def bid(player_id: str, price: int, at: float, gain: float, budget: int) -> int:
+    def bid(
+        player_id: str, price: int, at: float, gain: float, budget: int, squad_size: int
+    ) -> int:
+        # REH-85: the reserve the live bot applies. Without it the harness
+        # measures a bidder nobody deploys — the same reason the tiers and the
+        # REH-99 ceiling are read from the shipped defaults above.
+        reserve = capital_reserve(
+            slots_to_fill=available_squad_slots(squad_size, 0),
+            in_season_min_moves=in_season_min_moves,
+            median_move=median_move,
+        )
         rec = bidding.calculate_ep_bid(
             asking_price=price,
             market_value=mv_fn(player_id, at) or price,
@@ -453,6 +485,7 @@ def make_ep_bid_fn(
             current_budget=budget,
             sell_plan=None,
             trend_change_pct=0.0,
+            pacing=PacingContext(reserve=reserve, open_offers=0),
         )
         return int(rec.recommended_bid)
 

--- a/rehoboam/replay/driver.py
+++ b/rehoboam/replay/driver.py
@@ -16,7 +16,6 @@ from rehoboam.backtest.snapshot import matches_before
 from rehoboam.enrichment.corpus import TrainingCorpus
 from rehoboam.replay.attribution import LeagueStanding, format_report
 from rehoboam.replay.engine import (
-    DECISION_LEAD_SECONDS,
     Matchday,
     SeasonResult,
     run_season,
@@ -188,6 +187,44 @@ def _shipped_default(name: str) -> float:
     return float(Settings.model_fields[name].default)
 
 
+def _make_median_move_fn(
+    corpus: TrainingCorpus, *, window_days: int, floor_eur: int
+) -> Callable[[float], int]:
+    """Trailing-window median buy price, recomputed per decision instant (REH-85).
+
+    Production (`Trader._build_pacing_context`) recomputes this once per
+    session from a trailing `pacing_window_days` window over recent buys, so
+    the reserve tracks in-season price drift. A single pre-season constant
+    frozen for all 34 matchdays would silently stop reflecting the season's
+    real price level — this is what the replay must NOT do, or a "does this
+    knob matter" sweep over `pacing_window_days` would report an identical
+    number regardless of the window, when in truth the window was never
+    wired to move anything.
+
+    The replay's analogue of "one session" is one matchday's worth of
+    decisions: every listing considered for the same matchday shares the same
+    `at` (`decide_at` from `run_season`), so memoising by `at` reproduces
+    production's cadence — one query per matchday, not one per bid.
+
+    `at` is already the leak boundary (`decide_at = kickoff -
+    DECISION_LEAD_SECONDS`, applied upstream in `engine.py`), so bounding the
+    trailing window at `at` costs nothing extra here: nothing later than the
+    decision instant can enter the window.
+    """
+    window_seconds = window_days * 86400.0
+    cache: dict[float, int] = {}
+
+    def median_move_at(at: float) -> int:
+        if at not in cache:
+            prices = [
+                int(row["price"]) for row in corpus.transfers_between(at - window_seconds, at)
+            ]
+            cache[at] = median_move_price(prices, floor_eur=floor_eur)
+        return cache[at]
+
+    return median_move_at
+
+
 def buy_quota_from(result: SeasonResult) -> dict[int, int]:
     """Per-matchday buy counts, for holding a control's trading tempo fixed.
 
@@ -208,6 +245,9 @@ def run_replay(
     with_competition: bool = False,
     with_flips: bool = False,
     with_flip_buys: bool = False,
+    pacing_enabled: bool = True,
+    pacing_min_moves: int | None = None,
+    pacing_window_days: int | None = None,
 ) -> tuple[SeasonResult, str]:
     """Replay the whole season and return the result plus a formatted report.
 
@@ -215,6 +255,13 @@ def run_replay(
     describes the bot on main rather than an agent nobody deployed. Pass it
     explicitly only to answer a "what if the floor were X" question — and label
     any such run as a sensitivity check, not a counterfactual result.
+
+    ``pacing_enabled``/``pacing_min_moves``/``pacing_window_days`` (REH-85) are
+    only meaningful together with ``with_competition`` — pacing caps a bid,
+    and without bid competition every listing is bought at the real price
+    regardless. ``pacing_min_moves``/``pacing_window_days`` default to the
+    shipped ``Settings`` values when left ``None``, so a sweep that overrides
+    them explicitly is comparing against the same bot main ships.
     """
     corpus = TrainingCorpus(corpus_path)
     kickoffs = load_calendar(learning_db_path, league_id=LEAGUE_ID)
@@ -270,16 +317,21 @@ def run_replay(
             make_ep_bid_fn(
                 mv_fn=corpus.market_value_at,
                 score_fn=score_fn,
-                median_move=median_move_price(
-                    [
-                        int(row["price"])
-                        for row in corpus.transfers_between(
-                            0.0, matchdays[0].kickoff - DECISION_LEAD_SECONDS
-                        )
-                    ],
+                median_move_fn=_make_median_move_fn(
+                    corpus,
+                    window_days=(
+                        pacing_window_days
+                        if pacing_window_days is not None
+                        else int(_shipped_default("pacing_window_days"))
+                    ),
                     floor_eur=int(_shipped_default("pacing_median_floor_eur")),
                 ),
-                in_season_min_moves=int(_shipped_default("pacing_in_season_min_moves")),
+                in_season_min_moves=(
+                    pacing_min_moves
+                    if pacing_min_moves is not None
+                    else int(_shipped_default("pacing_in_season_min_moves"))
+                ),
+                pacing_enabled=pacing_enabled,
             )
             if with_competition
             else None
@@ -415,8 +467,9 @@ def make_ep_bid_fn(
     *,
     mv_fn: Callable[[str, float], int | None],
     score_fn: Callable[[str, float], float],
-    median_move: int,
+    median_move_fn: Callable[[float], int],
     in_season_min_moves: int,
+    pacing_enabled: bool = True,
 ) -> Callable[[str, int, float, float, int, int], int]:
     """Bid with the bot's own bidding strategy (REH-68).
 
@@ -437,6 +490,16 @@ def make_ep_bid_fn(
     ``offer_count=0`` (we cannot know how many rivals bid on a given listing)
     and ``trend_change_pct=0.0`` (no market-value trend is fed in). Confidence
     is fixed at 0.8 rather than derived from data quality grading.
+
+    ``median_move_fn`` is called with the decision instant on every bid rather
+    than closed over as a constant, so the reserve tracks a trailing window
+    the way production does instead of freezing a pre-season number for the
+    whole replayed season (REH-85). ``pacing_enabled=False`` passes
+    ``pacing=None`` into ``calculate_ep_bid`` rather than a ``PacingContext``
+    pinned to ``reserve=0`` — mirroring how production actually represents
+    "pacing off" (`Trader._build_pacing_context` returns ``None`` when
+    ``settings.pacing_enabled`` is ``False``), and skipping the median-price
+    query entirely rather than computing an answer only to zero it out.
     """
     from rehoboam.bidding_strategy import SmartBidding
     from rehoboam.config import Settings
@@ -471,11 +534,14 @@ def make_ep_bid_fn(
         # REH-85: the reserve the live bot applies. Without it the harness
         # measures a bidder nobody deploys — the same reason the tiers and the
         # REH-99 ceiling are read from the shipped defaults above.
-        reserve = capital_reserve(
-            slots_to_fill=available_squad_slots(squad_size, 0),
-            in_season_min_moves=in_season_min_moves,
-            median_move=median_move,
-        )
+        pacing_ctx = None
+        if pacing_enabled:
+            reserve = capital_reserve(
+                slots_to_fill=available_squad_slots(squad_size, 0),
+                in_season_min_moves=in_season_min_moves,
+                median_move=median_move_fn(at),
+            )
+            pacing_ctx = PacingContext(reserve=reserve, open_offers=0)
         rec = bidding.calculate_ep_bid(
             asking_price=price,
             market_value=mv_fn(player_id, at) or price,
@@ -485,7 +551,7 @@ def make_ep_bid_fn(
             current_budget=budget,
             sell_plan=None,
             trend_change_pct=0.0,
-            pacing=PacingContext(reserve=reserve, open_offers=0),
+            pacing=pacing_ctx,
         )
         return int(rec.recommended_bid)
 

--- a/rehoboam/replay/engine.py
+++ b/rehoboam/replay/engine.py
@@ -398,17 +398,18 @@ def run_season(
     buy_rank_fn: Callable[[str, float], float] | None = None,
     buy_quota: dict[int, int] | None = None,
     # REH-68 bid competition. Given (player_id, real_price, at, marginal_gain,
-    # budget), returns our maximum bid. Gain and budget are passed because a
-    # real bid is a function of both — SmartBidding sizes its overbid from the
-    # marginal-gain tier and caps it against what we can afford — and a hook
-    # without them could only express a flat willingness to pay, which is not
-    # what the bot does.
+    # budget, squad_size), returns our maximum bid. Gain and budget are passed
+    # because a real bid is a function of both — SmartBidding sizes its overbid
+    # from the marginal-gain tier and caps it against what we can afford — and
+    # a hook without them could only express a flat willingness to pay, which
+    # is not what the bot does. squad_size (REH-85) lets the hook derive how
+    # many slots remain, which is what capital pacing reserves against.
     # We win only if the bid EXCEEDS what the real buyer actually paid,
     # and we then pay our own bid rather than theirs — outbidding a rival costs
     # more than the rival paid, and charging their price would hand us the
     # upside of competition with none of its cost. None keeps the shipped
     # behaviour, in which every wanted player is won.
-    bid_fn: Callable[[str, int, float, float, int], int] | None = None,
+    bid_fn: Callable[[str, int, float, float, int, int], int] | None = None,
     # REH-68 profit flipping. The live trade-side thresholds
     # (min_sell_profit_pct 15.0 / max_loss_pct -15.0). Both None disables the
     # pass entirely, preserving the shipped replay behaviour in which the bot
@@ -484,7 +485,14 @@ def run_season(
             # the price the real buyer paid; with one it is our own winning bid.
             cost = listing.price
             if bid_fn is not None:
-                our_bid = bid_fn(listing.player_id, listing.price, decide_at, gain, state.budget)
+                our_bid = bid_fn(
+                    listing.player_id,
+                    listing.price,
+                    decide_at,
+                    gain,
+                    state.budget,
+                    state.squad_size,
+                )
                 if our_bid <= listing.price:
                     continue  # outbid by the manager who really signed him
                 cost = our_bid

--- a/rehoboam/services/pacing.py
+++ b/rehoboam/services/pacing.py
@@ -65,7 +65,18 @@ def capital_reserve(*, slots_to_fill: int, in_season_min_moves: int, median_move
     Deriving it from unfilled slots makes the reserve unwind as the squad
     completes, and `in_season_min_moves` is what remains at 15/15 so a full
     squad can still replace a player.
+
+    Critical boundary: `in_season_min_moves` is NOT a floor while slots remain.
+    When 0 < slots_to_fill < in_season_min_moves, the reserve falls below
+    the in-season minimum by design, allowing unwinding. `in_season_min_moves`
+    only becomes the floor at slots_to_fill <= 0 (full squad or over-committed).
+    Using max() instead would freeze the reserve once below in_season_min_moves,
+    preventing the reserve from unwinding as the squad fills — that is the bug
+    the brief accidentally encoded.
     """
+    # Use slots_to_fill when positive (unwinding), fall back to in_season_min_moves
+    # at 0 or negative (full squad, never go below minimum). Not max(), which would
+    # freeze the reserve and prevent unwinding.
     moves = slots_to_fill if slots_to_fill > 0 else in_season_min_moves
     return max(0, moves) * max(0, median_move)
 

--- a/rehoboam/services/pacing.py
+++ b/rehoboam/services/pacing.py
@@ -91,7 +91,7 @@ class PacingContext:
     reserve: int
     open_offers: int
 
-    def max_bid(self, budget_ceiling: int) -> int:
+    def max_bid(self, budget_ceiling: int, current_budget: int) -> int:
         """The largest bid that still leaves the reserve intact.
 
         `budget_ceiling` already includes any sell-plan recovery, which is why
@@ -101,5 +101,18 @@ class PacingContext:
         recycles capital rather than consuming it, and pacing it on the gross
         bid would freeze pair trading at 15/15 — the one mechanism a full squad
         has to improve itself.
+
+        `current_budget` is the cash actually on hand before this trade — it
+        deliberately excludes any sell-plan recovery, unlike `budget_ceiling`.
+        The reserve is clamped to never exceed what is currently spendable
+        (`current_budget - open_offers`): reserving more than exists refuses
+        EVERY trade once the budget has already fallen below the reserve,
+        including a net-positive trade pair that would recover money. The
+        rule this enforces is "don't leave the bot worse off than today", not
+        "always hold the full reserve regardless of where the budget already
+        is" — the latter freezes a full squad's only improvement mechanism
+        the moment the budget dips below the reserve, at exactly the point a
+        recycling trade is most needed.
         """
-        return max(0, int(budget_ceiling) - int(self.open_offers) - int(self.reserve))
+        effective_reserve = min(self.reserve, max(0, int(current_budget) - int(self.open_offers)))
+        return max(0, int(budget_ceiling) - int(self.open_offers) - effective_reserve)

--- a/rehoboam/services/pacing.py
+++ b/rehoboam/services/pacing.py
@@ -66,18 +66,16 @@ def capital_reserve(*, slots_to_fill: int, in_season_min_moves: int, median_move
     completes, and `in_season_min_moves` is what remains at 15/15 so a full
     squad can still replace a player.
 
-    Critical boundary: `in_season_min_moves` is NOT a floor while slots remain.
-    When 0 < slots_to_fill < in_season_min_moves, the reserve falls below
-    the in-season minimum by design, allowing unwinding. `in_season_min_moves`
-    only becomes the floor at slots_to_fill <= 0 (full squad or over-committed).
-    Using max() instead would freeze the reserve once below in_season_min_moves,
-    preventing the reserve from unwinding as the squad fills — that is the bug
-    the brief accidentally encoded.
+    Critical: the reserve funds moves remaining *after* this buy fills one slot.
+    At slots_to_fill=3, the reserve is 2 moves (not 3), because this bid will
+    fill one of the three. At 1 slot, the reserve is 0 — completing the squad
+    takes priority over holding replacement money. Only at slots_to_fill <= 0
+    (full squad or over-committed) does `in_season_min_moves` become the floor.
     """
-    # Use slots_to_fill when positive (unwinding), fall back to in_season_min_moves
-    # at 0 or negative (full squad, never go below minimum). Not max(), which would
-    # freeze the reserve and prevent unwinding.
-    moves = slots_to_fill if slots_to_fill > 0 else in_season_min_moves
+    # Account for this buy filling one slot: reserve is for moves remaining
+    # after it lands. Full squad (slots <= 0) falls back to in_season_min_moves.
+    moves_after_this_buy = max(slots_to_fill - 1, 0)
+    moves = moves_after_this_buy if slots_to_fill > 0 else in_season_min_moves
     return max(0, moves) * max(0, median_move)
 
 

--- a/rehoboam/services/pacing.py
+++ b/rehoboam/services/pacing.py
@@ -1,0 +1,96 @@
+"""How much budget a buy must leave behind (REH-85).
+
+`bidding_strategy.max_bid_fraction` asks what fraction of the *current* budget
+a signing justifies — a single-decision question with a defensible answer.
+Nothing asked the sequential one: what does this signing leave the bot able to
+do for the next thirty matchdays? A competition-modelled replay answered it —
+EUR 71m on one player, then five buys all season and EUR 500,000 left, with
+every declined candidate rated `must_have` by the bot's own tiering.
+
+Measured against `manager_transfers`, the champions each made ONE signing of
+EUR 60-65m *and* roughly 25 further purchases. So the rule here constrains what
+a buy leaves behind, never how large it is. A hard per-transaction cap near
+their EUR 11m mean — the ticket's first suggestion — would have banned both of
+their biggest signings; that mean is an artefact of a heavily skewed
+distribution.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+#: Kickbase's hard squad-size limit, including open (unresolved) bids.
+SQUAD_CAP = 15
+
+
+def available_squad_slots(squad_size: int, open_bid_count: int, cap: int = SQUAD_CAP) -> int:
+    """Slots left under the squad cap, counting open bids as committed.
+
+    Kickbase counts pending offers toward the 15-player cap before they
+    resolve — a squad at 13 with 2 open bids has zero room for a further bid,
+    not two. May return a negative number when over-committed; callers that
+    need a floor apply their own.
+    """
+    return cap - squad_size - open_bid_count
+
+
+def median_move_price(prices: Sequence[int], *, floor_eur: int) -> int:
+    """What one further purchase costs in this league, in euros.
+
+    The median rather than the mean, because the population is heavily skewed:
+    the champions' buys have a median near EUR 10m and a maximum of EUR 65m, and
+    a mean would price a "move" at something nobody routinely pays.
+
+    On an even count this takes the lower of the two middle values rather than
+    averaging them, so the result is always a price someone actually paid.
+
+    `floor_eur` guards the thin-window case. A near-empty window would otherwise
+    produce a reserve of nearly zero, which disables pacing silently — exactly
+    when there is least evidence to justify spending freely.
+    """
+    if not prices:
+        return floor_eur
+    ordered = sorted(int(p) for p in prices)
+    median = ordered[(len(ordered) - 1) // 2]
+    return max(median, floor_eur)
+
+
+def capital_reserve(*, slots_to_fill: int, in_season_min_moves: int, median_move: int) -> int:
+    """Euros that must survive this buy, so the bot can keep operating.
+
+    `slots_to_fill` rather than a constant is the load-bearing choice. A
+    constant N keeps the reserve fixed while the budget falls, so the bot
+    freezes one purchase later than it does today rather than not at all.
+    Deriving it from unfilled slots makes the reserve unwind as the squad
+    completes, and `in_season_min_moves` is what remains at 15/15 so a full
+    squad can still replace a player.
+    """
+    moves = slots_to_fill if slots_to_fill > 0 else in_season_min_moves
+    return max(0, moves) * max(0, median_move)
+
+
+@dataclass(frozen=True)
+class PacingContext:
+    """What pacing needs that the bidder itself cannot know.
+
+    Built once per session by the caller, which is the only layer that sees the
+    squad, the open offers and the learning DB. `SmartBidding` stays ignorant of
+    all three and just applies the number.
+    """
+
+    reserve: int
+    open_offers: int
+
+    def max_bid(self, budget_ceiling: int) -> int:
+        """The largest bid that still leaves the reserve intact.
+
+        `budget_ceiling` already includes any sell-plan recovery, which is why
+        trade pairs need no special case: `trader.py` gives a pair a synthetic
+        sell plan whose `total_recovery` is the sale proceeds, so subtracting
+        the reserve from the ceiling paces the pair on its NET cost. A pair
+        recycles capital rather than consuming it, and pacing it on the gross
+        bid would freeze pair trading at 15/15 — the one mechanism a full squad
+        has to improve itself.
+        """
+        return max(0, int(budget_ceiling) - int(self.open_offers) - int(self.reserve))

--- a/rehoboam/trader.py
+++ b/rehoboam/trader.py
@@ -727,6 +727,11 @@ class Trader:
             "market_players": market_player_map,
             "market_scores": {s.player_id: s for s in market_scores},
             "competitor_player_ids": competitor_player_ids,
+            # REH-85: surfaced so get_ep_recommendations_with_trends can reuse
+            # this session's context instead of rebuilding it — a rebuild
+            # would mean a second get_my_bids call and could yield a
+            # different reserve within one session.
+            "pacing": pacing,
             # Surfaced for matchday reconciliation (REH-20). Reconciliation
             # needs raw performance dicts to read past actual points (`p`,
             # `mdst`, `md`); piggybacking on the EP pipeline's existing
@@ -743,6 +748,10 @@ class Trader:
         """
         result = self.get_ep_recommendations(league)
         current_budget = int(result.get("budget", 0))
+        # REH-85: reuse the context built inside get_ep_recommendations rather
+        # than rebuilding it here — a rebuild would be a second get_my_bids
+        # call and could produce a different reserve within one session.
+        pacing = result.get("pacing")
 
         # League-level competitor context: checked once per session so all bids
         # in this run share the same "is the league aggressive today?" signal.
@@ -781,6 +790,7 @@ class Trader:
                     offer_count=rec.player.offer_count,
                     has_aggressive_competitors=has_whales,
                     is_dgw=rec.score.is_dgw,
+                    pacing=pacing,
                 )
                 rec.recommended_bid = bid_rec.recommended_bid
             except Exception:
@@ -819,6 +829,7 @@ class Trader:
                     offer_count=pair.buy_player.offer_count,
                     has_aggressive_competitors=has_whales,
                     is_dgw=pair.buy_score.is_dgw,
+                    pacing=pacing,
                 )
                 pair.recommended_bid = bid_rec.recommended_bid
             except Exception:

--- a/rehoboam/trader.py
+++ b/rehoboam/trader.py
@@ -203,6 +203,57 @@ class Trader:
     # EP pipeline
     # ------------------------------------------------------------------
 
+    def _build_pacing_context(self, squad_size: int, my_bids: list):
+        """The REH-85 reserve for this session, or None when pacing is off.
+
+        Built once per run rather than per candidate: the median move price is
+        a league-level measurement, and recomputing it inside the candidate
+        loop would hit the DB once per listing for an identical answer.
+
+        Returns None — pacing disabled — rather than raising when the learning
+        DB cannot be read. Pacing is a spending restraint, and the established
+        rule in this codebase is that a learning-side failure never blocks the
+        EP pipeline. A restraint that cannot be measured is not applied.
+        """
+        from .services.pacing import (
+            PacingContext,
+            available_squad_slots,
+            capital_reserve,
+            median_move_price,
+        )
+
+        if not getattr(self.settings, "pacing_enabled", True):
+            return None
+        if self.bid_learner is None:
+            return None
+        try:
+            prices = self.bid_learner.recent_buy_prices(
+                window_days=int(self.settings.pacing_window_days)
+            )
+        except Exception:
+            logger.exception("pacing: could not read recent buy prices — pacing disabled")
+            return None
+
+        median_move = median_move_price(
+            prices, floor_eur=int(self.settings.pacing_median_floor_eur)
+        )
+        open_offers = sum(int(getattr(b, "user_offer_price", 0) or 0) for b in my_bids)
+        slots_to_fill = available_squad_slots(squad_size, len(my_bids))
+        reserve = capital_reserve(
+            slots_to_fill=slots_to_fill,
+            in_season_min_moves=int(self.settings.pacing_in_season_min_moves),
+            median_move=median_move,
+        )
+        logger.info(
+            "pacing session median_move=%d slots_to_fill=%d reserve=%d open_offers=%d n_prices=%d",
+            median_move,
+            slots_to_fill,
+            reserve,
+            open_offers,
+            len(prices),
+        )
+        return PacingContext(reserve=reserve, open_offers=open_offers)
+
     def get_ep_recommendations(self, league: League) -> dict:
         """Run the EP scoring pipeline and return structured recommendations.
 
@@ -230,6 +281,15 @@ class Trader:
 
         team_info = self.api.get_team_info(league)
         current_budget = team_info.get("budget", 0)
+
+        # Open bids are needed twice over for REH-85: they are euros already
+        # committed, and Kickbase counts them toward the 15-player cap.
+        try:
+            my_bids = self.api.get_my_bids(league)
+        except Exception:
+            logger.exception("pacing: could not read open bids — pacing disabled this run")
+            my_bids = None
+        pacing = None if my_bids is None else self._build_pacing_context(squad_size, my_bids)
 
         # --- 2. Collect performance + details + team profiles ---
         team_profiles: dict[str, dict] = {}
@@ -605,6 +665,7 @@ class Trader:
                     sell_plan=rec.sell_plan,
                     player_id=rec.player.id,
                     is_dgw=rec.score.is_dgw,
+                    pacing=pacing,
                 )
                 rec.recommended_bid = bid_rec.recommended_bid
             except Exception:
@@ -638,6 +699,7 @@ class Trader:
                     sell_plan=synthetic_sell_plan,
                     player_id=pair.buy_player.id,
                     is_dgw=pair.buy_score.is_dgw,
+                    pacing=pacing,
                 )
                 pair.recommended_bid = bid_rec.recommended_bid
             except Exception:

--- a/rehoboam/trader.py
+++ b/rehoboam/trader.py
@@ -284,12 +284,24 @@ class Trader:
 
         # Open bids are needed twice over for REH-85: they are euros already
         # committed, and Kickbase counts them toward the 15-player cap.
+        #
+        # The whole block — the API call AND _build_pacing_context — shares
+        # one try/except. _build_pacing_context's docstring promises it fails
+        # open (returns None instead of raising), but that promise only
+        # covers its own body; the call to it was outside any try, so a
+        # malformed bid payload (e.g. a non-numeric user_offer_price) could
+        # abort the whole EP pipeline instead of merely disabling pacing.
+        # Best-effort learning: a learning-side failure must never block it.
         try:
             my_bids = self.api.get_my_bids(league)
+            # An empty lineup slot is -100 pts at kickoff, which outranks
+            # the pacing reserve — never cap spending during a formation
+            # emergency (see _determine_emergency above).
+            pacing = None if is_emergency else self._build_pacing_context(squad_size, my_bids)
         except Exception:
             logger.exception("pacing: could not read open bids — pacing disabled this run")
             my_bids = None
-        pacing = None if my_bids is None else self._build_pacing_context(squad_size, my_bids)
+            pacing = None
 
         # --- 2. Collect performance + details + team profiles ---
         team_profiles: dict[str, dict] = {}

--- a/tests/test_pacing.py
+++ b/tests/test_pacing.py
@@ -45,10 +45,13 @@ class TestAvailableSquadSlots:
 
 
 class TestCapitalReserve:
-    def test_reserves_one_median_move_per_unfilled_slot(self):
+    def test_reserve_accounts_for_this_buy_filling_one_slot(self):
+        # Off-by-one pin: at slots=3, reserve accounts for 2 moves remaining
+        # after this buy, not 3 unfilled slots before. Using 3*median (32_400_000)
+        # would incorrectly prohibit large signings.
         assert (
             capital_reserve(slots_to_fill=3, in_season_min_moves=2, median_move=10_800_000)
-            == 32_400_000
+            == 21_600_000
         )
 
     def test_full_squad_falls_back_to_the_in_season_minimum(self):
@@ -66,13 +69,10 @@ class TestCapitalReserve:
         )
 
     def test_reserve_unwinds_below_in_season_minimum_while_slots_remain(self):
-        # Discriminator: 0 < slots < in_season_min_moves must use slots, not max().
-        # Using max(1, 2) would incorrectly yield 21_600_000; correct is 10_800_000.
-        # This is the only case where slots-conditional and max() diverge.
-        assert (
-            capital_reserve(slots_to_fill=1, in_season_min_moves=2, median_move=10_800_000)
-            == 10_800_000
-        )
+        # At slots=1, the last slot may be filled freely (reserve=0).
+        # Completing the squad outranks holding replacement money.
+        # Old formula (1*median) would incorrectly give 10_800_000.
+        assert capital_reserve(slots_to_fill=1, in_season_min_moves=2, median_move=10_800_000) == 0
 
 
 class TestPacingContext:
@@ -108,7 +108,7 @@ class TestPacingContext:
             cap = PacingContext(reserve=reserve, open_offers=0).max_bid(budget)
             caps.append(cap)
             budget -= cap  # spend the whole cap, the worst case for the next step
-        assert caps[0] == 29_907_522
+        assert caps[0] == 40_707_522
         assert all(c > 0 for c in caps), "the reserve must never freeze the next buy"
 
 

--- a/tests/test_pacing.py
+++ b/tests/test_pacing.py
@@ -65,6 +65,15 @@ class TestCapitalReserve:
             == 21_600_000
         )
 
+    def test_reserve_unwinds_below_in_season_minimum_while_slots_remain(self):
+        # Discriminator: 0 < slots < in_season_min_moves must use slots, not max().
+        # Using max(1, 2) would incorrectly yield 21_600_000; correct is 10_800_000.
+        # This is the only case where slots-conditional and max() diverge.
+        assert (
+            capital_reserve(slots_to_fill=1, in_season_min_moves=2, median_move=10_800_000)
+            == 10_800_000
+        )
+
 
 class TestPacingContext:
     def test_max_bid_is_the_ceiling_less_open_offers_and_reserve(self):

--- a/tests/test_pacing.py
+++ b/tests/test_pacing.py
@@ -145,13 +145,19 @@ class TestPacingSettings:
         assert s.pacing_median_floor_eur == 3_000_000
 
     def test_every_knob_is_overridable_from_the_environment(self, monkeypatch):
-        """Re-tunable mid-season without a deploy — the REH-99 requirement."""
+        """REH-85 requires all pacing knobs to be re-tunable mid-season from .env
+        without a deploy. This follows the convention established by REH-99: every
+        tunable is a Settings field, populated from the environment."""
         monkeypatch.setenv("KICKBASE_EMAIL", "test@example.com")
         monkeypatch.setenv("KICKBASE_PASSWORD", "test")
         monkeypatch.setenv("PACING_ENABLED", "false")
         monkeypatch.setenv("PACING_IN_SEASON_MIN_MOVES", "4")
+        monkeypatch.setenv("PACING_WINDOW_DAYS", "30")
+        monkeypatch.setenv("PACING_MEDIAN_FLOOR_EUR", "1000000")
         from rehoboam.config import Settings
 
         s = Settings()
         assert s.pacing_enabled is False
         assert s.pacing_in_season_min_moves == 4
+        assert s.pacing_window_days == 30
+        assert s.pacing_median_floor_eur == 1_000_000

--- a/tests/test_pacing.py
+++ b/tests/test_pacing.py
@@ -130,3 +130,28 @@ def test_auto_trader_slot_helper_delegates_to_the_pacing_module():
         assert auto_trader._available_squad_slots(squad, bids) == pacing.available_squad_slots(
             squad, bids
         )
+
+
+class TestPacingSettings:
+    def test_defaults_match_the_design(self, monkeypatch):
+        monkeypatch.setenv("KICKBASE_EMAIL", "test@example.com")
+        monkeypatch.setenv("KICKBASE_PASSWORD", "test")
+        from rehoboam.config import Settings
+
+        s = Settings()
+        assert s.pacing_enabled is True
+        assert s.pacing_in_season_min_moves == 2
+        assert s.pacing_window_days == 90
+        assert s.pacing_median_floor_eur == 3_000_000
+
+    def test_every_knob_is_overridable_from_the_environment(self, monkeypatch):
+        """Re-tunable mid-season without a deploy — the REH-99 requirement."""
+        monkeypatch.setenv("KICKBASE_EMAIL", "test@example.com")
+        monkeypatch.setenv("KICKBASE_PASSWORD", "test")
+        monkeypatch.setenv("PACING_ENABLED", "false")
+        monkeypatch.setenv("PACING_IN_SEASON_MIN_MOVES", "4")
+        from rehoboam.config import Settings
+
+        s = Settings()
+        assert s.pacing_enabled is False
+        assert s.pacing_in_season_min_moves == 4

--- a/tests/test_pacing.py
+++ b/tests/test_pacing.py
@@ -110,3 +110,23 @@ class TestPacingContext:
             budget -= cap  # spend the whole cap, the worst case for the next step
         assert caps[0] == 29_907_522
         assert all(c > 0 for c in caps), "the reserve must never freeze the next buy"
+
+
+def test_auto_trader_slot_helper_delegates_to_the_pacing_module():
+    """One definition of the squad cap, not two.
+
+    REH-99 was caused by two constants for one concept living in different
+    modules and drifting apart. This asserts the copies cannot.
+    """
+    from rehoboam import auto_trader
+    from rehoboam.services import pacing
+
+    # Identity on the FUNCTION, not on SQUAD_CAP: CPython interns small
+    # integers, so `15 is 15` is True even for two separate definitions and
+    # would pass before this task did anything.
+    assert auto_trader.available_squad_slots is pacing.available_squad_slots
+    assert auto_trader.SQUAD_CAP == pacing.SQUAD_CAP
+    for squad, bids in ((11, 1), (15, 0), (13, 2), (15, 2)):
+        assert auto_trader._available_squad_slots(squad, bids) == pacing.available_squad_slots(
+            squad, bids
+        )

--- a/tests/test_pacing.py
+++ b/tests/test_pacing.py
@@ -6,6 +6,9 @@ one EUR 60-65m signing AND roughly 25 more purchases. The difference is not
 the size of a bid; it is what the bid leaves behind.
 """
 
+import pytest
+from pydantic import ValidationError
+
 from rehoboam.services.pacing import (
     PacingContext,
     available_squad_slots,
@@ -40,7 +43,10 @@ class TestAvailableSquadSlots:
     def test_full_squad_has_no_slots(self):
         assert available_squad_slots(squad_size=15, open_bid_count=0) == 0
 
-    def test_over_committed_squad_does_not_report_negative_room(self):
+    def test_over_committed_squad_reports_negative_room_intentionally(self):
+        # The negative return is load-bearing: `capital_reserve` branches on
+        # `slots_to_fill > 0`, and a negative value routes to the
+        # `in_season_min_moves` floor rather than being clamped to zero here.
         assert available_squad_slots(squad_size=15, open_bid_count=2) == -2
 
 
@@ -78,17 +84,43 @@ class TestCapitalReserve:
 class TestPacingContext:
     def test_max_bid_is_the_ceiling_less_open_offers_and_reserve(self):
         ctx = PacingContext(reserve=32_400_000, open_offers=0)
-        assert ctx.max_bid(budget_ceiling=62_307_522) == 29_907_522
+        assert ctx.max_bid(budget_ceiling=62_307_522, current_budget=62_307_522) == 29_907_522
 
     def test_open_offers_are_already_spent(self):
         # Kickbase's reported budget does not deduct pending offers, so two
         # bids sized against the same nominal budget can both land.
         ctx = PacingContext(reserve=10_000_000, open_offers=5_000_000)
-        assert ctx.max_bid(budget_ceiling=50_000_000) == 35_000_000
+        assert ctx.max_bid(budget_ceiling=50_000_000, current_budget=50_000_000) == 35_000_000
 
     def test_max_bid_never_goes_negative(self):
         ctx = PacingContext(reserve=50_000_000, open_offers=0)
-        assert ctx.max_bid(budget_ceiling=10_000_000) == 0
+        assert ctx.max_bid(budget_ceiling=10_000_000, current_budget=10_000_000) == 0
+
+    def test_reserve_never_exceeds_what_currently_exists(self):
+        """A 15/15 squad at EUR 2.0m budget with a EUR 21.6m reserve must not
+        refuse a trade that RECOVERS money. Unclamped, the reserve alone
+        (21.6m) swamps a budget_ceiling built from a EUR 12.0m sell recovery
+        (2.0m + 12.0m = 14.0m), zeroing every trade — including this one,
+        which nets +3.14m into the budget. The clamp caps the reserve at
+        what is actually spendable right now (current_budget - open_offers),
+        so a trade is refused only when it would leave the bot worse off
+        than today, never merely because today is already tight.
+        """
+        ctx = PacingContext(reserve=21_600_000, open_offers=0)
+        # budget_ceiling includes the 12.0m sell recovery; current_budget does not.
+        cap = ctx.max_bid(budget_ceiling=14_000_000, current_budget=2_000_000)
+        assert cap == 12_000_000
+        assert cap >= 8_860_000, "the 8.86m buy this reserve was blocking must now fit"
+
+    def test_the_clamp_does_not_loosen_an_already_binding_reserve(self):
+        """When current_budget comfortably clears the reserve, the clamp must
+        be a no-op — this is the same arithmetic the pre-clamp code always
+        did, and asserts the fix does not loosen the cap in the ordinary case
+        where the reserve is genuinely affordable."""
+        ctx = PacingContext(reserve=32_400_000, open_offers=0)
+        clamped = ctx.max_bid(budget_ceiling=62_307_522, current_budget=62_307_522)
+        unclamped_formula = 62_307_522 - 0 - 32_400_000
+        assert clamped == unclamped_formula == 29_907_522
 
     def test_the_unwind_sequence_from_the_spec(self):
         """Section 2 of the design doc, as executable arithmetic.
@@ -105,7 +137,9 @@ class TestPacingContext:
             reserve = capital_reserve(
                 slots_to_fill=slots, in_season_min_moves=2, median_move=median
             )
-            cap = PacingContext(reserve=reserve, open_offers=0).max_bid(budget)
+            cap = PacingContext(reserve=reserve, open_offers=0).max_bid(
+                budget, current_budget=budget
+            )
             caps.append(cap)
             budget -= cap  # spend the whole cap, the worst case for the next step
         assert caps[0] == 40_707_522
@@ -161,3 +195,22 @@ class TestPacingSettings:
         assert s.pacing_in_season_min_moves == 4
         assert s.pacing_window_days == 30
         assert s.pacing_median_floor_eur == 1_000_000
+
+    @pytest.mark.parametrize(
+        "env_var",
+        ["PACING_IN_SEASON_MIN_MOVES", "PACING_WINDOW_DAYS", "PACING_MEDIAN_FLOOR_EUR"],
+    )
+    def test_negative_values_are_rejected(self, monkeypatch, env_var):
+        """A better guard than the untested `max(0, ...)` clamps inside
+        `capital_reserve` — those silently absorb a bad value instead of
+        surfacing it. A negative window/floor/move-count is nonsensical
+        (there's no such thing as a negative trailing window or a negative
+        euro floor), so Settings should refuse to start with one rather than
+        let it flow into arithmetic that quietly floors it to zero."""
+        monkeypatch.setenv("KICKBASE_EMAIL", "test@example.com")
+        monkeypatch.setenv("KICKBASE_PASSWORD", "test")
+        monkeypatch.setenv(env_var, "-1")
+        from rehoboam.config import Settings
+
+        with pytest.raises(ValidationError):
+            Settings()

--- a/tests/test_pacing.py
+++ b/tests/test_pacing.py
@@ -1,0 +1,103 @@
+"""Reserve the ability to keep buying (REH-85).
+
+The bot committed EUR 71m of an EUR 80m ceiling to one player and then made
+four more buys all season, finishing on EUR 500,000. The champions each made
+one EUR 60-65m signing AND roughly 25 more purchases. The difference is not
+the size of a bid; it is what the bid leaves behind.
+"""
+
+from rehoboam.services.pacing import (
+    PacingContext,
+    available_squad_slots,
+    capital_reserve,
+    median_move_price,
+)
+
+
+class TestMedianMovePrice:
+    def test_returns_the_median_of_the_observed_prices(self):
+        assert median_move_price([1_000_000, 5_000_000, 9_000_000], floor_eur=0) == 5_000_000
+
+    def test_even_count_takes_the_lower_of_the_two_middles(self):
+        # Deliberately not an average: a reserve must be a price someone
+        # actually paid, not an interpolation between two that nobody did.
+        assert median_move_price([2_000_000, 4_000_000], floor_eur=0) == 2_000_000
+
+    def test_empty_population_falls_back_to_the_floor(self):
+        # A thin window must not collapse the reserve to zero, which would
+        # silently disable pacing exactly when there is least evidence.
+        assert median_move_price([], floor_eur=3_000_000) == 3_000_000
+
+    def test_floor_wins_when_the_measured_median_is_below_it(self):
+        assert median_move_price([500_000, 600_000], floor_eur=3_000_000) == 3_000_000
+
+
+class TestAvailableSquadSlots:
+    def test_open_bids_count_as_filled(self):
+        # Kickbase counts a pending offer toward the 15-player cap.
+        assert available_squad_slots(squad_size=11, open_bid_count=1) == 3
+
+    def test_full_squad_has_no_slots(self):
+        assert available_squad_slots(squad_size=15, open_bid_count=0) == 0
+
+    def test_over_committed_squad_does_not_report_negative_room(self):
+        assert available_squad_slots(squad_size=15, open_bid_count=2) == -2
+
+
+class TestCapitalReserve:
+    def test_reserves_one_median_move_per_unfilled_slot(self):
+        assert (
+            capital_reserve(slots_to_fill=3, in_season_min_moves=2, median_move=10_800_000)
+            == 32_400_000
+        )
+
+    def test_full_squad_falls_back_to_the_in_season_minimum(self):
+        # At 15/15 there are no slots to fill, but the bot must still be able
+        # to replace a player mid-season.
+        assert (
+            capital_reserve(slots_to_fill=0, in_season_min_moves=2, median_move=10_800_000)
+            == 21_600_000
+        )
+
+    def test_negative_slots_never_shrink_the_reserve_below_the_minimum(self):
+        assert (
+            capital_reserve(slots_to_fill=-2, in_season_min_moves=2, median_move=10_800_000)
+            == 21_600_000
+        )
+
+
+class TestPacingContext:
+    def test_max_bid_is_the_ceiling_less_open_offers_and_reserve(self):
+        ctx = PacingContext(reserve=32_400_000, open_offers=0)
+        assert ctx.max_bid(budget_ceiling=62_307_522) == 29_907_522
+
+    def test_open_offers_are_already_spent(self):
+        # Kickbase's reported budget does not deduct pending offers, so two
+        # bids sized against the same nominal budget can both land.
+        ctx = PacingContext(reserve=10_000_000, open_offers=5_000_000)
+        assert ctx.max_bid(budget_ceiling=50_000_000) == 35_000_000
+
+    def test_max_bid_never_goes_negative(self):
+        ctx = PacingContext(reserve=50_000_000, open_offers=0)
+        assert ctx.max_bid(budget_ceiling=10_000_000) == 0
+
+    def test_the_unwind_sequence_from_the_spec(self):
+        """Section 2 of the design doc, as executable arithmetic.
+
+        The point of deriving the reserve from slots-to-fill rather than a
+        constant N is that it unwinds. A constant 3 moves would leave the
+        reserve at EUR 32.4m while the budget fell, capping the second buy
+        near EUR 4.8m and freezing the bot one purchase later.
+        """
+        median = 10_800_000
+        budget = 62_307_522
+        caps = []
+        for slots in (3, 2, 1):
+            reserve = capital_reserve(
+                slots_to_fill=slots, in_season_min_moves=2, median_move=median
+            )
+            cap = PacingContext(reserve=reserve, open_offers=0).max_bid(budget)
+            caps.append(cap)
+            budget -= cap  # spend the whole cap, the worst case for the next step
+        assert caps[0] == 29_907_522
+        assert all(c > 0 for c in caps), "the reserve must never freeze the next buy"

--- a/tests/test_pacing_bidding.py
+++ b/tests/test_pacing_bidding.py
@@ -43,8 +43,65 @@ def _bid(bidding, *, asking, mv, gain, budget, pacing=None):
 
 
 def test_without_pacing_the_bid_is_unchanged(bidding):
-    """None must be a true no-op, or every existing caller changes behaviour."""
-    assert _bid(bidding, asking=10_000_000, mv=10_000_000, gain=90.0, budget=62_307_522) > 0
+    """`pacing=None` must be a true no-op, or every existing caller changes
+    behaviour — `trader.py` and `replay/driver.py` never pass the argument at
+    all, which defaults to `None`.
+
+    Asserting `> 0` (the old assertion) only proves *some* bid came back; it
+    would still pass even if the default silently changed what that bid was.
+    Assert the two calls — explicit `pacing=None` and the argument omitted
+    entirely — return the exact same integer.
+    """
+    kwargs = {"asking": 10_000_000, "mv": 10_000_000, "gain": 90.0, "budget": 62_307_522}
+    explicit_none = _bid(bidding, **kwargs, pacing=None)
+    omitted = bidding.calculate_ep_bid(
+        asking_price=kwargs["asking"],
+        market_value=kwargs["mv"],
+        expected_points=80.0,
+        marginal_ep_gain=kwargs["gain"],
+        confidence=0.8,
+        current_budget=kwargs["budget"],
+        sell_plan=None,
+        # pacing intentionally omitted — this is what every real caller does today.
+    ).recommended_bid
+    assert explicit_none == omitted
+    assert explicit_none > 0
+
+
+def test_the_cap_must_sit_after_the_market_value_floor(bidding):
+    """Pins placement: pacing must be applied AFTER the market-value floor
+    (`recommended_bid = min(market_value_floor, budget_ceiling)`), or that
+    floor silently undoes the cap.
+
+    Numbers are chosen so the two placements diverge, not just so the
+    end-state assertion holds:
+
+    - asking=EUR 30.0m sits just above pace_cap=EUR 29.907m (budget EUR
+      62.307522m - reserve EUR 32.4m - open_offers 0), so a *correctly*
+      placed cap lands below asking and the existing
+      `if recommended_bid < asking_price: recommended_bid = 0` zeroes it.
+    - market_value * 1.01 = EUR 30.098m is ABOVE asking_price. If the cap
+      were applied before the market-value floor instead, the floor would
+      raise the capped bid straight back up to EUR 30.098m — above asking,
+      so it would NOT get zeroed, and this test would fail.
+
+    The previous version of this test (Tah, EUR 44.1m asking / EUR 37.0m mv)
+    passed regardless of placement: `mv * 1.01` there is *below* asking, so
+    the floor could never rescue a misplaced cap above the asking price, and
+    the assertion was `== 0` either way. Verified directly (see task-5
+    fix report): temporarily moving the pacing block to before the
+    market-value floor made this test FAIL and left the old Tah-shaped test
+    passing.
+    """
+    paced = _bid(
+        bidding,
+        asking=30_000_000,
+        mv=29_800_000,
+        gain=90.0,
+        budget=62_307_522,
+        pacing=PacingContext(reserve=32_400_000, open_offers=0),
+    )
+    assert paced == 0
 
 
 def test_a_signing_that_would_break_the_reserve_is_not_bid_on(bidding):
@@ -53,6 +110,12 @@ def test_a_signing_that_would_break_the_reserve_is_not_bid_on(bidding):
     The cap lands below the asking price, and the existing
     `if recommended_bid < asking_price: recommended_bid = 0` turns that into a
     skip. Pacing therefore needs no refusal path of its own.
+
+    Kept as a realistic scenario alongside
+    `test_the_cap_must_sit_after_the_market_value_floor` above, which is the
+    one that actually discriminates cap placement — here `market_value * 1.01`
+    (~EUR 37.4m) stays below the EUR 44.1m asking price, so this test passes
+    at `paced == 0` whether the cap is placed correctly or not.
     """
     paced = _bid(
         bidding,

--- a/tests/test_pacing_bidding.py
+++ b/tests/test_pacing_bidding.py
@@ -208,3 +208,39 @@ def test_a_trade_pair_is_paced_on_its_net_cost(bidding):
     ).recommended_bid
     assert gross_only == 0
     assert with_pair >= 25_000_000
+
+
+def test_a_net_positive_pair_is_not_frozen_by_an_unaffordable_reserve(bidding):
+    """Finding 1: at 15/15 the reserve must not freeze a trade that RECOVERS
+    money. Squad 15/15 (in_season_min_moves=2, median 10.8m -> reserve
+    21.6m), budget already down to EUR 2.0m, selling a 12.0m player to buy an
+    8.86m one -- a trade that nets +3.14m into the budget.
+
+    Before the clamp: budget_ceiling = 2.0m + 12.0m recovery = 14.0m, and the
+    21.6m reserve alone exceeds that, so pace_cap = 0 and the bid is refused
+    even though the squad ends up with MORE money than it has today. The
+    clamp caps the reserve at what is actually spendable right now
+    (current_budget - open_offers = 2.0m), so the cap becomes 12.0m and the
+    trade proceeds.
+    """
+    from rehoboam.scoring.models import SellPlan
+
+    plan = SellPlan(
+        players_to_sell=[],
+        total_recovery=12_000_000,
+        net_budget_after=2_000_000 + 12_000_000 - 8_860_000,
+        is_viable=True,
+        ep_impact=0.0,
+        reasoning="test",
+    )
+    paced = bidding.calculate_ep_bid(
+        asking_price=8_860_000,
+        market_value=8_860_000,
+        expected_points=80.0,
+        marginal_ep_gain=90.0,
+        confidence=0.8,
+        current_budget=2_000_000,
+        sell_plan=plan,
+        pacing=PacingContext(reserve=21_600_000, open_offers=0),
+    ).recommended_bid
+    assert paced >= 8_860_000

--- a/tests/test_pacing_bidding.py
+++ b/tests/test_pacing_bidding.py
@@ -1,0 +1,147 @@
+"""Pacing inside the live bidding path (REH-85).
+
+These drive the real `SmartBidding.calculate_ep_bid`, because the whole defect
+was that a cap existed in one place and the number that executed came from
+another.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rehoboam.bidding_strategy import SmartBidding
+from rehoboam.services.bid_ceiling import BidCeilingPolicy, Tier
+from rehoboam.services.pacing import PacingContext
+
+CEILING = BidCeilingPolicy(
+    floor_eur=250_000,
+    tier_pcts={
+        Tier.MARGINAL: 8.0,
+        Tier.SOLID: 15.0,
+        Tier.STRONG: 25.0,
+        Tier.MUST_HAVE: 35.0,
+    },
+)
+
+
+@pytest.fixture
+def bidding():
+    return SmartBidding(bid_learner=None, activity_feed_learner=None, ceiling_policy=CEILING)
+
+
+def _bid(bidding, *, asking, mv, gain, budget, pacing=None):
+    return bidding.calculate_ep_bid(
+        asking_price=asking,
+        market_value=mv,
+        expected_points=80.0,
+        marginal_ep_gain=gain,
+        confidence=0.8,
+        current_budget=budget,
+        sell_plan=None,
+        pacing=pacing,
+    ).recommended_bid
+
+
+def test_without_pacing_the_bid_is_unchanged(bidding):
+    """None must be a true no-op, or every existing caller changes behaviour."""
+    assert _bid(bidding, asking=10_000_000, mv=10_000_000, gain=90.0, budget=62_307_522) > 0
+
+
+def test_a_signing_that_would_break_the_reserve_is_not_bid_on(bidding):
+    """Tah: EUR 44.1m asking against a EUR 32.4m reserve on a EUR 62.3m budget.
+
+    The cap lands below the asking price, and the existing
+    `if recommended_bid < asking_price: recommended_bid = 0` turns that into a
+    skip. Pacing therefore needs no refusal path of its own.
+    """
+    paced = _bid(
+        bidding,
+        asking=44_068_628,
+        mv=37_028_628,
+        gain=90.0,
+        budget=62_307_522,
+        pacing=PacingContext(reserve=32_400_000, open_offers=0),
+    )
+    assert paced == 0
+
+
+def test_a_signing_that_fits_the_reserve_still_happens(bidding):
+    """Asllani: EUR 25.1m leaves EUR 37.2m against a EUR 32.4m reserve."""
+    paced = _bid(
+        bidding,
+        asking=25_058_860,
+        mv=23_708_860,
+        gain=90.0,
+        budget=62_307_522,
+        pacing=PacingContext(reserve=32_400_000, open_offers=0),
+    )
+    assert paced >= 25_058_860
+
+
+def test_pacing_never_raises_a_bid(bidding):
+    """It is a cap. It composes with the REH-99 ceiling; it never competes."""
+    unpaced = _bid(bidding, asking=5_000_000, mv=5_000_000, gain=90.0, budget=62_307_522)
+    paced = _bid(
+        bidding,
+        asking=5_000_000,
+        mv=5_000_000,
+        gain=90.0,
+        budget=62_307_522,
+        pacing=PacingContext(reserve=32_400_000, open_offers=0),
+    )
+    assert paced <= unpaced
+
+
+def test_open_offers_reduce_what_may_be_committed(bidding):
+    """A EUR 30m open offer plus a EUR 32.4m reserve leaves nothing spendable."""
+    paced = _bid(
+        bidding,
+        asking=25_058_860,
+        mv=23_708_860,
+        gain=90.0,
+        budget=62_307_522,
+        pacing=PacingContext(reserve=32_400_000, open_offers=30_000_000),
+    )
+    assert paced == 0
+
+
+def test_a_trade_pair_is_paced_on_its_net_cost(bidding):
+    """The synthetic sell plan is what makes this work with no special case.
+
+    `trader.py` gives a pair a SellPlan whose total_recovery is the sale
+    proceeds, so budget_ceiling already includes them. A pair that looks
+    unaffordable gross becomes affordable net — which is correct, because a
+    pair recycles capital rather than consuming it.
+    """
+    from rehoboam.scoring.models import SellPlan
+
+    plan = SellPlan(
+        players_to_sell=[],
+        total_recovery=20_000_000,
+        net_budget_after=0,
+        is_viable=True,
+        ep_impact=0.0,
+        reasoning="test",
+    )
+    gross_only = bidding.calculate_ep_bid(
+        asking_price=25_000_000,
+        market_value=25_000_000,
+        expected_points=80.0,
+        marginal_ep_gain=90.0,
+        confidence=0.8,
+        current_budget=40_000_000,
+        sell_plan=None,
+        pacing=PacingContext(reserve=32_400_000, open_offers=0),
+    ).recommended_bid
+    with_pair = bidding.calculate_ep_bid(
+        asking_price=25_000_000,
+        market_value=25_000_000,
+        expected_points=80.0,
+        marginal_ep_gain=90.0,
+        confidence=0.8,
+        current_budget=40_000_000,
+        sell_plan=plan,
+        pacing=PacingContext(reserve=32_400_000, open_offers=0),
+    ).recommended_bid
+    assert gross_only == 0
+    assert with_pair >= 25_000_000

--- a/tests/test_pacing_emergency_and_fail_open.py
+++ b/tests/test_pacing_emergency_and_fail_open.py
@@ -1,0 +1,136 @@
+"""Findings 3 and 5 from the final whole-branch review (REH-85).
+
+Finding 3: pacing must not apply during a formation emergency. The reserve
+scales with empty slots but has no relation to affordability -- at the live
+median it demands 10.8m per unfilled slot, so an under-strength squad (the
+state that costs -100 pts/empty lineup slot at kickoff) is exactly the state
+where pacing is most likely to zero every candidate. The emergency-fill
+fallback (`_run_emergency_squad_fill`) only helps 2-5 days before kickoff; a
+paced-to-zero recommendation is dropped from the candidate list entirely
+outside that window, so this has to be fixed at the source: don't build a
+pacing context at all while the squad can't field a legal eleven.
+
+Finding 5: `_build_pacing_context`'s docstring promises it returns None
+rather than raising, but the call to it at `trader.py`'s call site sat
+outside any try -- so a malformed bid payload (Kickbase API contract
+drift, corrupted cache, etc.) would abort the whole EP pipeline instead of
+just disabling pacing. Best-effort learning: a learning-side failure must
+never block the pipeline.
+
+Both drive the real `Trader.get_ep_recommendations` end to end (rather than
+`_build_pacing_context` in isolation, which is already covered by
+`test_pacing_session.py`) because the defect in both cases lives in the
+surrounding call site, not in `_build_pacing_context` itself.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from rehoboam.config import Settings
+from rehoboam.trader import Trader
+
+
+def _trader_with_mock_api(tmp_path, monkeypatch, *, recent_buy_prices=None):
+    """Mirrors `test_pacing_session.py`'s `trader` fixture, but chdir's BEFORE
+    constructing `Trader` -- `Trader.__init__` eagerly opens a real
+    `ValueHistoryCache` sqlite file under `./logs/`, and constructing it
+    before the chdir would create that file in the repo root instead of
+    `tmp_path`.
+    """
+    monkeypatch.setenv("KICKBASE_EMAIL", "test@example.com")
+    monkeypatch.setenv("KICKBASE_PASSWORD", "test")
+    monkeypatch.chdir(tmp_path)
+    api = MagicMock()
+    learner = MagicMock()
+    learner.recent_buy_prices.return_value = (
+        recent_buy_prices if recent_buy_prices is not None else [10_800_000] * 9
+    )
+    trader = Trader(api=api, settings=Settings(), bid_learner=learner)
+    return api, trader
+
+
+def _squad_player(pid: str, position: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=pid,
+        position=position,
+        first_name="P",
+        last_name=pid,
+        team_id=f"club-{pid}",
+        price=1_000_000,
+        market_value=1_000_000,
+    )
+
+
+# 11 players meeting every FormationRequirements minimum (1 GK, 5 DEF, 4 MID,
+# 1 FW) -- a normal, fieldable squad.
+_FIELDABLE_SQUAD = [
+    _squad_player("g1", "Goalkeeper"),
+    *[_squad_player(f"d{i}", "Defender") for i in range(1, 6)],
+    *[_squad_player(f"m{i}", "Midfielder") for i in range(1, 5)],
+    _squad_player("f1", "Forward"),
+]
+
+# 9 Defenders: below the 11-player floor AND missing GK/MID/FW entirely --
+# cannot field a legal eleven under any formation.
+_EMERGENCY_SQUAD = [_squad_player(f"d{i}", "Defender") for i in range(1, 10)]
+
+
+def _quiet_api(api) -> None:
+    """Best-effort side calls the pipeline makes that this test doesn't care
+    about -- raising lets their own try/except blocks short-circuit them
+    cleanly instead of returning MagicMocks that real downstream code (e.g.
+    MatchupAnalyzer) would choke on trying to interpret as real payloads.
+    """
+    api.get_market.return_value = []
+    api.get_team_info.return_value = {"budget": 20_000_000, "team_value": 20_000_000}
+    api.get_league_ranking.side_effect = RuntimeError("no network in this test")
+    api.get_competition_matchdays.side_effect = RuntimeError("no network in this test")
+
+
+class TestEmergencyExemption:
+    """Finding 3."""
+
+    def test_emergency_squad_gets_no_pacing_context(self, tmp_path, monkeypatch):
+        api, trader = _trader_with_mock_api(tmp_path, monkeypatch)
+        _quiet_api(api)
+        api.get_squad.return_value = list(_EMERGENCY_SQUAD)
+        api.get_my_bids.return_value = []
+
+        result = trader.get_ep_recommendations(league=SimpleNamespace(id="L"))
+
+        assert result["pacing"] is None
+
+    def test_normal_squad_gets_a_pacing_context(self, tmp_path, monkeypatch):
+        api, trader = _trader_with_mock_api(tmp_path, monkeypatch)
+        _quiet_api(api)
+        api.get_squad.return_value = list(_FIELDABLE_SQUAD)
+        api.get_my_bids.return_value = []
+
+        result = trader.get_ep_recommendations(league=SimpleNamespace(id="L"))
+
+        assert result["pacing"] is not None
+
+
+class TestFailOpenGuardCoversTheWholeBlock:
+    """Finding 5."""
+
+    def test_a_malformed_bid_payload_disables_pacing_rather_than_raising(
+        self, tmp_path, monkeypatch
+    ):
+        """`user_offer_price="not-a-number"` makes `_build_pacing_context`'s
+        `open_offers = sum(int(getattr(b, "user_offer_price", 0) or 0) ...)`
+        line raise a ValueError. On a normal (non-emergency) squad, that call
+        must be swallowed by the same try/except that already guards
+        `api.get_my_bids` -- the whole EP pipeline must still complete and
+        return a dict with pacing disabled, not propagate the exception.
+        """
+        api, trader = _trader_with_mock_api(tmp_path, monkeypatch)
+        _quiet_api(api)
+        api.get_squad.return_value = list(_FIELDABLE_SQUAD)
+        api.get_my_bids.return_value = [SimpleNamespace(user_offer_price="not-a-number")]
+
+        result = trader.get_ep_recommendations(league=SimpleNamespace(id="L"))
+
+        assert result["pacing"] is None

--- a/tests/test_pacing_flips.py
+++ b/tests/test_pacing_flips.py
@@ -1,0 +1,192 @@
+"""Finding 2: profit flips must be paced too (REH-85 design §3).
+
+Flips are sized by `ProfitTrader` via `Trader.find_profit_opportunities` and
+never reach `SmartBidding.calculate_ep_bid` — the reserve `pacing.py`
+computes never applied to them, even though the design's §3 table says it
+should ("discretionary, and a flip is capital parked rather than deployed").
+`enable_flip_buys` defaults to True, so this ran in production: a flip could
+consume the exact capital the reserve exists to protect, in the same session
+where pacing refused a squad-improvement buy for lack of it.
+
+These tests drive `AutoTrader.run_unified_trade_phase` end to end (with
+`execution.buy` mocked out so a real safety-gate/dry-run pass isn't needed)
+and assert the pacing cap is applied at the same spot the existing
+`opp.buy_price > ctx.flip_budget` affordability check already lives.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from rehoboam.auto_trader import AutoTrader, EPSessionContext, MatchdayPhase
+from rehoboam.config import Settings
+from rehoboam.profit_trader import ProfitOpportunity
+from rehoboam.services.execution import AutoTradeResult
+from rehoboam.services.pacing import PacingContext
+
+
+@pytest.fixture
+def settings(monkeypatch) -> Settings:
+    monkeypatch.setenv("KICKBASE_EMAIL", "test@example.com")
+    monkeypatch.setenv("KICKBASE_PASSWORD", "test")
+    return Settings()
+
+
+@pytest.fixture
+def trader(tmp_path, settings, monkeypatch) -> AutoTrader:
+    monkeypatch.chdir(tmp_path)  # BidLearner/ActivityFeedLearner default to ./logs
+    api = MagicMock()
+    t = AutoTrader(api=api, settings=settings, dry_run=True)
+    t.learner = Mock()
+    t.learner.was_recently_sold.return_value = False
+    return t
+
+
+def _squad_player(pid: str, position: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=pid, position=position, first_name="P", last_name=pid, team_id=f"club-{pid}"
+    )
+
+
+# 14 players (1 slot open under the 15-cap): fieldable on its own, and stays
+# fieldable + not dead-weight after adding one more Midfielder (4 -> 5, the
+# max any formation can start).
+_SQUAD14 = [
+    *[_squad_player(f"g{i}", "Goalkeeper") for i in range(1, 4)],
+    *[_squad_player(f"d{i}", "Defender") for i in range(1, 6)],
+    *[_squad_player(f"m{i}", "Midfielder") for i in range(1, 5)],
+    *[_squad_player(f"f{i}", "Forward") for i in range(1, 3)],
+]
+
+
+def _configure(trader):
+    trader.api.get_squad.return_value = list(_SQUAD14)
+    trader.api.get_my_bids.return_value = []
+    trader.api.get_team_info.return_value = {"budget": 20_000_000, "team_value": 40_000_000}
+    # Zero the debt allowance so `_compute_flip_budget`'s "aggressive phase"
+    # branch (current_budget + max_debt - pending_bids) reduces to exactly
+    # current_budget -- keeping the pace_cap arithmetic in each test legible
+    # instead of entangled with a second Settings field.
+    trader.settings.max_debt_pct_of_team_value = 0.0
+
+
+def _ctx(pacing_ctx) -> EPSessionContext:
+    """One plain-buy candidate priced far beyond any plausible flip_budget, so
+    it is skipped in the main loop's affordability check without consuming a
+    slot or a bid -- present only so `candidates` is non-empty and the method
+    doesn't return before ever reaching the flip search.
+    """
+    buy_rec = SimpleNamespace(
+        player=SimpleNamespace(
+            id="p1", first_name="Un", last_name="Affordable", market_value=1_000_000
+        ),
+        recommended_bid=999_999_999,
+        marginal_ep_gain=10.0,
+        reason="test upgrade",
+        sell_plan=None,
+        score=SimpleNamespace(expected_points=50.0),
+    )
+    phase = MatchdayPhase(
+        days_until_match=5, phase="aggressive", max_trades=5, allow_flips=True, reason="test"
+    )
+    return EPSessionContext(
+        ep_result={
+            "buy_recs": [buy_rec],
+            "trade_pairs": [],
+            "pacing": pacing_ctx,
+            "market_players": {},
+            "competitor_player_ids": set(),
+        },
+        matchday_phase=phase,
+        my_bids=[],
+        my_bid_amounts={},
+        squad=[],
+        current_budget=20_000_000,
+        team_value=40_000_000,
+        flip_budget=20_000_000,
+    )
+
+
+def _flip_opp(buy_price: int) -> ProfitOpportunity:
+    player = SimpleNamespace(
+        id="flip1",
+        position="Midfielder",
+        first_name="Flip",
+        last_name="Target",
+        team_id="clubF",
+        market_value=buy_price,
+    )
+    return ProfitOpportunity(
+        player=player,
+        buy_price=buy_price,
+        market_value=buy_price,
+        value_gap=0,
+        value_gap_pct=0.0,
+        expected_appreciation=15.0,
+        risk_score=10.0,
+        hold_days=3,
+        reason="test flip",
+    )
+
+
+def _successful_buy(price: int) -> AutoTradeResult:
+    return AutoTradeResult(
+        success=True,
+        player_name="Flip Target",
+        action="BUY",
+        price=price,
+        reason="flip",
+        timestamp=0.0,
+    )
+
+
+class TestFlipPacing:
+    def test_a_flip_exceeding_the_pacing_cap_is_skipped(self, trader):
+        """reserve=15.0m, current_budget=flip_budget=20.0m (no clamp since
+        20.0m > 15.0m) -> pace_cap = 20.0m - 15.0m = 5.0m. The flip asks
+        8.0m, so it must be skipped."""
+        _configure(trader)
+        ctx = _ctx(PacingContext(reserve=15_000_000, open_offers=0))
+        opp = _flip_opp(buy_price=8_000_000)
+        trader.execution.buy = MagicMock()
+
+        with patch("rehoboam.trader.Trader.find_profit_opportunities", return_value=[opp]):
+            trader.run_unified_trade_phase(league=SimpleNamespace(id="L"), ctx=ctx)
+
+        trader.execution.buy.assert_not_called()
+
+    def test_an_affordable_flip_still_executes(self, trader):
+        """Same reserve, same pace_cap of 5.0m -- a 3.0m flip fits and must
+        still go through."""
+        _configure(trader)
+        ctx = _ctx(PacingContext(reserve=15_000_000, open_offers=0))
+        opp = _flip_opp(buy_price=3_000_000)
+        trader.execution.buy = MagicMock(return_value=_successful_buy(opp.buy_price))
+
+        with patch("rehoboam.trader.Trader.find_profit_opportunities", return_value=[opp]):
+            trader.run_unified_trade_phase(league=SimpleNamespace(id="L"), ctx=ctx)
+
+        trader.execution.buy.assert_called_once()
+        call_args = trader.execution.buy.call_args[0]
+        assert call_args[1] is opp.player
+        assert call_args[2] == opp.buy_price
+
+    def test_no_pacing_context_means_flips_are_not_capped(self, trader):
+        """`ep_result["pacing"]` is None when pacing is off entirely
+        (`Settings.pacing_enabled=False`, or a learning-side failure). A
+        flip that would have exceeded the 5.0m cap from the tests above must
+        proceed unimpeded -- pacing being off is not the same as pacing
+        refusing everything.
+        """
+        _configure(trader)
+        ctx = _ctx(pacing_ctx=None)
+        opp = _flip_opp(buy_price=8_000_000)
+        trader.execution.buy = MagicMock(return_value=_successful_buy(opp.buy_price))
+
+        with patch("rehoboam.trader.Trader.find_profit_opportunities", return_value=[opp]):
+            trader.run_unified_trade_phase(league=SimpleNamespace(id="L"), ctx=ctx)
+
+        trader.execution.buy.assert_called_once()

--- a/tests/test_pacing_prices.py
+++ b/tests/test_pacing_prices.py
@@ -1,0 +1,62 @@
+"""The measured price of one further move (REH-85).
+
+A "move" costs EUR 6.03m across the whole `manager_transfers` table but
+EUR 10.8m in the 2026/27 pre-season. A hardcoded euro figure would be wrong
+within one transfer window, which is the same lesson REH-99 learned about the
+overbid cap: measure the population, and re-measure it.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from rehoboam.bid_learner import BidLearner
+
+
+@pytest.fixture
+def learner(tmp_path):
+    return BidLearner(db_path=tmp_path / "bid_learning.db")
+
+
+def _iso(days_ago: float) -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time() - days_ago * 86400))
+
+
+def _row(price: int, days_ago: float, transfer_type: int = 1, player_id: str = "p") -> dict:
+    return {
+        "league_id": "L",
+        "manager_id": "m1",
+        "transfer_dt": _iso(days_ago),
+        "player_id": f"{player_id}{price}",
+        "player_name": "Test",
+        "transfer_type": transfer_type,
+        "transfer_price": price,
+    }
+
+
+def test_returns_buy_prices_inside_the_window(learner):
+    learner.record_manager_transfers([_row(5_000_000, 10), _row(9_000_000, 20)])
+    assert sorted(learner.recent_buy_prices(window_days=90)) == [5_000_000, 9_000_000]
+
+
+def test_excludes_sells(learner):
+    """Type 2 is a sale. Pricing a move off sale proceeds would be wrong."""
+    learner.record_manager_transfers([_row(5_000_000, 10), _row(80_000_000, 10, transfer_type=2)])
+    assert learner.recent_buy_prices(window_days=90) == [5_000_000]
+
+
+def test_excludes_rows_outside_the_window(learner):
+    learner.record_manager_transfers([_row(5_000_000, 10), _row(9_000_000, 200)])
+    assert learner.recent_buy_prices(window_days=90) == [5_000_000]
+
+
+def test_prices_are_absolute(learner):
+    """The feed signs a buy negative in some payloads; a reserve is a magnitude."""
+    learner.record_manager_transfers([_row(-7_000_000, 5)])
+    assert learner.recent_buy_prices(window_days=90) == [7_000_000]
+
+
+def test_empty_table_returns_empty_list_not_an_error(learner):
+    assert learner.recent_buy_prices(window_days=90) == []

--- a/tests/test_pacing_replay.py
+++ b/tests/test_pacing_replay.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import inspect
 
-from rehoboam.replay.driver import make_ep_bid_fn
+from rehoboam.replay.driver import _make_median_move_fn, make_ep_bid_fn
 
 
 def test_bid_fn_takes_squad_size():
@@ -12,18 +12,20 @@ def test_bid_fn_takes_squad_size():
     fn = make_ep_bid_fn(
         mv_fn=lambda pid, at: 10_000_000,
         score_fn=lambda pid, at: 80.0,
-        median_move=10_800_000,
+        median_move_fn=lambda at: 10_800_000,
         in_season_min_moves=2,
     )
     assert len(inspect.signature(fn).parameters) == 6
 
 
 def test_a_short_squad_is_capped_below_an_unaffordable_signing():
-    """9 players = 6 slots to fill = a EUR 64.8m reserve on EUR 80m."""
+    """9 players = 6 slots to fill = 5 moves after this buy = a EUR 54.0m
+    reserve on EUR 80m (the slots-minus-one discount: this buy itself fills
+    one of the 6 slots, so only 5 remain to be protected for)."""
     fn = make_ep_bid_fn(
         mv_fn=lambda pid, at: 40_000_000,
         score_fn=lambda pid, at: 80.0,
-        median_move=10_800_000,
+        median_move_fn=lambda at: 10_800_000,
         in_season_min_moves=2,
     )
     assert fn("p1", 44_000_000, 0.0, 90.0, 80_000_000, 9) == 0
@@ -33,7 +35,79 @@ def test_an_affordable_signing_still_goes_through():
     fn = make_ep_bid_fn(
         mv_fn=lambda pid, at: 5_000_000,
         score_fn=lambda pid, at: 80.0,
-        median_move=10_800_000,
+        median_move_fn=lambda at: 10_800_000,
         in_season_min_moves=2,
     )
     assert fn("p1", 5_000_000, 0.0, 90.0, 80_000_000, 9) >= 5_000_000
+
+
+def test_pacing_enabled_false_bypasses_the_reserve():
+    """--no-pacing is the genuinely unpaced code path (pacing=None), not a
+    reserve pinned to zero — the same short-squad signing that gets capped to
+    0 when paced (see above) must clear when pacing is off."""
+    fn = make_ep_bid_fn(
+        mv_fn=lambda pid, at: 40_000_000,
+        score_fn=lambda pid, at: 80.0,
+        median_move_fn=lambda at: 10_800_000,
+        in_season_min_moves=2,
+        pacing_enabled=False,
+    )
+    assert fn("p1", 44_000_000, 0.0, 90.0, 80_000_000, 9) >= 44_000_000
+
+
+def test_median_move_fn_is_called_with_the_decision_instant():
+    """The reserve must be able to move matchday to matchday, not freeze at a
+    single pre-season constant for the whole season (review finding 2)."""
+    seen: list[float] = []
+
+    def median_move_fn(at: float) -> int:
+        seen.append(at)
+        return 10_800_000
+
+    fn = make_ep_bid_fn(
+        mv_fn=lambda pid, at: 40_000_000,
+        score_fn=lambda pid, at: 80.0,
+        median_move_fn=median_move_fn,
+        in_season_min_moves=2,
+    )
+    fn("p1", 44_000_000, 123.0, 90.0, 80_000_000, 9)
+
+    assert seen == [123.0]
+
+
+class _FakeCorpus:
+    """A stand-in for TrainingCorpus that just records the query window."""
+
+    def __init__(self, rows: list[dict]):
+        self._rows = rows
+        self.calls: list[tuple[float, float]] = []
+
+    def transfers_between(self, lo: float, hi: float) -> list[dict]:
+        self.calls.append((lo, hi))
+        return self._rows
+
+
+def test_make_median_move_fn_windows_and_memoises_by_at():
+    """One query per distinct decision instant, bounded at (at - window, at) —
+    never past `at`, which is already the leak boundary upstream."""
+    corpus = _FakeCorpus([{"price": 5_000_000}, {"price": 15_000_000}, {"price": 10_000_000}])
+    median_move_at = _make_median_move_fn(corpus, window_days=7, floor_eur=1_000_000)
+
+    first = median_move_at(1_000_000.0)
+    second = median_move_at(1_000_000.0)  # same `at` -> memoised, no new query
+    third = median_move_at(2_000_000.0)  # different `at` -> a new query
+
+    assert first == 10_000_000  # median of [5m, 10m, 15m]
+    assert second == 10_000_000
+    assert third == 10_000_000
+    assert corpus.calls == [
+        (1_000_000.0 - 7 * 86400.0, 1_000_000.0),
+        (2_000_000.0 - 7 * 86400.0, 2_000_000.0),
+    ]
+
+
+def test_make_median_move_fn_applies_the_floor_on_an_empty_window():
+    corpus = _FakeCorpus([])
+    median_move_at = _make_median_move_fn(corpus, window_days=7, floor_eur=3_000_000)
+
+    assert median_move_at(1_000_000.0) == 3_000_000

--- a/tests/test_pacing_replay.py
+++ b/tests/test_pacing_replay.py
@@ -1,0 +1,39 @@
+"""The replay must exercise pacing, or the measurement means nothing (REH-85)."""
+
+from __future__ import annotations
+
+import inspect
+
+from rehoboam.replay.driver import make_ep_bid_fn
+
+
+def test_bid_fn_takes_squad_size():
+    """Pacing needs slots-to-fill, which needs the squad size."""
+    fn = make_ep_bid_fn(
+        mv_fn=lambda pid, at: 10_000_000,
+        score_fn=lambda pid, at: 80.0,
+        median_move=10_800_000,
+        in_season_min_moves=2,
+    )
+    assert len(inspect.signature(fn).parameters) == 6
+
+
+def test_a_short_squad_is_capped_below_an_unaffordable_signing():
+    """9 players = 6 slots to fill = a EUR 64.8m reserve on EUR 80m."""
+    fn = make_ep_bid_fn(
+        mv_fn=lambda pid, at: 40_000_000,
+        score_fn=lambda pid, at: 80.0,
+        median_move=10_800_000,
+        in_season_min_moves=2,
+    )
+    assert fn("p1", 44_000_000, 0.0, 90.0, 80_000_000, 9) == 0
+
+
+def test_an_affordable_signing_still_goes_through():
+    fn = make_ep_bid_fn(
+        mv_fn=lambda pid, at: 5_000_000,
+        score_fn=lambda pid, at: 80.0,
+        median_move=10_800_000,
+        in_season_min_moves=2,
+    )
+    assert fn("p1", 5_000_000, 0.0, 90.0, 80_000_000, 9) >= 5_000_000

--- a/tests/test_pacing_session.py
+++ b/tests/test_pacing_session.py
@@ -1,0 +1,64 @@
+"""Building the pacing context from live session state (REH-85)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from rehoboam.config import Settings
+from rehoboam.trader import Trader
+
+
+@pytest.fixture
+def settings(monkeypatch):
+    monkeypatch.setenv("KICKBASE_EMAIL", "test@example.com")
+    monkeypatch.setenv("KICKBASE_PASSWORD", "test")
+    return Settings()
+
+
+@pytest.fixture
+def trader(settings):
+    learner = MagicMock()
+    learner.recent_buy_prices.return_value = [10_800_000] * 9
+    return Trader(api=MagicMock(), settings=settings, bid_learner=learner)
+
+
+def _bid(amount):
+    return SimpleNamespace(user_offer_price=amount)
+
+
+def test_reserve_covers_every_unfilled_slot(trader):
+    """11 players + 1 open bid = 12/15, so 3 slots at EUR 10.8m each."""
+    ctx = trader._build_pacing_context(squad_size=11, my_bids=[_bid(40_717_295)])
+    assert ctx is not None
+    assert ctx.reserve == 32_400_000
+
+
+def test_open_offers_are_carried_into_the_context(trader):
+    ctx = trader._build_pacing_context(squad_size=11, my_bids=[_bid(40_717_295)])
+    assert ctx.open_offers == 40_717_295
+
+
+def test_full_squad_falls_back_to_the_in_season_minimum(trader):
+    ctx = trader._build_pacing_context(squad_size=15, my_bids=[])
+    assert ctx.reserve == 21_600_000
+
+
+def test_disabled_setting_returns_no_context(trader, settings):
+    settings.pacing_enabled = False
+    assert trader._build_pacing_context(squad_size=11, my_bids=[]) is None
+
+
+def test_a_learner_failure_disables_pacing_rather_than_breaking_the_session(settings):
+    """Best-effort learning: a DB problem must never block the EP pipeline."""
+    learner = MagicMock()
+    learner.recent_buy_prices.side_effect = RuntimeError("db gone")
+    t = Trader(api=MagicMock(), settings=settings, bid_learner=learner)
+    assert t._build_pacing_context(squad_size=11, my_bids=[]) is None
+
+
+def test_no_learner_at_all_disables_pacing(settings):
+    t = Trader(api=MagicMock(), settings=settings, bid_learner=None)
+    assert t._build_pacing_context(squad_size=11, my_bids=[]) is None

--- a/tests/test_pacing_session.py
+++ b/tests/test_pacing_session.py
@@ -141,3 +141,132 @@ def test_the_trend_recompute_does_not_discard_pacing(trader):
     # not None (dropped) and not a freshly rebuilt one.
     assert len(recorded_pacing) == 2
     assert all(p is pacing_ctx for p in recorded_pacing)
+
+
+# ---------------------------------------------------------------------------
+# Task 7: emergency squad fill must be exempt from the pacing reserve.
+#
+# An empty lineup slot is -100 pts at kickoff -- that outranks the spending
+# discipline pacing exists to enforce. Emergency fill does not size its own
+# bids; it reads `rec.recommended_bid` off recommendations that
+# `get_ep_recommendations` already paced. The real risk is upstream: if
+# pacing legitimately zeroes a candidate's bid (its reserve rule consumed the
+# whole spendable budget -- confirmed live in a production dry-run where
+# EVERY plain-buy candidate paced to 0), the fill loop's
+# `if not rec.recommended_bid or rec.recommended_bid <= 0: continue` skips
+# it, and the slot is left empty. It fails hardest exactly when it matters
+# most: emergency fill only runs when the squad is short, which means a
+# large `slots_to_fill`, which means a large reserve, which means more
+# zeroed bids.
+# ---------------------------------------------------------------------------
+
+
+def _emergency_fill_ctx(recommended_bid: int):
+    """A short squad (11/15, one gap slot) plus one candidate to fill it."""
+    squad = [
+        SimpleNamespace(
+            id=f"s{i}",
+            first_name="X",
+            last_name=f"P{i}",
+            position="Defender",
+            price=1_000_000,
+            market_value=1_000_000,
+            team_id=f"club{i}",
+        )
+        for i in range(9)
+    ]
+    target = SimpleNamespace(
+        id="fill",
+        first_name="Fill",
+        last_name="Target",
+        position="Forward",
+        price=4_000_000,
+        market_value=4_000_000,
+        team_id="club99",
+    )
+    ctx = SimpleNamespace(
+        ep_result={
+            "buy_recs": [
+                SimpleNamespace(
+                    player=target,
+                    recommended_bid=recommended_bid,
+                    marginal_ep_gain=10.0,
+                    sell_plan=None,
+                )
+            ],
+            "trade_pairs": [],
+            "squad_scores": [],
+            "market_players": {"fill": target},
+        },
+        my_bid_amounts={},
+        my_bids=[],
+        squad=squad,
+        current_budget=50_000_000,
+        flip_budget=50_000_000,
+        executed_trade_count=0,
+        matchday_phase=SimpleNamespace(days_until_match=None),
+    )
+    return squad, target, ctx
+
+
+def _autotrader_with_mock_api(tmp_path, monkeypatch):
+    from rehoboam.auto_trader import AutoTrader
+
+    monkeypatch.setenv("KICKBASE_EMAIL", "test@example.com")
+    monkeypatch.setenv("KICKBASE_PASSWORD", "test")
+    monkeypatch.chdir(tmp_path)
+
+    api = MagicMock()
+    api.buy_player = MagicMock(return_value=None)
+    trader = AutoTrader(api=api, settings=Settings(), dry_run=False)
+    trader.learner = MagicMock()
+    trader.learner.was_recently_sold.return_value = False
+    return api, trader
+
+
+def test_emergency_fill_buys_when_bid_is_already_sized(tmp_path, monkeypatch):
+    """Baseline from the task brief: with a normally-sized (non-zero)
+    recommended_bid, the fill loop buys the candidate as sized.
+
+    This is NOT the exemption test -- it passes whether or not pacing ever
+    reaches this path, because the bid it is given is already usable. Kept
+    because it pins the ordinary (non-paced-to-zero) behaviour of the loop;
+    see `test_emergency_fill_is_not_starved_by_a_paced_zero_bid` below for
+    the test that actually exercises the pacing risk.
+    """
+    api, trader = _autotrader_with_mock_api(tmp_path, monkeypatch)
+    squad, target, ctx = _emergency_fill_ctx(recommended_bid=4_000_000)
+
+    results = trader._run_emergency_squad_fill(
+        league=SimpleNamespace(id="L"), ctx=ctx, fresh_squad=squad, slots_short=1
+    )
+    assert any(r.success for r in results), "the slot must be filled"
+    assert api.buy_player.call_count == 1
+    assert api.buy_player.call_args[0][2] == 4_000_000
+
+
+def test_emergency_fill_is_not_starved_by_a_paced_zero_bid(tmp_path, monkeypatch):
+    """The real risk: pacing can legitimately size recommended_bid to 0.
+
+    Drives `_run_emergency_squad_fill` with a candidate whose
+    `recommended_bid` is 0 -- exactly what pacing produces once its reserve
+    rule consumes the whole spendable budget -- and asserts the slot still
+    gets filled. Uses the real `ExecutionService` against a mock API and
+    asserts on `api.buy_player`, so this is a behavioural check, not a stub's
+    bookkeeping.
+    """
+    api, trader = _autotrader_with_mock_api(tmp_path, monkeypatch)
+    squad, target, ctx = _emergency_fill_ctx(recommended_bid=0)
+
+    results = trader._run_emergency_squad_fill(
+        league=SimpleNamespace(id="L"), ctx=ctx, fresh_squad=squad, slots_short=1
+    )
+    assert any(
+        r.success for r in results
+    ), "the slot must be filled despite the paced bid being zero"
+    assert api.buy_player.call_count == 1
+    # The fallback must actually place an offer -- at the asking price, not 0.
+    assert api.buy_player.call_args[0][2] == target.price
+    # The fallback must still respect the budget the emergency path is
+    # working with, not spend blindly past it.
+    assert api.buy_player.call_args[0][2] <= ctx.current_budget

--- a/tests/test_pacing_session.py
+++ b/tests/test_pacing_session.py
@@ -62,3 +62,81 @@ def test_a_learner_failure_disables_pacing_rather_than_breaking_the_session(sett
 def test_no_learner_at_all_disables_pacing(settings):
     t = Trader(api=MagicMock(), settings=settings, bid_learner=None)
     assert t._build_pacing_context(squad_size=11, my_bids=[]) is None
+
+
+def test_the_trend_recompute_does_not_discard_pacing(trader):
+    """Production only ever calls get_ep_recommendations_with_trends — both
+    live entry points (auto_trader.py, cli.py) go through it, never through
+    the plain get_ep_recommendations directly. The trends variant recomputes
+    every bid a second time (to fold in trend_change_pct) and overwrites
+    recommended_bid. If that recompute forgets to pass `pacing` through, the
+    correctly-paced bid from the first pass is silently thrown away and
+    pacing does nothing in production, even though the plain pipeline (and
+    every other test in this file) looks correct in isolation.
+    """
+    from rehoboam.bidding_strategy import BidRecommendation
+    from rehoboam.services.pacing import PacingContext
+
+    pacing_ctx = PacingContext(reserve=5_000_000, open_offers=0)
+
+    buy_rec = SimpleNamespace(
+        player=SimpleNamespace(id="p1", price=1_000_000, market_value=1_000_000, offer_count=0),
+        score=SimpleNamespace(
+            expected_points=50.0,
+            is_dgw=False,
+            data_quality=SimpleNamespace(games_played=10),
+        ),
+        marginal_ep_gain=10.0,
+        sell_plan=None,
+        metadata={},
+        recommended_bid=0,
+    )
+    pair = SimpleNamespace(
+        buy_player=SimpleNamespace(id="p2", price=2_000_000, market_value=2_000_000, offer_count=0),
+        sell_player=SimpleNamespace(market_value=1_000_000),
+        buy_score=SimpleNamespace(expected_points=40.0, is_dgw=False),
+        ep_gain=5.0,
+        metadata={},
+        recommended_bid=0,
+    )
+
+    # Short-circuit the heavy inner pipeline: get_ep_recommendations is
+    # exercised by test_reserve_covers_every_unfilled_slot etc. above.
+    # This test is only about what get_ep_recommendations_with_trends does
+    # with the result once pacing is already computed and attached.
+    trader.get_ep_recommendations = MagicMock(
+        return_value={
+            "buy_recs": [buy_rec],
+            "trade_pairs": [pair],
+            "budget": 10_000_000,
+            "pacing": pacing_ctx,
+        }
+    )
+    trader.trend_service = MagicMock()
+    trader.trend_service.get_trend.return_value = SimpleNamespace(
+        trend_7d_pct=0.0, trend_14d_pct=0.0, momentum="flat"
+    )
+
+    recorded_pacing = []
+
+    def fake_calculate_ep_bid(*args, **kwargs):
+        recorded_pacing.append(kwargs.get("pacing"))
+        return BidRecommendation(
+            base_price=1_000_000,
+            recommended_bid=1_000_000,
+            overbid_amount=0,
+            overbid_pct=0.0,
+            reasoning="test",
+            budget_ceiling=10_000_000,
+        )
+
+    trader.bidding.calculate_ep_bid = MagicMock(side_effect=fake_calculate_ep_bid)
+
+    league = SimpleNamespace(id="league1")
+    trader.get_ep_recommendations_with_trends(league)
+
+    # One call for the buy rec, one for the trade pair — both must carry
+    # the SAME pacing context that get_ep_recommendations already built,
+    # not None (dropped) and not a freshly rebuilt one.
+    assert len(recorded_pacing) == 2
+    assert all(p is pacing_ctx for p in recorded_pacing)

--- a/tests/test_pacing_session.py
+++ b/tests/test_pacing_session.py
@@ -30,10 +30,11 @@ def _bid(amount):
 
 
 def test_reserve_covers_every_unfilled_slot(trader):
-    """11 players + 1 open bid = 12/15, so 3 slots at EUR 10.8m each."""
+    """11 players + 1 open bid = 12/15, so 3 slots remain. Reserve is for
+    2 moves after this buy fills one slot, at EUR 10.8m each."""
     ctx = trader._build_pacing_context(squad_size=11, my_bids=[_bid(40_717_295)])
     assert ctx is not None
-    assert ctx.reserve == 32_400_000
+    assert ctx.reserve == 21_600_000
 
 
 def test_open_offers_are_carried_into_the_context(trader):

--- a/tests/test_replay/test_bid_competition.py
+++ b/tests/test_replay/test_bid_competition.py
@@ -107,7 +107,7 @@ def test_the_ep_bid_fn_bids_more_for_a_must_have_than_for_a_marginal_gain():
     bid_fn = make_ep_bid_fn(
         mv_fn=lambda pid, at: 10_000_000,
         score_fn=lambda pid, at: 100.0,
-        median_move=10_000_000,
+        median_move_fn=lambda at: 10_000_000,
         in_season_min_moves=2,
     )
 
@@ -126,7 +126,7 @@ def test_the_ep_bid_fn_never_bids_beyond_the_budget():
     bid_fn = make_ep_bid_fn(
         mv_fn=lambda pid, at: 10_000_000,
         score_fn=lambda pid, at: 100.0,
-        median_move=10_000_000,
+        median_move_fn=lambda at: 10_000_000,
         in_season_min_moves=2,
     )
 

--- a/tests/test_replay/test_bid_competition.py
+++ b/tests/test_replay/test_bid_competition.py
@@ -51,13 +51,13 @@ def _run(bid_fn):
 
 def test_a_bid_below_the_real_price_loses_the_auction():
     """The rival paid 10,000,000. Bidding under that must not win."""
-    _result, state = _run(lambda pid, price, at, gain, budget: 9_999_999)
+    _result, state = _run(lambda pid, price, at, gain, budget, squad_size: 9_999_999)
 
     assert "target" not in state.squad
 
 
 def test_a_bid_above_the_real_price_wins():
-    _result, state = _run(lambda pid, price, at, gain, budget: 11_000_000)
+    _result, state = _run(lambda pid, price, at, gain, budget, squad_size: 11_000_000)
 
     assert "target" in state.squad
 
@@ -65,7 +65,7 @@ def test_a_bid_above_the_real_price_wins():
 def test_the_winner_pays_its_own_bid_not_the_rivals_price():
     """Outbidding costs more than the rival paid. Charging the rival's price
     would give us the upside of competition with none of its cost."""
-    _result, state = _run(lambda pid, price, at, gain, budget: 11_000_000)
+    _result, state = _run(lambda pid, price, at, gain, budget, squad_size: 11_000_000)
 
     assert state.budget == 100_000_000 - 11_000_000
 
@@ -84,8 +84,8 @@ def test_bid_fn_receives_the_marginal_gain_and_the_current_budget():
     hook can only express a flat willingness to pay, which is not the bot."""
     seen: dict = {}
 
-    def bid(pid, price, at, gain, budget):
-        seen.update(pid=pid, price=price, gain=gain, budget=budget)
+    def bid(pid, price, at, gain, budget, squad_size):
+        seen.update(pid=pid, price=price, gain=gain, budget=budget, squad_size=squad_size)
         return 0  # lose, so the run is unaffected
 
     _run(bid)
@@ -94,6 +94,7 @@ def test_bid_fn_receives_the_marginal_gain_and_the_current_budget():
     assert seen["price"] == 10_000_000
     assert seen["gain"] > 0.0, "target scores 200 against a squad of 10s"
     assert seen["budget"] == 100_000_000
+    assert seen["squad_size"] == 11
 
 
 def test_the_ep_bid_fn_bids_more_for_a_must_have_than_for_a_marginal_gain():
@@ -106,10 +107,15 @@ def test_the_ep_bid_fn_bids_more_for_a_must_have_than_for_a_marginal_gain():
     bid_fn = make_ep_bid_fn(
         mv_fn=lambda pid, at: 10_000_000,
         score_fn=lambda pid, at: 100.0,
+        median_move=10_000_000,
+        in_season_min_moves=2,
     )
 
-    must_have = bid_fn("p", 10_000_000, 0.0, 80.0, 50_000_000)
-    marginal = bid_fn("p", 10_000_000, 0.0, 5.0, 50_000_000)
+    # squad_size=14 -> 1 slot left -> capital_reserve's last-slot case (0
+    # reserve): this test is about tiers, not pacing, so the reserve must not
+    # confound it.
+    must_have = bid_fn("p", 10_000_000, 0.0, 80.0, 50_000_000, 14)
+    marginal = bid_fn("p", 10_000_000, 0.0, 5.0, 50_000_000, 14)
 
     assert must_have > marginal
 
@@ -120,6 +126,10 @@ def test_the_ep_bid_fn_never_bids_beyond_the_budget():
     bid_fn = make_ep_bid_fn(
         mv_fn=lambda pid, at: 10_000_000,
         score_fn=lambda pid, at: 100.0,
+        median_move=10_000_000,
+        in_season_min_moves=2,
     )
 
-    assert bid_fn("p", 10_000_000, 0.0, 80.0, 3_000_000) <= 3_000_000
+    # squad_size=14 -> 0 reserve (see above) -> this exercises the budget cap
+    # alone, not the pacing cap.
+    assert bid_fn("p", 10_000_000, 0.0, 80.0, 3_000_000, 14) <= 3_000_000

--- a/tests/test_replay/test_flip_buy_pass.py
+++ b/tests/test_replay/test_flip_buy_pass.py
@@ -86,7 +86,11 @@ def _run(
         # `with_competition` True inside `_flip_buys`. The EP loop never calls
         # it for real in these tests: the marginal-gain floor above always
         # sends "new" through the `continue` before bid_fn would be reached.
-        bid_fn=(lambda player_id, price, at, gain, budget: price + 1) if with_competition else None,
+        bid_fn=(
+            (lambda player_id, price, at, gain, budget, squad_size: price + 1)
+            if with_competition
+            else None
+        ),
     )
     return result, state
 


### PR DESCRIPTION
## Description

Adds a **capital reserve** to the bidding path: a rule constraining what a buy
*leaves behind*, rather than how large it is.

The motivating failure, found in a competition-modelled replay: the bot spent
EUR 71m on one player, then made five buys all season and finished with
EUR 500,000 — with every declined candidate rated `must_have` by its own
tiering. `max_bid_fraction` answers "what fraction of today's budget does this
signing justify?", a single-decision question. Nothing asked the sequential
one: *what does this signing leave the bot able to do for the next thirty
matchdays?*

Measured against `manager_transfers`, the league's champions each made ONE
signing of EUR 60-65m **and** roughly 25 further purchases. So the rule
constrains the leftover, never the ticket size — a hard per-transaction cap
near their EUR 11m mean (the ticket's first suggestion) would have banned both
of their biggest signings, that mean being an artefact of a heavily skewed
distribution.

**Mechanism.** `services/pacing.py` is pure and exhaustively testable:

- `median_move_price(prices, floor_eur)` — what one further purchase costs in
  this league, read from `manager_transfers` over a rolling window. Median, not
  mean (skewed population); on an even count it takes the lower middle value so
  the result is always a price someone actually paid.
- `capital_reserve(slots_to_fill, in_season_min_moves, median_move)` — euros
  that must survive this buy. Scales with *unfilled slots* so it unwinds as the
  squad completes; `in_season_min_moves` is the floor at 15/15 so a full squad
  can still replace a player. The reserve funds moves remaining **after** this
  buy fills one slot, so at 3 slots it reserves 2 moves, and at 1 slot it
  reserves 0 — completing the squad outranks holding replacement money.
- `PacingContext.max_bid(budget_ceiling, current_budget)` — applied in
  `SmartBidding.calculate_ep_bid`. Because `budget_ceiling` already includes
  sell-plan recovery, trade pairs are paced on **net** cost with no special
  case.

Built once per session in `trader.py` and reused, so `SmartBidding` stays
ignorant of the squad, the open offers and the learning DB.

All three knobs are `Settings` fields, re-tunable from `.env` without a deploy.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code quality improvement (refactoring, formatting, etc.)

## The measured sweep

All runs `uv run rehoboam replay-season --with-competition`. Baseline is the
genuinely-unpaced run (`--no-pacing`), **not** the 26,391 figure in the ticket
brief — that predates REH-98/99/100 and produced a false alarm when used as
the bar. Actual season total, for reference only: 26,172.

| configuration              | points | delta vs no-pacing | buys | sells |   finish |
| -------------------------- | -----: | -----------------: | ---: | ----: | -------: |
| `--no-pacing`              | 24,141 |                  — |    3 |     0 | 11 of 14 |
| `--pacing-window-days 7`   | 27,957 |             +3,816 |    8 |     5 |  7 of 14 |
| `--pacing-window-days 14`  | 27,561 |             +3,420 |    6 |     3 |  7 of 14 |
| `--pacing-window-days 30`  | 25,000 |               +859 |    3 |     0 | 10 of 14 |
| `--pacing-window-days 60`  | 25,000 |               +859 |    3 |     0 | 10 of 14 |
| **default (90)**           | 25,000 |           **+859** |    3 |     0 | 10 of 14 |
| `--pacing-window-days 180` | 23,676 |               -465 |    3 |     0 | 11 of 14 |

`pacing_in_season_min_moves` is not swept: it governs the reserve floor only
once `slots_to_fill <= 0`, and this replay never reaches 15/15 (peak 8 buys),
so the knob is inert in this instrument by construction.

## Did buy count rise? No.

**The design's own acceptance criterion is not met at the shipped default.**
Buy count is 3 with pacing on and 3 with pacing off, identically. This is
stated here rather than deferred to a follow-up, per the plan.

Root cause, diagnosed by querying `manager_transfers` directly rather than
inferred from the replay: at 14 empty slots (the squad's early-season state)
the reserve is EUR 65-87m against a replay starting budget of ~EUR 80m. The
constraint is near-unsatisfiable at season start, so the rule degenerates to
"buy nothing beyond a small handful of early low-slot-count signings".
**The reserve is calibrated for topping up a squad that already has most of
its slots filled, not for building one from an under-strength start.**

Do **not** read the 7/14-day wins as a better setting. Those windows are not
more accurate price estimates — a 76-row sample is noisier than a 1,154-row
one, and the 7-day median is genuinely lower, not floored. `pacing_window_days`
is behaving as a proxy knob for reserve size, and a window chosen to sit near
that edge is nearly as fragile as the hardcoded euro figure the design
explicitly rejects. Per REH-71's caution, treat any delta below 6,162 points
with suspicion unless it replicates; none of these clear that bar.

**Recommended follow-up ticket** (targets the mechanism instead of tuning
around it): bound the reserve by what is actually available —
`reserve = min(moves_wanted * median_move, budget * max_reserve_fraction)`.

## Live smoke test — `uv run rehoboam auto --dry-run`

Re-run on the merge candidate (`6b17311`), because the review fixes in
`ebfe5bb` changed four production files after the first smoke run:

```
pacing session median_move=10800000 slots_to_fill=3 reserve=21600000 open_offers=0 n_prices=50
session-context phase=locked days_to_match=1 squad=12/15 budget=21650227 team_value=145278078 pending_bids=0
```

The EUR 40.7m Raum offer has since resolved, so this exercises the
`open_offers=0` path the earlier run could not. Reserve is `2 x EUR 10.8m =
EUR 21.6m` against a EUR 21,650,227 budget → **EUR 50,227 of headroom**. All
22 `ep-bid paced` lines reconcile exactly against `max_bid`:

| candidate                  |    ceiling | sell-plan recovery | paced cap |
| -------------------------- | ---------: | -----------------: | --------: |
| plain buy (no sell plan)   | 21,650,227 |                  0 |    50,227 |
| with a mid sell plan       | 23,808,825 |         +2,158,598 | 2,208,825 |
| with the largest sell plan | 26,151,720 |         +4,501,493 | 4,551,720 |

Every line reports the same `reserve`/`open_offers`, confirming the context is
built once per session and reused. Consistent with the sweep, plain buys are
capped far below any real ask — the buy-side lockout persists under the fixes.
Session was `phase=locked` (1 day to kickoff) and traded nothing regardless, so
this confirms wiring and arithmetic, not trading outcomes.

## Pre-merge review fixes (`ebfe5bb`)

A whole-branch review found three defects the sweep was structurally blind to
— all "the bot stops trading when it should not"; none could overspend:

1. **Trade pairs frozen at 15/15, including budget-positive ones.** `max_bid`
   demanded "budget after this trade >= reserve"; once the budget fell below
   the reserve, a pair selling a EUR 12m player to buy an EUR 8.86m one —
   netting **+EUR 3.14m** — was refused. At 15/15 the budget is small by
   construction and plain buys are already blocked by `available_slots <= 0`,
   so pairs are the only improvement mechanism left. **The feature spent a
   season driving the bot toward the one state nothing measured.** Fixed by
   clamping the reserve at pre-trade spendable budget: the rule becomes "refuse
   only if this leaves things worse than now".
2. **Profit flips were never paced**, despite the design's own table saying
   they were — they are sized by `ProfitTrader` and never reach
   `calculate_ep_bid`. Since `enable_flip_buys` defaults on, this would have
   run in production: a flip could consume the exact capital the reserve was
   protecting, in the same session pacing refused a squad-improvement buy for
   lack of it.
3. **An under-strength squad froze buying** exactly when empty slots cost -100,
   because the reserve scales with empty slots. The emergency-fill exemption
   did not cover it (that path runs only in the locked phase), so 2-5 days
   before kickoff such a squad got no autonomous buy *and no proposal*.

Also: `_build_pacing_context`'s call site now fails open per its own docstring
(a malformed bid payload disables pacing instead of aborting the EP pipeline),
and the three pacing `Settings` fields gained `ge=0` bounds.

## Testing

- [x] I have run the test suite locally (`pytest`)
- [x] I have added new tests for my changes
- [x] All tests pass
- [x] I have tested this manually

```
$ uv run pytest -q
1284 passed, 1 skipped in 5.55s
```

Six new test modules: `test_pacing`, `test_pacing_bidding`, `test_pacing_prices`,
`test_pacing_session`, `test_pacing_replay`, `test_pacing_flips`, plus
`test_pacing_emergency_and_fail_open`. Manual verification is the live dry-run
above.

## Code Quality

- [x] My code follows the project's style guidelines (Black, Ruff)
- [x] I have run `pre-commit` and all checks pass
- [x] I have added docstrings to new functions/classes
- [x] I have updated relevant documentation

Hooks were run on this branch's changed files rather than `--all-files`: the
repo is not black-clean, so a whole-repo pass would bury this diff in unrelated
churn. Black, Ruff, Bandit, pyupgrade and mdformat all pass on the 22 changed
files. `mypy rehoboam/` reports 72 errors on both `main` and this branch — no
new type errors — and the new `services/pacing.py` is clean.

## Related Issues

Related to REH-85 — https://linear.app/jovily/issue/REH-85

## Additional Notes

**Read the +859 as an allocation result from one regime, not as evidence the
feature is safe across the season.** The replay builds a squad from near-empty
and never reaches 15/15; the live bot is at 12/15. The three review defects
above lived entirely outside what the sweep could see, and re-measuring after
fixing them leaves the sweep numbers unchanged — which is the point.

The sell side is deliberately untouched by this ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
