### PR TITLE
fix(pacing): bound the reserve by budget that exists (REH-101)

### DIFF
--- a/docs/superpowers/specs/2026-08-27-reh-101-bounded-reserve-results.md
+++ b/docs/superpowers/specs/2026-08-27-reh-101-bounded-reserve-results.md
@@ -1,0 +1,151 @@
+# Bounding the capital reserve (REH-101): measured results
+
+Date: 2026-08-27
+Status: measured, recommendation below, not yet merged
+Ticket: https://linear.app/jovily/issue/REH-101
+Builds on: REH-85 (`docs/superpowers/specs/2026-08-26-reh-85-capital-pacing-results.md`), PR #85, unmerged
+Branch: `marcobraun2013/reh-101-bounded-reserve`
+
+## Verdict up front
+
+Ship at `pacing_max_reserve_fraction=0.5`. The fix is real and provable on the
+live position — the plain-buy cap goes from **EUR 50,227 to EUR 10,825,114**,
+which is the difference between a bot that cannot buy anything and one that can
+afford a median move.
+
+It does **not** meet the acceptance criterion this ticket was filed with ("buy
+count must rise above the unpaced baseline of 3"). Neither did REH-85. The
+reason turns out to be that **the criterion is untestable in this instrument**,
+which is a more useful finding than another failed sweep — see below. The
+recommendation therefore rests on the live measurement and on unit-level
+proof of the sell/headroom invariant, not on a replay points delta.
+
+## The sweep
+
+All runs `uv run rehoboam replay-season --with-competition`, varying only
+`--pacing-max-reserve-fraction`.
+
+|                fraction | points | delta vs no-pacing | buys | sells | final budget |
+| ----------------------: | -----: | -----------------: | ---: | ----: | -----------: |
+| `--no-pacing` (control) | 24,141 |                  — |    3 |     0 |        EUR 0 |
+|                     0.0 | 24,141 |                  0 |    3 |     0 |        EUR 0 |
+|                    0.25 | 25,309 |             +1,168 |    3 |     0 |   EUR 62,660 |
+|       **0.5 (shipped)** | 25,000 |               +859 |    3 |     0 |        EUR 0 |
+|                    0.75 | 25,000 |               +859 |    3 |     0 |        EUR 0 |
+|  1.0 (REH-85 behaviour) | 25,000 |               +859 |    3 |     0 |        EUR 0 |
+
+Two sanity checks pass: `0.0` reproduces `--no-pacing` exactly (24,141/3
+buys), confirming the fraction genuinely disables the reserve; and `1.0`
+reproduces REH-85's +859, confirming the unbounded arithmetic is still
+reachable for rollback and A/B.
+
+## Why "buy count must rise" cannot be tested here
+
+**Buy count is 3 in every row — including the rows with no reserve at all.**
+`--no-pacing` and `fraction=0.0` both remove the constraint entirely and still
+buy exactly 3 players, ending on EUR 0.
+
+That settles something REH-85 left ambiguous. REH-85 read a flat buy count of 3
+as evidence that its reserve "converted one lockout into another". It is not:
+buy count in this replay is **not reserve-limited at any setting**. It is
+limited by how many players clear the EP-gain floor and are visible at all —
+the harness's own report says buy availability is `medium`, "only players who
+actually traded are visible".
+
+So the acceptance criterion as written cannot discriminate a good reserve from
+no reserve, and no amount of tuning this knob will move it. **Any future
+reserve work should stop using replay buy count as its bar.** The instrument
+that would answer it is a market-availability model, which does not exist.
+
+The points column is not a tiebreaker either. The spread across 0.25-1.0 is
+309 points, far below REH-71's 6,162-point noise bar. Reading 0.25 as "best"
+because it scored highest would be exactly the window-tuning mistake REH-85
+diagnosed and refused.
+
+## The live measurement, which does discriminate
+
+`uv run rehoboam auto --dry-run` against prod state, squad 12/15, budget
+EUR 21,650,227, zero open offers:
+
+```
+pacing session median_move=11011011 slots_to_fill=3 reserve=10825113 \
+  open_offers=0 n_prices=58 budget=21650227 max_fraction=0.50
+```
+
+|                       |    reserve |  plain-buy cap | can it afford a median move? |
+| --------------------- | ---------: | -------------: | ---------------------------- |
+| REH-85, unbounded     | 21,600,000 |     **50,227** | no                           |
+| REH-101, fraction 0.5 | 10,825,113 | **10,825,114** | yes (median is 11,011,011)   |
+
+The arithmetic: `min(2 x 11,011,011, 0.5 x 21,650,227) = 10,825,113`, so the
+bound binds, and `21,650,227 - 0 - 10,825,113 = 10,825,114`. Candidates with a
+sell plan clear more still — 12,983,712 and 15,326,607.
+
+This is the failure the ticket was filed on, fixed: a reserve that demanded
+99.8% of the wallet now demands half of it.
+
+## The perverse sale effect, fixed
+
+Because the reserve scales with empty slots, selling a player below the median
+move price used to make the next buy *harder* — one more slot costs a full
+median of reserve while the sale raises less than that.
+
+Worked from the live position (12/15, EUR 21.65m, median EUR 10.8m), selling
+someone for EUR 5m:
+
+|                 | reserve before | headroom before | reserve after | headroom after |
+| --------------- | -------------: | --------------: | ------------: | -------------: |
+| unbounded (1.0) |     21,600,000 |          50,227 |    26,650,227 |          **0** |
+| bounded (0.5)   |     10,825,113 |      10,825,114 |    13,325,113 | **13,325,114** |
+
+Pinned by `TestRaisingCashMustNotMakeBuyingHarder`, which also asserts the
+pathology still reproduces at fraction 1.0 — without that the suite could not
+tell a real fix from a coincidence.
+
+## Recommended default: 0.5
+
+Chosen on reasoning, not on the 309-point spread:
+
+- It is the point at which the reserve can never take more than half the
+  wallet, so **at least half the budget is always spendable** whatever the
+  slot count does. That is a property that can be stated and defended, unlike
+  a number picked off a noisy sweep.
+- At the live budget it clears exactly one median move (10.83m cap against an
+  11.01m median), which is the smallest useful amount of freedom.
+- 0.25 scored 309 points higher and leaves the bot holding almost nothing back
+  (5.4m reserve at the live budget) — the failure mode REH-85 exists to
+  prevent. Buying that back for a sub-noise points delta is not a trade worth
+  making.
+- 0.75 and 1.0 both leave the live position effectively frozen, which is the
+  bug.
+
+Re-tunable from `.env` as `PACING_MAX_RESERVE_FRACTION` without a deploy, like
+the other three pacing knobs.
+
+## Caveats
+
+- Every REH-85 caveat still applies, in particular that the replay's buy side
+  is an upper bound and that its squad builds from near-empty while the live
+  bot sits at 12/15.
+- The 0.25 row's non-zero final budget (EUR 62,660) is the only run that does
+  not end on exactly EUR 0. Not investigated; it is within rounding of zero
+  and does not change the recommendation.
+- This ticket bounds the reserve. It does not give the bot a way to *raise*
+  cash — that is REH-104, and it is still the larger problem. A bot that can
+  spend half its wallet is not much better off when the wallet is nearly
+  empty.
+
+## Test suite
+
+```
+$ uv run pytest -q
+1298 passed, 1 skipped in 4.51s
+```
+
+14 new tests in `tests/test_pacing_bounded_reserve.py`. Eighteen existing tests
+were updated for the signature change — `budget` and `max_reserve_fraction`
+are **required** keyword arguments on `capital_reserve`, deliberately: the
+whole defect was a reserve that ignored the budget, and a default would let a
+new call site reintroduce that by omission. The REH-85 arithmetic tests keep
+their exact assertions by passing an ample budget at fraction 1.0, where the
+bound does not bind.

--- a/rehoboam/cli.py
+++ b/rehoboam/cli.py
@@ -764,6 +764,16 @@ def replay_season(
             "override to sweep the knob."
         ),
     ),
+    pacing_max_reserve_fraction: float | None = typer.Option(
+        None,
+        "--pacing-max-reserve-fraction",
+        help=(
+            "REH-101: hard ceiling on the pacing reserve as a fraction of "
+            "current budget. Defaults to the shipped "
+            "pacing_max_reserve_fraction Settings value; 1.0 reproduces "
+            "REH-85's unbounded reserve, 0.0 disables the reserve."
+        ),
+    ),
     pacing_window_days: int | None = typer.Option(
         None,
         "--pacing-window-days",
@@ -807,6 +817,7 @@ def replay_season(
         pacing_enabled=pacing,
         pacing_min_moves=pacing_min_moves,
         pacing_window_days=pacing_window_days,
+        pacing_max_reserve_fraction=pacing_max_reserve_fraction,
     )
     console.print(report)
 

--- a/rehoboam/config.py
+++ b/rehoboam/config.py
@@ -387,6 +387,18 @@ class Settings(BaseSettings):
             "in the 2026/27 pre-season, so this is measured, not hardcoded."
         ),
     )
+    pacing_max_reserve_fraction: float = Field(
+        default=0.5,
+        ge=0.0,
+        description=(
+            "REH-101: hard ceiling on the reserve, as a fraction of current "
+            "budget. REH-85 sized the reserve purely as moves x median move "
+            "with nothing bounding it by money that exists, so it could demand "
+            "more than the bot owns — and a constraint nothing can satisfy "
+            "refuses every buy instead of degrading. 1.0 reproduces the "
+            "unbounded REH-85 behaviour; 0.0 disables the reserve entirely."
+        ),
+    )
     pacing_median_floor_eur: int = Field(
         default=3_000_000,
         ge=0,

--- a/rehoboam/replay/driver.py
+++ b/rehoboam/replay/driver.py
@@ -248,6 +248,7 @@ def run_replay(
     pacing_enabled: bool = True,
     pacing_min_moves: int | None = None,
     pacing_window_days: int | None = None,
+    pacing_max_reserve_fraction: float | None = None,
 ) -> tuple[SeasonResult, str]:
     """Replay the whole season and return the result plus a formatted report.
 
@@ -330,6 +331,11 @@ def run_replay(
                     pacing_min_moves
                     if pacing_min_moves is not None
                     else int(_shipped_default("pacing_in_season_min_moves"))
+                ),
+                max_reserve_fraction=(
+                    pacing_max_reserve_fraction
+                    if pacing_max_reserve_fraction is not None
+                    else float(_shipped_default("pacing_max_reserve_fraction"))
                 ),
                 pacing_enabled=pacing_enabled,
             )
@@ -469,6 +475,7 @@ def make_ep_bid_fn(
     score_fn: Callable[[str, float], float],
     median_move_fn: Callable[[float], int],
     in_season_min_moves: int,
+    max_reserve_fraction: float,
     pacing_enabled: bool = True,
 ) -> Callable[[str, int, float, float, int, int], int]:
     """Bid with the bot's own bidding strategy (REH-68).
@@ -540,6 +547,8 @@ def make_ep_bid_fn(
                 slots_to_fill=available_squad_slots(squad_size, 0),
                 in_season_min_moves=in_season_min_moves,
                 median_move=median_move_fn(at),
+                budget=budget,
+                max_reserve_fraction=max_reserve_fraction,
             )
             pacing_ctx = PacingContext(reserve=reserve, open_offers=0)
         rec = bidding.calculate_ep_bid(

--- a/rehoboam/services/pacing.py
+++ b/rehoboam/services/pacing.py
@@ -56,7 +56,14 @@ def median_move_price(prices: Sequence[int], *, floor_eur: int) -> int:
     return max(median, floor_eur)
 
 
-def capital_reserve(*, slots_to_fill: int, in_season_min_moves: int, median_move: int) -> int:
+def capital_reserve(
+    *,
+    slots_to_fill: int,
+    in_season_min_moves: int,
+    median_move: int,
+    budget: int,
+    max_reserve_fraction: float,
+) -> int:
     """Euros that must survive this buy, so the bot can keep operating.
 
     `slots_to_fill` rather than a constant is the load-bearing choice. A
@@ -71,12 +78,33 @@ def capital_reserve(*, slots_to_fill: int, in_season_min_moves: int, median_move
     fill one of the three. At 1 slot, the reserve is 0 — completing the squad
     takes priority over holding replacement money. Only at slots_to_fill <= 0
     (full squad or over-committed) does `in_season_min_moves` become the floor.
+
+    REH-101: the move-count figure is then bounded by `budget *
+    max_reserve_fraction`. Without that bound the reserve can demand more
+    capital than the bot owns, and a constraint nothing can satisfy refuses
+    every buy instead of degrading. Measured in REH-85: at 14 empty slots the
+    reserve wanted EUR 65-87m against an ~EUR 80m budget, and buy count came
+    out identical with pacing on and off. Live at 12/15 it wanted EUR 21.6m of
+    a EUR 21.65m budget, capping every plain buy at EUR 50,227.
+
+    `budget` is required rather than defaulted on purpose. This whole function
+    was a reserve that ignored the budget; a default would let a new call site
+    reintroduce that by omission, silently.
+
+    The bound also fixes a perverse second-order effect. The reserve scales
+    with empty slots, so selling a player below the median move price used to
+    make the next buy *harder* — one more slot costs a full median of reserve
+    while the sale raises less than that. Against a fraction of the budget,
+    raising cash raises the ceiling instead of lowering it.
     """
     # Account for this buy filling one slot: reserve is for moves remaining
     # after it lands. Full squad (slots <= 0) falls back to in_season_min_moves.
     moves_after_this_buy = max(slots_to_fill - 1, 0)
     moves = moves_after_this_buy if slots_to_fill > 0 else in_season_min_moves
-    return max(0, moves) * max(0, median_move)
+    wanted = max(0, moves) * max(0, median_move)
+
+    affordable = int(max(0, budget) * max(0.0, max_reserve_fraction))
+    return min(wanted, affordable)
 
 
 @dataclass(frozen=True)

--- a/rehoboam/trader.py
+++ b/rehoboam/trader.py
@@ -203,7 +203,7 @@ class Trader:
     # EP pipeline
     # ------------------------------------------------------------------
 
-    def _build_pacing_context(self, squad_size: int, my_bids: list):
+    def _build_pacing_context(self, squad_size: int, my_bids: list, current_budget: int):
         """The REH-85 reserve for this session, or None when pacing is off.
 
         Built once per run rather than per candidate: the median move price is
@@ -239,18 +239,24 @@ class Trader:
         )
         open_offers = sum(int(getattr(b, "user_offer_price", 0) or 0) for b in my_bids)
         slots_to_fill = available_squad_slots(squad_size, len(my_bids))
+        max_reserve_fraction = float(getattr(self.settings, "pacing_max_reserve_fraction", 0.5))
         reserve = capital_reserve(
             slots_to_fill=slots_to_fill,
             in_season_min_moves=int(self.settings.pacing_in_season_min_moves),
             median_move=median_move,
+            budget=int(current_budget),
+            max_reserve_fraction=max_reserve_fraction,
         )
         logger.info(
-            "pacing session median_move=%d slots_to_fill=%d reserve=%d open_offers=%d n_prices=%d",
+            "pacing session median_move=%d slots_to_fill=%d reserve=%d open_offers=%d "
+            "n_prices=%d budget=%d max_fraction=%.2f",
             median_move,
             slots_to_fill,
             reserve,
             open_offers,
             len(prices),
+            int(current_budget),
+            max_reserve_fraction,
         )
         return PacingContext(reserve=reserve, open_offers=open_offers)
 
@@ -297,7 +303,11 @@ class Trader:
             # An empty lineup slot is -100 pts at kickoff, which outranks
             # the pacing reserve — never cap spending during a formation
             # emergency (see _determine_emergency above).
-            pacing = None if is_emergency else self._build_pacing_context(squad_size, my_bids)
+            pacing = (
+                None
+                if is_emergency
+                else self._build_pacing_context(squad_size, my_bids, int(current_budget))
+            )
         except Exception:
             logger.exception("pacing: could not read open bids — pacing disabled this run")
             my_bids = None

--- a/tests/test_pacing.py
+++ b/tests/test_pacing.py
@@ -51,12 +51,26 @@ class TestAvailableSquadSlots:
 
 
 class TestCapitalReserve:
+    """The move-count arithmetic.
+
+    These pass an ample budget at `max_reserve_fraction=1.0` so REH-101's
+    budget bound never binds — the subject here is how many moves the reserve
+    funds, which is a separate question from whether the bot can afford them.
+    The bound has its own file, `test_pacing_bounded_reserve.py`.
+    """
+
     def test_reserve_accounts_for_this_buy_filling_one_slot(self):
         # Off-by-one pin: at slots=3, reserve accounts for 2 moves remaining
         # after this buy, not 3 unfilled slots before. Using 3*median (32_400_000)
         # would incorrectly prohibit large signings.
         assert (
-            capital_reserve(slots_to_fill=3, in_season_min_moves=2, median_move=10_800_000)
+            capital_reserve(
+                slots_to_fill=3,
+                in_season_min_moves=2,
+                median_move=10_800_000,
+                budget=1_000_000_000,
+                max_reserve_fraction=1.0,
+            )
             == 21_600_000
         )
 
@@ -64,13 +78,25 @@ class TestCapitalReserve:
         # At 15/15 there are no slots to fill, but the bot must still be able
         # to replace a player mid-season.
         assert (
-            capital_reserve(slots_to_fill=0, in_season_min_moves=2, median_move=10_800_000)
+            capital_reserve(
+                slots_to_fill=0,
+                in_season_min_moves=2,
+                median_move=10_800_000,
+                budget=1_000_000_000,
+                max_reserve_fraction=1.0,
+            )
             == 21_600_000
         )
 
     def test_negative_slots_never_shrink_the_reserve_below_the_minimum(self):
         assert (
-            capital_reserve(slots_to_fill=-2, in_season_min_moves=2, median_move=10_800_000)
+            capital_reserve(
+                slots_to_fill=-2,
+                in_season_min_moves=2,
+                median_move=10_800_000,
+                budget=1_000_000_000,
+                max_reserve_fraction=1.0,
+            )
             == 21_600_000
         )
 
@@ -78,7 +104,16 @@ class TestCapitalReserve:
         # At slots=1, the last slot may be filled freely (reserve=0).
         # Completing the squad outranks holding replacement money.
         # Old formula (1*median) would incorrectly give 10_800_000.
-        assert capital_reserve(slots_to_fill=1, in_season_min_moves=2, median_move=10_800_000) == 0
+        assert (
+            capital_reserve(
+                slots_to_fill=1,
+                in_season_min_moves=2,
+                median_move=10_800_000,
+                budget=1_000_000_000,
+                max_reserve_fraction=1.0,
+            )
+            == 0
+        )
 
 
 class TestPacingContext:
@@ -135,7 +170,11 @@ class TestPacingContext:
         caps = []
         for slots in (3, 2, 1):
             reserve = capital_reserve(
-                slots_to_fill=slots, in_season_min_moves=2, median_move=median
+                slots_to_fill=slots,
+                in_season_min_moves=2,
+                median_move=median,
+                budget=budget,
+                max_reserve_fraction=0.5,
             )
             cap = PacingContext(reserve=reserve, open_offers=0).max_bid(
                 budget, current_budget=budget

--- a/tests/test_pacing_bounded_reserve.py
+++ b/tests/test_pacing_bounded_reserve.py
@@ -1,0 +1,168 @@
+"""Tests for REH-101: the reserve must be bounded by money that exists.
+
+REH-85 sized the reserve purely as `moves_wanted * median_move`. Nothing
+bounded it by what the bot owns, so it could demand more capital than exists —
+and when it did, it refused every buy rather than degrading.
+
+Measured there: at 14 empty slots the reserve is EUR 65-87m against an ~EUR 80m
+starting budget, and buy count came out 3 with pacing on and 3 with pacing off,
+identically. Live at 12/15 on 2026-08-27 the reserve was EUR 21,600,000 against
+a EUR 21,650,227 budget, capping every plain buy at EUR 50,227.
+
+The second-order effect is the sharper one, and has its own test below:
+because the reserve scales with EMPTY SLOTS, selling a player below the median
+move price makes the next buy *harder*, since it adds a slot (+1 median of
+reserve) while adding less than that to the budget.
+"""
+
+import pytest
+
+from rehoboam.services.pacing import PacingContext, capital_reserve
+
+MEDIAN = 10_800_000
+
+# The live position on 2026-08-27, which is what the ticket is measured against.
+LIVE_BUDGET = 21_650_227
+LIVE_SLOTS = 3
+
+
+class TestTheBoundBites:
+    def test_the_bound_caps_a_reserve_larger_than_the_budget_allows(self):
+        """Two moves at the median is EUR 21.6m against a EUR 21.65m budget."""
+        reserve = capital_reserve(
+            slots_to_fill=LIVE_SLOTS,
+            in_season_min_moves=2,
+            median_move=MEDIAN,
+            budget=LIVE_BUDGET,
+            max_reserve_fraction=0.5,
+        )
+
+        assert reserve == int(LIVE_BUDGET * 0.5)
+
+    def test_a_reserve_the_budget_can_cover_is_left_alone(self):
+        """The bound is a ceiling, not a target — it must not inflate."""
+        reserve = capital_reserve(
+            slots_to_fill=2,  # one move after this buy
+            in_season_min_moves=2,
+            median_move=MEDIAN,
+            budget=200_000_000,
+            max_reserve_fraction=0.5,
+        )
+
+        assert reserve == MEDIAN
+
+    def test_fraction_of_one_reproduces_the_unbounded_reserve(self):
+        """The REH-85 arithmetic must remain reachable, for A/B and rollback."""
+        reserve = capital_reserve(
+            slots_to_fill=LIVE_SLOTS,
+            in_season_min_moves=2,
+            median_move=MEDIAN,
+            budget=LIVE_BUDGET,
+            max_reserve_fraction=1.0,
+        )
+
+        assert reserve == 2 * MEDIAN
+
+    def test_a_zero_fraction_disables_the_reserve(self):
+        reserve = capital_reserve(
+            slots_to_fill=LIVE_SLOTS,
+            in_season_min_moves=2,
+            median_move=MEDIAN,
+            budget=LIVE_BUDGET,
+            max_reserve_fraction=0.0,
+        )
+
+        assert reserve == 0
+
+    def test_an_empty_wallet_reserves_nothing(self):
+        """Nothing to protect, and a fraction of zero is zero either way."""
+        reserve = capital_reserve(
+            slots_to_fill=14,
+            in_season_min_moves=2,
+            median_move=MEDIAN,
+            budget=0,
+            max_reserve_fraction=0.5,
+        )
+
+        assert reserve == 0
+
+    def test_a_negative_budget_never_yields_a_negative_reserve(self):
+        """The bot is allowed to go into debt; a negative reserve is nonsense."""
+        reserve = capital_reserve(
+            slots_to_fill=3,
+            in_season_min_moves=2,
+            median_move=MEDIAN,
+            budget=-5_000_000,
+            max_reserve_fraction=0.5,
+        )
+
+        assert reserve == 0
+
+
+class TestRaisingCashMustNotMakeBuyingHarder:
+    """The acceptance criterion REH-101 was filed on.
+
+    Selling a player adds one empty slot. Under REH-85's unbounded reserve that
+    costs a full median move (EUR 10.8m) while the sale raises less than that,
+    so the bot ends up strictly worse off for having raised cash.
+    """
+
+    @staticmethod
+    def _headroom(budget: int, slots: int, fraction: float) -> int:
+        reserve = capital_reserve(
+            slots_to_fill=slots,
+            in_season_min_moves=2,
+            median_move=MEDIAN,
+            budget=budget,
+            max_reserve_fraction=fraction,
+        )
+        return PacingContext(reserve=reserve, open_offers=0).max_bid(
+            budget_ceiling=budget, current_budget=budget
+        )
+
+    def test_selling_a_cheap_player_increases_headroom(self):
+        """Live case: 12/15 with EUR 21.65m, then sell someone for EUR 5m."""
+        before = self._headroom(LIVE_BUDGET, LIVE_SLOTS, 0.5)
+        after = self._headroom(LIVE_BUDGET + 5_000_000, LIVE_SLOTS + 1, 0.5)
+
+        assert after > before, (
+            f"raising EUR 5m cut headroom from {before:,} to {after:,} — "
+            "the bot is worse off for having sold"
+        )
+
+    def test_the_unbounded_reserve_is_what_broke_this(self):
+        """Pins the regression: at fraction 1.0 the pathology is still there.
+
+        Without this the suite could not tell a real fix from a coincidence.
+        """
+        before = self._headroom(LIVE_BUDGET, LIVE_SLOTS, 1.0)
+        after = self._headroom(LIVE_BUDGET + 5_000_000, LIVE_SLOTS + 1, 1.0)
+
+        assert after < before
+
+    @pytest.mark.parametrize("sale_price", [1_000_000, 5_000_000, 10_000_000, 25_000_000])
+    def test_headroom_never_falls_after_a_sale_at_any_price(self, sale_price):
+        before = self._headroom(LIVE_BUDGET, LIVE_SLOTS, 0.5)
+        after = self._headroom(LIVE_BUDGET + sale_price, LIVE_SLOTS + 1, 0.5)
+
+        assert after >= before
+
+
+class TestTheKnob:
+    def test_the_fraction_is_a_settings_field(self, monkeypatch):
+        monkeypatch.setenv("KICKBASE_EMAIL", "test@example.com")
+        monkeypatch.setenv("KICKBASE_PASSWORD", "x")
+        from rehoboam.config import Settings
+
+        assert 0.0 <= Settings().pacing_max_reserve_fraction <= 1.0
+
+    def test_a_negative_fraction_is_refused(self, monkeypatch):
+        from pydantic import ValidationError
+
+        monkeypatch.setenv("KICKBASE_EMAIL", "test@example.com")
+        monkeypatch.setenv("KICKBASE_PASSWORD", "x")
+        monkeypatch.setenv("PACING_MAX_RESERVE_FRACTION", "-0.5")
+        from rehoboam.config import Settings
+
+        with pytest.raises(ValidationError):
+            Settings()

--- a/tests/test_pacing_replay.py
+++ b/tests/test_pacing_replay.py
@@ -14,6 +14,7 @@ def test_bid_fn_takes_squad_size():
         score_fn=lambda pid, at: 80.0,
         median_move_fn=lambda at: 10_800_000,
         in_season_min_moves=2,
+        max_reserve_fraction=1.0,
     )
     assert len(inspect.signature(fn).parameters) == 6
 
@@ -27,6 +28,7 @@ def test_a_short_squad_is_capped_below_an_unaffordable_signing():
         score_fn=lambda pid, at: 80.0,
         median_move_fn=lambda at: 10_800_000,
         in_season_min_moves=2,
+        max_reserve_fraction=1.0,
     )
     assert fn("p1", 44_000_000, 0.0, 90.0, 80_000_000, 9) == 0
 
@@ -37,6 +39,7 @@ def test_an_affordable_signing_still_goes_through():
         score_fn=lambda pid, at: 80.0,
         median_move_fn=lambda at: 10_800_000,
         in_season_min_moves=2,
+        max_reserve_fraction=1.0,
     )
     assert fn("p1", 5_000_000, 0.0, 90.0, 80_000_000, 9) >= 5_000_000
 
@@ -50,6 +53,7 @@ def test_pacing_enabled_false_bypasses_the_reserve():
         score_fn=lambda pid, at: 80.0,
         median_move_fn=lambda at: 10_800_000,
         in_season_min_moves=2,
+        max_reserve_fraction=1.0,
         pacing_enabled=False,
     )
     assert fn("p1", 44_000_000, 0.0, 90.0, 80_000_000, 9) >= 44_000_000
@@ -69,6 +73,7 @@ def test_median_move_fn_is_called_with_the_decision_instant():
         score_fn=lambda pid, at: 80.0,
         median_move_fn=median_move_fn,
         in_season_min_moves=2,
+        max_reserve_fraction=1.0,
     )
     fn("p1", 44_000_000, 123.0, 90.0, 80_000_000, 9)
 

--- a/tests/test_pacing_session.py
+++ b/tests/test_pacing_session.py
@@ -32,24 +32,30 @@ def _bid(amount):
 def test_reserve_covers_every_unfilled_slot(trader):
     """11 players + 1 open bid = 12/15, so 3 slots remain. Reserve is for
     2 moves after this buy fills one slot, at EUR 10.8m each."""
-    ctx = trader._build_pacing_context(squad_size=11, my_bids=[_bid(40_717_295)])
+    ctx = trader._build_pacing_context(
+        squad_size=11, my_bids=[_bid(40_717_295)], current_budget=62_307_522
+    )
     assert ctx is not None
     assert ctx.reserve == 21_600_000
 
 
 def test_open_offers_are_carried_into_the_context(trader):
-    ctx = trader._build_pacing_context(squad_size=11, my_bids=[_bid(40_717_295)])
+    ctx = trader._build_pacing_context(
+        squad_size=11, my_bids=[_bid(40_717_295)], current_budget=62_307_522
+    )
     assert ctx.open_offers == 40_717_295
 
 
 def test_full_squad_falls_back_to_the_in_season_minimum(trader):
-    ctx = trader._build_pacing_context(squad_size=15, my_bids=[])
+    ctx = trader._build_pacing_context(squad_size=15, my_bids=[], current_budget=62_307_522)
     assert ctx.reserve == 21_600_000
 
 
 def test_disabled_setting_returns_no_context(trader, settings):
     settings.pacing_enabled = False
-    assert trader._build_pacing_context(squad_size=11, my_bids=[]) is None
+    assert (
+        trader._build_pacing_context(squad_size=11, my_bids=[], current_budget=62_307_522) is None
+    )
 
 
 def test_a_learner_failure_disables_pacing_rather_than_breaking_the_session(settings):
@@ -57,12 +63,12 @@ def test_a_learner_failure_disables_pacing_rather_than_breaking_the_session(sett
     learner = MagicMock()
     learner.recent_buy_prices.side_effect = RuntimeError("db gone")
     t = Trader(api=MagicMock(), settings=settings, bid_learner=learner)
-    assert t._build_pacing_context(squad_size=11, my_bids=[]) is None
+    assert t._build_pacing_context(squad_size=11, my_bids=[], current_budget=62_307_522) is None
 
 
 def test_no_learner_at_all_disables_pacing(settings):
     t = Trader(api=MagicMock(), settings=settings, bid_learner=None)
-    assert t._build_pacing_context(squad_size=11, my_bids=[]) is None
+    assert t._build_pacing_context(squad_size=11, my_bids=[], current_budget=62_307_522) is None
 
 
 def test_the_trend_recompute_does_not_discard_pacing(trader):

--- a/tests/test_replay/test_bid_competition.py
+++ b/tests/test_replay/test_bid_competition.py
@@ -109,6 +109,7 @@ def test_the_ep_bid_fn_bids_more_for_a_must_have_than_for_a_marginal_gain():
         score_fn=lambda pid, at: 100.0,
         median_move_fn=lambda at: 10_000_000,
         in_season_min_moves=2,
+        max_reserve_fraction=1.0,
     )
 
     # squad_size=14 -> 1 slot left -> capital_reserve's last-slot case (0
@@ -128,6 +129,7 @@ def test_the_ep_bid_fn_never_bids_beyond_the_budget():
         score_fn=lambda pid, at: 100.0,
         median_move_fn=lambda at: 10_000_000,
         in_season_min_moves=2,
+        max_reserve_fraction=1.0,
     )
 
     # squad_size=14 -> 0 reserve (see above) -> this exercises the budget cap


### PR DESCRIPTION
> **Stacked on #85.** Base is `marcobraun2013/reh-85-capital-pacing`, not
> `main` — `services/pacing.py` only exists there. Merge #85 first.

## Description

REH-85 sized the capital reserve purely as `moves_wanted * median_move`.
Nothing bounded it by what the bot actually owns, so it could demand more
capital than exists — and **a constraint nothing can satisfy refuses every buy
instead of degrading**.

This adds the bound REH-85's own results document recommended as a fast-follow:

```
reserve = min(moves_wanted * median_move, budget * max_reserve_fraction)
```

## The live effect

`uv run rehoboam auto --dry-run` against prod, squad 12/15, budget
EUR 21,650,227:

| | reserve | plain-buy cap | affords a median move? |
| -- | --: | --: | -- |
| REH-85, unbounded | 21,600,000 | **50,227** | no |
| REH-101, fraction 0.5 | 10,825,113 | **10,825,114** | yes (median 11,011,011) |

```
pacing session median_move=11011011 slots_to_fill=3 reserve=10825113 \
  open_offers=0 n_prices=58 budget=21650227 max_fraction=0.50
```

A reserve that demanded 99.8% of the wallet now demands half of it.

## The perverse sale effect, also fixed

Because the reserve scales with **empty slots**, selling a player below the
median move price used to make the next buy *harder* — one more slot costs a
full median of reserve while the sale raises less than that.

Selling for EUR 5m from the live position:

| | headroom before | headroom after |
| -- | --: | --: |
| unbounded (1.0) | 50,227 | **0** |
| bounded (0.5) | 10,825,114 | **13,325,114** |

`TestRaisingCashMustNotMakeBuyingHarder` pins both directions — it also
asserts the pathology **still reproduces at fraction 1.0**, so the suite can
tell a real fix from a coincidence.

## The sweep does not meet this ticket's acceptance criterion — and that retires the criterion

| fraction | points | delta | buys | sells | final budget |
| -------: | -----: | ----: | ---: | ----: | -----------: |
| `--no-pacing` (control) | 24,141 | — | 3 | 0 | EUR 0 |
| 0.0 | 24,141 | 0 | 3 | 0 | EUR 0 |
| 0.25 | 25,309 | +1,168 | 3 | 0 | EUR 62,660 |
| **0.5 (shipped)** | 25,000 | +859 | 3 | 0 | EUR 0 |
| 0.75 | 25,000 | +859 | 3 | 0 | EUR 0 |
| 1.0 (REH-85 behaviour) | 25,000 | +859 | 3 | 0 | EUR 0 |

**Buy count is 3 in every row — including the rows with no reserve at all.**
`--no-pacing` and `fraction=0.0` remove the constraint entirely and still buy
exactly 3.

So buy count in this replay is **not reserve-limited at any setting**; it is
limited by how many players clear the EP floor and are visible (the harness
reports buy availability as `medium`, "only players who actually traded are
visible"). The criterion cannot discriminate a good reserve from no reserve,
and no tuning of this knob will move it. This also **corrects REH-85's
reading** of the same flat 3 as evidence its reserve "converted one lockout
into another" — it was not evidence of that.

Points are not a tiebreaker either: the 0.25-1.0 spread is 309, far under
REH-71's 6,162 noise bar. Picking 0.25 because it scored highest would be the
window-tuning mistake REH-85 diagnosed and refused.

Two sanity checks do pass: `0.0` reproduces `--no-pacing` exactly, and `1.0`
reproduces REH-85's +859 — the unbounded arithmetic stays reachable for
rollback and A/B.

## Why 0.5

Chosen on the property it guarantees, not the sweep: **the reserve can never
take more than half the wallet, so at least half is always spendable**
whatever the slot count does. At the live budget that clears exactly one
median move. 0.25 leaves only EUR 5.4m held back — the failure mode REH-85
exists to prevent — for a sub-noise gain. 0.75 and 1.0 leave the live position
frozen.

Re-tunable from `.env` as `PACING_MAX_RESERVE_FRACTION`, like the other pacing
knobs.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code quality improvement

## Testing

- [x] I have run the test suite locally (`pytest`)
- [x] I have added new tests for my changes
- [x] All tests pass
- [x] I have tested this manually

```
$ uv run pytest -q
1298 passed, 1 skipped in 4.50s     # +14 from this branch
```

**`budget` and `max_reserve_fraction` are required keyword arguments, not
defaulted.** The whole defect was a reserve that ignored the budget; a default
would let a new call site reintroduce it by omission. Eighteen existing tests
were updated — the REH-85 arithmetic tests keep their exact assertions by
passing an ample budget at fraction 1.0, where the bound does not bind.

Threaded through both call sites (`trader._build_pacing_context` and the
replay driver) so the harness measures the bidder that ships.

## Code Quality

- [x] Style guidelines (Black, Ruff)
- [x] `pre-commit` passes
- [x] Docstrings added
- [x] Documentation updated

## Related Issues

Related to REH-101 — https://linear.app/jovily/issue/REH-101
Builds on REH-85 (#85). Related to REH-104.

## Additional Notes

This bounds the reserve. **It does not give the bot a way to raise cash** —
that is REH-104, and it remains the larger problem. A bot that can spend half
its wallet is not much better off when the wallet is nearly empty.

Full measurement, including the caveats:
`docs/superpowers/specs/2026-08-27-reh-101-bounded-reserve-results.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
