### PR TITLE
fix(learning): recover cost basis from squad membership, not pending bids (REH-103)

### DIFF
--- a/rehoboam/auto_trader.py
+++ b/rehoboam/auto_trader.py
@@ -1580,6 +1580,21 @@ class AutoTrader:
                 squad_ids={p.id for p in squad},
                 active_bid_ids={p.id for p in bids},
             )
+
+            # REH-103: resolve_auctions can only record a purchase it can match
+            # to a pending bid, so a player who joined the squad any other way
+            # is tracked nowhere — and with no cost basis, `enable_profit_sells`
+            # can never evaluate them. Raum (EUR 40.7m) arrived that way and
+            # left 10 of 12 squad players unsellable-on-profit, silently.
+            # Reconciling against squad membership closes the gap regardless of
+            # how the player arrived. Never raises; reports what it could not
+            # recover rather than inventing a price.
+            try:
+                my_id = getattr(getattr(self.api, "user", None), "id", None)
+                if my_id:
+                    self.tracker.reconcile_squad_cost_basis(squad, manager_id=str(my_id))
+            except Exception:  # pragma: no cover - defensive
+                logger.exception("cost-basis reconciliation failed (non-fatal)")
             # Execute any deferred sell plans from bids we won (buy-first-sell-after).
             if deferred_sell_ids:
                 console.print(

--- a/rehoboam/bid_learner.py
+++ b/rehoboam/bid_learner.py
@@ -1313,6 +1313,60 @@ class BidLearner:
             conn.commit()
         return len(rows)
 
+    def get_last_purchase(self, manager_id: str, player_id: str) -> dict[str, Any] | None:
+        """Our most recent purchase of a player, if we still hold that purchase.
+
+        REH-103. `manager_transfers` mirrors the league activity feed, so it
+        records purchases the bidding path never saw — which is the only reason
+        Raum's EUR 40.7m cost basis is recoverable at all.
+
+        A buy followed by a SELL is deliberately reported as no basis rather
+        than as the old price. Da Costa was bought 2026-05-03 and sold
+        2026-05-11; the player of that name in the squad today is a different,
+        untracked holding, and attaching the May figure to it would drive
+        profit-and-loss decisions off a basis that belongs to a position we no
+        longer own. Returns None in that case so the caller reports a gap
+        instead of acting on a stale number.
+
+        `transfer_dt` is stored as an ISO-8601 string, so the ordering and the
+        after-the-sale comparison are both plain lexicographic.
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            buy = conn.execute(
+                """
+                SELECT transfer_price, transfer_dt
+                FROM manager_transfers
+                WHERE manager_id = ? AND player_id = ? AND transfer_type = 1
+                  AND transfer_price IS NOT NULL
+                ORDER BY transfer_dt DESC
+                LIMIT 1
+                """,
+                (str(manager_id), str(player_id)),
+            ).fetchone()
+            if buy is None:
+                return None
+
+            sold_since = conn.execute(
+                """
+                SELECT 1
+                FROM manager_transfers
+                WHERE manager_id = ? AND player_id = ? AND transfer_type = 2
+                  AND transfer_dt > ?
+                LIMIT 1
+                """,
+                (str(manager_id), str(player_id), buy["transfer_dt"]),
+            ).fetchone()
+
+        if sold_since is not None:
+            return None
+        return {"price": int(buy["transfer_price"]), "transfer_dt": buy["transfer_dt"]}
+
+    def get_last_purchase_price(self, manager_id: str, player_id: str) -> int | None:
+        """Price of the purchase we still hold, or None if there is no basis."""
+        purchase = self.get_last_purchase(manager_id, player_id)
+        return purchase["price"] if purchase else None
+
     def has_matchday_outcome(self, player_id: str, matchday_date: str) -> bool:
         """True if ``matchday_outcomes`` already has a row for this player+date."""
         with sqlite3.connect(self.db_path) as conn:

--- a/rehoboam/learning/tracker.py
+++ b/rehoboam/learning/tracker.py
@@ -22,6 +22,7 @@ into the BidLearner's history tables.
 
 import logging
 import time
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 
@@ -29,6 +30,29 @@ from ..bid_learner import AuctionOutcome, BidLearner, FlipOutcome
 from .migration import migrate_json_state_if_needed
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class CostBasisReconciliation:
+    """What one `reconcile_squad_cost_basis` pass managed to close.
+
+    `still_missing` is the point of the return value, not `recovered`: a
+    squad player with no cost basis is one `enable_profit_sells` can never
+    act on, and until REH-103 nothing surfaced that.
+    """
+
+    recovered: int = 0
+    still_missing: list[str] = field(default_factory=list)
+
+
+def _iso_to_epoch(value: str) -> float:
+    """Parse `manager_transfers.transfer_dt` ("2026-08-26T15:28:32Z") to epoch.
+
+    `fromisoformat` only learned to accept a trailing "Z" in 3.11 and CI still
+    runs 3.10, so the offset is spelled out.
+    """
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+
 
 _LOG_DIR = Path("logs")
 _PENDING_BIDS_JSON = _LOG_DIR / "pending_bids.json"
@@ -168,6 +192,72 @@ class LearningTracker:
             )
         except Exception as e:
             logger.warning("Failed to track purchase: %s", e)
+
+    def reconcile_squad_cost_basis(self, squad, *, manager_id) -> CostBasisReconciliation:
+        """Give every squad player a cost basis, however it got into the squad.
+
+        REH-103. `resolve_auctions` only records a purchase it can match to a
+        `pending_bids` row, so a player who arrives any other way is tracked
+        nowhere — and a player with no cost basis is invisible to
+        `enable_profit_sells` forever, silently. Raum (EUR 40,717,295, the
+        season's largest buy) arrived that way; on 2026-08-27 only 2 of 12
+        squad players had a basis.
+
+        This runs off squad membership instead, so it closes the gap without
+        needing to know how the player arrived. The price comes from
+        `manager_transfers`, the activity-feed mirror, which did record Raum.
+
+        A basis that cannot be recovered is reported, never invented. Writing a
+        placeholder price would feed straight into profit-sell arithmetic — a
+        zero divides, and any other figure quietly authorises a real trade
+        against a number nobody measured. An absent row keeps the player
+        untouched, which is the safe failure.
+
+        An existing row always wins: the bidding path knows the actual bid,
+        while this only knows the settled transfer price.
+        """
+        recovered = 0
+        still_missing: list[str] = []
+        try:
+            for player in squad:
+                player_id = str(player.id)
+                if self.bid_learner.get_tracked_purchase(player_id) is not None:
+                    continue
+
+                purchase = self.bid_learner.get_last_purchase(manager_id, player_id)
+                if purchase is None:
+                    still_missing.append(player_id)
+                    continue
+
+                name = f"{player.first_name} {player.last_name}".strip()
+                self.bid_learner.add_tracked_purchase(
+                    player_id=player_id,
+                    player_name=name,
+                    buy_price=purchase["price"],
+                    buy_date=_iso_to_epoch(purchase["transfer_dt"]),
+                    source="transfer_feed",
+                )
+                recovered += 1
+                logger.info(
+                    "cost-basis recovered player=%s (%s) buy_price=%d from=%s",
+                    player_id,
+                    name,
+                    purchase["price"],
+                    purchase["transfer_dt"],
+                )
+        except Exception as e:
+            logger.warning("Cost-basis reconciliation failed: %s", e, exc_info=True)
+            return CostBasisReconciliation(recovered=recovered, still_missing=still_missing)
+
+        if still_missing:
+            logger.warning(
+                "cost-basis gap: %d of %d squad players have no basis (%s) — "
+                "profit-taking and loss-cutting cannot evaluate them",
+                len(still_missing),
+                len(squad),
+                ", ".join(still_missing),
+            )
+        return CostBasisReconciliation(recovered=recovered, still_missing=still_missing)
 
     # ------------------------------------------------------------------
     # Flip outcome (bought + sold → profit recorded)

--- a/tests/test_cost_basis_reconciliation.py
+++ b/tests/test_cost_basis_reconciliation.py
@@ -1,0 +1,292 @@
+"""Tests for REH-103: a won purchase must never be invisible to the learning loop.
+
+Raum (EUR 40,717,295, 2026-08-26) — the season's largest acquisition — entered
+the squad with no `pending_bids` row, so `resolve_auctions` never saw him and
+neither `auction_outcomes` nor `tracked_purchases` recorded anything. The
+consequence is not cosmetic: `enable_profit_sells` evaluates a squad player
+against its cost basis, so a missing row silently disables profit-taking and
+loss-cutting for that player forever. On 2026-08-27 only 2 of 12 squad players
+had a basis.
+
+The fix reconciles squad membership against `tracked_purchases` every session,
+recovering the real price from `manager_transfers` (the activity-feed mirror,
+which did record Raum) rather than depending on the bidding path having
+remembered.
+"""
+
+import sqlite3
+
+import pytest
+
+from rehoboam.bid_learner import BidLearner
+from rehoboam.learning.tracker import LearningTracker
+
+LEAGUE = "1933872"
+US = "3616202"
+THEM = "1907519"
+
+BUY = 1
+SELL = 2
+
+
+@pytest.fixture
+def learner(tmp_path):
+    return BidLearner(db_path=tmp_path / "bid_learning.db")
+
+
+@pytest.fixture
+def tracker(learner):
+    return LearningTracker(learner)
+
+
+def _transfer(player_id, name, dt, typ, price, manager_id=US):
+    return {
+        "league_id": LEAGUE,
+        "manager_id": manager_id,
+        "transfer_dt": dt,
+        "player_id": player_id,
+        "player_name": name,
+        "transfer_type": typ,
+        "transfer_price": price,
+    }
+
+
+class FakePlayer:
+    """Minimal stand-in for api.Player — only what reconciliation reads."""
+
+    def __init__(self, player_id, first_name, last_name):
+        self.id = player_id
+        self.first_name = first_name
+        self.last_name = last_name
+
+
+class TestLastPurchasePrice:
+    """`BidLearner.get_last_purchase_price` — recover a real cost basis."""
+
+    def test_returns_price_of_the_most_recent_buy(self, learner):
+        learner.record_manager_transfers(
+            [
+                _transfer("p1", "Raum", "2026-08-26T15:28:32Z", BUY, 40_717_295),
+            ]
+        )
+
+        assert learner.get_last_purchase_price(US, "p1") == 40_717_295
+
+    def test_a_sale_after_the_buy_invalidates_that_basis(self, learner):
+        """The Da Costa case — the reason 'most recent buy' is not enough.
+
+        Bought 2026-05-03 for EUR 11,908,528 and SOLD 2026-05-11. The player
+        now in the squad is an untracked re-acquisition at an unknown price;
+        reporting the May figure would attach a stale basis to a different
+        holding and drive profit/loss decisions off it.
+        """
+        learner.record_manager_transfers(
+            [
+                _transfer("p2", "Da Costa", "2026-05-03T06:51:08Z", BUY, 11_908_528),
+                _transfer("p2", "Da Costa", "2026-05-11T20:00:01Z", SELL, 11_099_669),
+            ]
+        )
+
+        assert learner.get_last_purchase_price(US, "p2") is None
+
+    def test_a_rebuy_after_the_sale_is_the_live_basis(self, learner):
+        learner.record_manager_transfers(
+            [
+                _transfer("p2", "Da Costa", "2026-05-03T06:51:08Z", BUY, 11_908_528),
+                _transfer("p2", "Da Costa", "2026-05-11T20:00:01Z", SELL, 11_099_669),
+                _transfer("p2", "Da Costa", "2026-08-01T09:00:00Z", BUY, 9_308_429),
+            ]
+        )
+
+        assert learner.get_last_purchase_price(US, "p2") == 9_308_429
+
+    def test_another_managers_purchase_is_not_ours(self, learner):
+        learner.record_manager_transfers(
+            [
+                _transfer("p3", "Kimmich", "2026-08-25T02:16:46Z", BUY, 65_000_065, THEM),
+            ]
+        )
+
+        assert learner.get_last_purchase_price(US, "p3") is None
+
+    def test_no_transfer_history_yields_no_basis(self, learner):
+        assert learner.get_last_purchase_price(US, "unknown-player") is None
+
+
+class TestReconcileSquadCostBasis:
+    """`LearningTracker.reconcile_squad_cost_basis` — close the recording gap."""
+
+    def test_records_a_basis_for_an_untracked_squad_player(self, learner, tracker):
+        """Raum, exactly: in the squad, in the transfer feed, tracked nowhere."""
+        learner.record_manager_transfers(
+            [_transfer("p1", "Raum", "2026-08-26T15:28:32Z", BUY, 40_717_295)]
+        )
+        squad = [FakePlayer("p1", "David", "Raum")]
+
+        tracker.reconcile_squad_cost_basis(squad, manager_id=US)
+
+        tracked = learner.get_tracked_purchase("p1")
+        assert tracked is not None
+        assert tracked["buy_price"] == 40_717_295
+
+    def test_recovered_rows_are_marked_as_backfilled(self, learner, tracker):
+        """`source` must distinguish a recovered basis from one the bidder wrote."""
+        learner.record_manager_transfers(
+            [_transfer("p1", "Raum", "2026-08-26T15:28:32Z", BUY, 40_717_295)]
+        )
+
+        tracker.reconcile_squad_cost_basis([FakePlayer("p1", "David", "Raum")], manager_id=US)
+
+        assert learner.get_tracked_purchase("p1")["source"] == "transfer_feed"
+
+    def test_an_existing_basis_is_never_overwritten(self, learner, tracker):
+        """The bidding path's own record is authoritative — it knows the bid."""
+        learner.add_tracked_purchase(
+            player_id="p1",
+            player_name="Raum",
+            buy_price=38_000_000,
+            buy_date=1_000.0,
+            source="real",
+        )
+        learner.record_manager_transfers(
+            [_transfer("p1", "Raum", "2026-08-26T15:28:32Z", BUY, 40_717_295)]
+        )
+
+        tracker.reconcile_squad_cost_basis([FakePlayer("p1", "David", "Raum")], manager_id=US)
+
+        tracked = learner.get_tracked_purchase("p1")
+        assert tracked["buy_price"] == 38_000_000
+        assert tracked["source"] == "real"
+
+    def test_unrecoverable_basis_writes_no_row(self, learner, tracker):
+        """No fabricated price.
+
+        A sentinel price would feed straight into profit-sell arithmetic:
+        zero divides, and any invented figure silently authorises a real trade.
+        Absence is reported instead — see the return value.
+        """
+        squad = [FakePlayer("p9", "Kevin", "Stark")]
+
+        tracker.reconcile_squad_cost_basis(squad, manager_id=US)
+
+        assert learner.get_tracked_purchase("p9") is None
+
+    def test_reports_squad_players_left_without_a_basis(self, learner, tracker):
+        """The invariant: the caller must be able to see the remaining gap."""
+        learner.record_manager_transfers(
+            [_transfer("p1", "Raum", "2026-08-26T15:28:32Z", BUY, 40_717_295)]
+        )
+        squad = [
+            FakePlayer("p1", "David", "Raum"),
+            FakePlayer("p9", "Kevin", "Stark"),
+            FakePlayer("p8", "Jordan", "Chandler"),
+        ]
+
+        result = tracker.reconcile_squad_cost_basis(squad, manager_id=US)
+
+        assert result.recovered == 1
+        assert set(result.still_missing) == {"p9", "p8"}
+
+    def test_a_fully_tracked_squad_reports_no_gap(self, learner, tracker):
+        learner.add_tracked_purchase(
+            player_id="p1",
+            player_name="Raum",
+            buy_price=40_717_295,
+            buy_date=1_000.0,
+            source="real",
+        )
+
+        result = tracker.reconcile_squad_cost_basis(
+            [FakePlayer("p1", "David", "Raum")], manager_id=US
+        )
+
+        assert result.recovered == 0
+        assert result.still_missing == []
+
+    def test_buy_date_comes_from_the_transfer_not_from_now(self, learner, tracker):
+        """Hold-period maths (flip_outcomes.hold_days) reads this date."""
+        learner.record_manager_transfers(
+            [_transfer("p1", "Raum", "2026-08-26T15:28:32Z", BUY, 40_717_295)]
+        )
+
+        tracker.reconcile_squad_cost_basis([FakePlayer("p1", "David", "Raum")], manager_id=US)
+
+        # 2026-08-26T15:28:32Z
+        assert learner.get_tracked_purchase("p1")["buy_date"] == pytest.approx(
+            1_787_758_112.0, abs=1.0
+        )
+
+    def test_reconciliation_is_scoped_to_the_squad(self, learner, tracker):
+        """A player we once owned but no longer hold must not be re-tracked."""
+        learner.record_manager_transfers(
+            [_transfer("gone", "Sabitzer", "2026-08-01T09:00:00Z", BUY, 7_951_576)]
+        )
+
+        tracker.reconcile_squad_cost_basis([], manager_id=US)
+
+        assert learner.get_tracked_purchase("gone") is None
+
+    def test_a_learning_failure_never_raises_into_the_session(self, learner, tracker):
+        """Every tracker method is best-effort; a broken DB must not stop trading."""
+        with sqlite3.connect(learner.db_path) as conn:
+            conn.execute("DROP TABLE manager_transfers")
+            conn.commit()
+
+        result = tracker.reconcile_squad_cost_basis(
+            [FakePlayer("p1", "David", "Raum")], manager_id=US
+        )
+
+        assert result.recovered == 0
+
+
+class TestTheSessionActuallyCallsIt:
+    """REH-103 is instrumentation. Shipping it unwired would repeat the bug.
+
+    `auction_outcomes.winning_bid` sat NULL on every production row for a
+    season because a writer existed and nothing called it (REH-86). The same
+    trap applies here, so the call site is proved rather than assumed.
+    """
+
+    def test_step_one_recovers_cost_basis_for_the_live_squad(self, tmp_path, monkeypatch):
+        from types import SimpleNamespace
+        from unittest.mock import patch
+
+        from rehoboam.auto_trader import AutoTrader
+        from rehoboam.config import Settings
+
+        monkeypatch.setenv("KICKBASE_EMAIL", "test@example.com")
+        monkeypatch.setenv("KICKBASE_PASSWORD", "test")
+        monkeypatch.chdir(tmp_path)
+
+        class _Api:
+            user = SimpleNamespace(id=US)
+
+            def get_squad(self, league):
+                return [FakePlayer("p1", "David", "Raum")]
+
+            def get_my_bids(self, league):
+                return []
+
+            def get_team_info(self, league):
+                return {"budget": 21_650_227, "teamValue": 145_278_078}
+
+        trader = AutoTrader(api=_Api(), settings=Settings(), dry_run=True)
+        trader.learner = BidLearner(db_path=tmp_path / "bid_learning.db")
+        trader.tracker = LearningTracker(trader.learner)
+        trader.learner.record_manager_transfers(
+            [_transfer("p1", "Raum", "2026-08-26T15:28:32Z", BUY, 40_717_295)]
+        )
+
+        # Stop the session immediately after step 1 — this test is about the
+        # call site, not the rest of the pipeline.
+        with (
+            patch.object(
+                AutoTrader, "_build_session_context", side_effect=RuntimeError("stop after step 1")
+            ),
+            patch.object(AutoTrader, "_set_optimal_lineup", return_value=[]),
+        ):
+            trader.run_full_session(SimpleNamespace(id="L1", name="L1"))
+
+        tracked = trader.learner.get_tracked_purchase("p1")
+        assert tracked is not None, "step 1 never reconciled cost basis"
+        assert tracked["buy_price"] == 40_717_295


### PR DESCRIPTION
## Description

`resolve_auctions` can only record a purchase it can match to a `pending_bids`
row, so a player who joins the squad any other way is tracked nowhere.

**Raum — EUR 40,717,295, 2026-08-26, the season's largest acquisition —
appeared in no learning table at all:**

| table | rows |
| -- | -- |
| `auction_outcomes` | 0 |
| `tracked_purchases` | 0 |
| `pending_bids` | 0 |
| `manager_transfers` (activity-feed mirror) | 1 |

That is not cosmetic. `enable_profit_sells` evaluates a squad player against
its cost basis, so a missing row silently disables profit-taking and
loss-cutting for that player permanently. On prod state at 2026-08-27, **10 of
12 squad players had no basis** — 83% of the squad was unsellable-on-profit
while the setting read `True`.

## Approach

Reconcile against **squad membership** instead of pending bids, so the gap
closes regardless of how the player arrived.

- `BidLearner.get_last_purchase` / `get_last_purchase_price` read the price
  from `manager_transfers`, which did record Raum.
- **A sale after the buy invalidates the basis.** Da Costa was bought
  2026-05-03 for EUR 11,908,528 and sold 2026-05-11. The player of that name
  in the squad today is a different, untracked holding; attaching the May
  figure would drive profit-and-loss decisions off a position we no longer
  own. Verified live — he is correctly left without a basis.
- `LearningTracker.reconcile_squad_cost_basis` marks recovered rows
  `source='transfer_feed'`, never overwrites a row the bidding path wrote (it
  knows the actual bid, this only knows the settled price), and returns what
  it could not recover.

### An unrecoverable basis writes no row

Deliberate, and the one design call worth reviewing. A placeholder price would
feed straight into profit-sell arithmetic — a zero divides, and any other
invented figure quietly authorises a real trade against a number nobody
measured. Absence leaves the player untouched, which is the safe failure, and
the gap is logged loudly rather than hidden.

The consequence is that 9 players remain unevaluable. Deciding what to do
about them is a **policy** question and belongs to REH-104, not here.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code quality improvement

## Testing

- [x] I have run the test suite locally (`pytest`)
- [x] I have added new tests for my changes
- [x] All tests pass
- [x] I have tested this manually

```
$ uv run pytest -q
1241 passed, 1 skipped in 4.81s     # +15 from this branch
```

15 new tests in `tests/test_cost_basis_reconciliation.py`, including the
Da Costa sold-after-buy case, the never-overwrite rule, the no-fabricated-price
rule, and a scoping test proving a player we no longer hold is not re-tracked.

**The call site is proved, not assumed.** REH-86 shipped a writer nothing
called and left `auction_outcomes.winning_bid` NULL on every production row
for a season. `TestTheSessionActuallyCallsIt` drives `run_full_session` and
asserts step 1 reached the reconciler.

### Live smoke — `uv run rehoboam auto --dry-run` against prod state

```
INFO  cost-basis recovered player=2522 (Raum) buy_price=40717295 from=2026-08-26T15:28:32Z
WARN  cost-basis gap: 9 of 12 squad players have no basis (11748, 9776, 157, 2172,
      461, 3754, 1540, 72, 1865) — profit-taking and loss-cutting cannot evaluate them
```

Resulting `tracked_purchases`: Raum added at the real price with
`source='transfer_feed'`; the two `real` rows untouched; **Da Costa correctly
absent** despite having a May buy record, because he was sold in May.

### Replay

```
$ uv run rehoboam replay-season --with-competition
Simulated total: 24,141 points
```

Unchanged against the `--no-pacing` baseline recorded in REH-85's results
document — expected, since this is a recording fix on the live path and the
replay does not exercise `manager_transfers` recovery.

## Code Quality

- [x] Style guidelines (Black, Ruff)
- [x] `pre-commit` passes
- [x] Docstrings added
- [x] Documentation updated

Hooks run on changed files rather than `--all-files`; the repo is not
black-clean and a whole-repo pass would bury this diff.

## Related Issues

Related to REH-103 — https://linear.app/jovily/issue/REH-103
Unblocks REH-104 (no cash-generation loop).

## Additional Notes

This fixes the **recording**, not the policy. Nine squad players still have no
basis and remain unevaluable by the sell side; that is REH-104's decision to
make, with real numbers now visible to make it on.

It also means the conversion metrics quoted in REH-102 are understated — Raum
is a win that never reached `auction_outcomes`. Re-derive them after this
lands before drawing conclusions about bid win rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
