### PR TITLE
feat(learning): raise an alarm when we lose an auction we were winning (REH-102)

### DIFF
--- a/rehoboam/bid_learner.py
+++ b/rehoboam/bid_learner.py
@@ -1,12 +1,15 @@
 """Learn from auction outcomes to improve bidding strategy"""
 
 import json
+import logging
 import sqlite3
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -1230,12 +1233,12 @@ class BidLearner:
         with sqlite3.connect(self.db_path) as conn:
             pending = conn.execute(
                 """
-                SELECT id, player_id, timestamp, our_bid, asking_price
+                SELECT id, player_id, timestamp, our_bid, asking_price, player_name
                 FROM auction_outcomes
                 WHERE won = 0 AND winning_bid IS NULL
                 """
             ).fetchall()
-            for row_id, player_id, ts, _our_bid, asking in pending:
+            for row_id, player_id, ts, _our_bid, asking, player_name in pending:
                 if ts is None:
                     continue
                 best = None
@@ -1268,8 +1271,56 @@ class BidLearner:
                     (int(price), str(winner), overbid, row_id),
                 )
                 filled += 1
+
+                # REH-102: losing while holding the best price is not a loss,
+                # it is a missing offer. Three August 2026 auctions went that
+                # way — Rohr twice and Gyamerah, all Kickbase-listed, where the
+                # highest bid should win — and nobody noticed for a week
+                # because `won` is a boolean and cannot say "we were ahead".
+                # This is the first instant the anomaly is knowable, so it is
+                # raised here rather than left for someone to query.
+                if _our_bid is not None and int(price) < int(_our_bid):
+                    logger.warning(
+                        "auction anomaly: we were HIGH BIDDER and still lost %s — "
+                        "ours EUR %s, winner paid EUR %s (margin EUR %s). "
+                        "An offer that loses to a lower price was not present at "
+                        "resolution; see REH-102.",
+                        player_name,
+                        f"{int(_our_bid):,}",
+                        f"{int(price):,}",
+                        f"{int(_our_bid) - int(price):,}",
+                    )
             conn.commit()
         return filled
+
+    def high_bidder_losses(self) -> list[dict[str, Any]]:
+        """Auctions lost despite our bid exceeding what the winner paid.
+
+        REH-102. On a Kickbase-listed player the highest bid wins, so these
+        cannot be explained by being outbid — the offer was not there when the
+        listing resolved. Reported worst-margin-first, because the largest
+        unexplained loss is the one worth chasing.
+
+        Only rows with an attributed `winning_bid` are considered. An
+        unattributed loss is honestly unknown, and guessing would turn the one
+        signal that distinguishes this failure from ordinary competition into
+        noise.
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(
+                """
+                SELECT player_id, player_name, our_bid, winning_bid, timestamp,
+                       our_bid - winning_bid AS margin
+                FROM auction_outcomes
+                WHERE won = 0
+                  AND winning_bid IS NOT NULL
+                  AND winning_bid > 0
+                  AND our_bid > winning_bid
+                ORDER BY margin DESC
+                """
+            ).fetchall()
+        return [dict(r) for r in rows]
 
     def record_manager_transfers(self, rows: list[dict]) -> int:
         """Bulk-upsert per-trade rows into ``manager_transfers``.

--- a/tests/test_high_bidder_losses.py
+++ b/tests/test_high_bidder_losses.py
@@ -1,0 +1,166 @@
+"""Tests for REH-102: losing an auction you were the high bidder in is an alarm.
+
+Three August 2026 losses had our bid ABOVE what the winner paid:
+
+    Rohr     2026-08-21   ours 12,305,344   winner 10,621,111   +1,684,233
+    Rohr     2026-08-22   ours 11,587,747   winner 10,621,111     +966,636
+    Gyamerah 2026-08-22   ours  8,616,278   winner  7,676,767     +939,511
+
+All on Kickbase-listed players, where the highest bid should win. That is not
+being outbid — the offer was gone. It went unnoticed for a week because
+`auction_outcomes.won` is a boolean: it can record THAT we lost, never that we
+lost while holding the best price.
+
+`resolve_auction_winners` already learns the winning price from the transfer
+feed a session or two later. That is the moment the anomaly becomes knowable,
+so that is where it is now raised.
+"""
+
+import logging
+import sqlite3
+
+import pytest
+
+from rehoboam.bid_learner import AuctionOutcome, BidLearner
+
+LEAGUE = "1933872"
+THEM = "1907519"
+BUY = 1
+
+# 2026-08-22T08:00:00Z, and a transfer close enough to fall inside the
+# three-day attribution window resolve_auction_winners uses.
+AUCTION_TS = 1_787_385_600.0
+TRANSFER_DT = "2026-08-22T14:00:00Z"
+
+
+@pytest.fixture
+def learner(tmp_path):
+    return BidLearner(db_path=tmp_path / "bid_learning.db")
+
+
+def _lost_auction(learner, player_id, name, our_bid, *, won=False):
+    learner.record_outcome(
+        AuctionOutcome(
+            player_id=player_id,
+            player_name=name,
+            our_bid=our_bid,
+            asking_price=int(our_bid * 0.9),
+            our_overbid_pct=11.1,
+            won=won,
+            timestamp=AUCTION_TS,
+        )
+    )
+
+
+def _transfer(learner, player_id, name, price):
+    learner.record_manager_transfers(
+        [
+            {
+                "league_id": LEAGUE,
+                "manager_id": THEM,
+                "transfer_dt": TRANSFER_DT,
+                "player_id": player_id,
+                "player_name": name,
+                "transfer_type": BUY,
+                "transfer_price": price,
+            }
+        ]
+    )
+
+
+class TestHighBidderLosses:
+    def test_a_loss_above_the_winning_price_is_reported(self, learner):
+        """The Rohr case: ours 12,305,344, winner paid 10,621,111."""
+        _lost_auction(learner, "rohr", "Maximilian Rohr", 12_305_344)
+        _transfer(learner, "rohr", "Maximilian Rohr", 10_621_111)
+        learner.resolve_auction_winners()
+
+        anomalies = learner.high_bidder_losses()
+
+        assert [a["player_name"] for a in anomalies] == ["Maximilian Rohr"]
+        assert anomalies[0]["our_bid"] == 12_305_344
+        assert anomalies[0]["winning_bid"] == 10_621_111
+        assert anomalies[0]["margin"] == 1_684_233
+
+    def test_a_genuine_outbid_is_not_an_anomaly(self, learner):
+        """Kimmich: ours 60,447,397, winner paid 65,000,065. Simply outbid."""
+        _lost_auction(learner, "kimmich", "Joshua Kimmich", 60_447_397)
+        _transfer(learner, "kimmich", "Joshua Kimmich", 65_000_065)
+        learner.resolve_auction_winners()
+
+        assert learner.high_bidder_losses() == []
+
+    def test_an_auction_we_won_is_not_an_anomaly(self, learner):
+        _lost_auction(learner, "pav", "Aleksandar Pavlović", 38_336_318, won=True)
+        _transfer(learner, "pav", "Aleksandar Pavlović", 30_000_000)
+        learner.resolve_auction_winners()
+
+        assert learner.high_bidder_losses() == []
+
+    def test_an_unattributed_loss_is_not_an_anomaly(self, learner):
+        """No transfer inside the window, so winning_bid stays NULL.
+
+        Reporting these would be a guess, and the whole point of the alarm is
+        that it fires only on evidence.
+        """
+        _lost_auction(learner, "schwolow", "Alexander Schwolow", 6_631_597)
+
+        assert learner.high_bidder_losses() == []
+
+    def test_an_equal_bid_is_not_an_anomaly(self, learner):
+        """Ties go to whoever bid first; nothing to explain."""
+        _lost_auction(learner, "tie", "Tied Player", 5_000_000)
+        _transfer(learner, "tie", "Tied Player", 5_000_000)
+        learner.resolve_auction_winners()
+
+        assert learner.high_bidder_losses() == []
+
+    def test_anomalies_are_ordered_by_margin(self, learner):
+        """Worst first — the biggest unexplained loss is the one to chase."""
+        _lost_auction(learner, "a", "Small Margin", 8_616_278)
+        _transfer(learner, "a", "Small Margin", 7_676_767)  # +939,511
+        _lost_auction(learner, "b", "Big Margin", 12_305_344)
+        _transfer(learner, "b", "Big Margin", 10_621_111)  # +1,684,233
+        learner.resolve_auction_winners()
+
+        assert [a["player_name"] for a in learner.high_bidder_losses()] == [
+            "Big Margin",
+            "Small Margin",
+        ]
+
+
+class TestTheAlarmFires:
+    def test_resolving_a_high_bidder_loss_logs_a_warning(self, learner, caplog):
+        """Silence for a week is the actual defect being fixed here."""
+        _lost_auction(learner, "rohr", "Maximilian Rohr", 12_305_344)
+        _transfer(learner, "rohr", "Maximilian Rohr", 10_621_111)
+
+        with caplog.at_level(logging.WARNING, logger="rehoboam.bid_learner"):
+            learner.resolve_auction_winners()
+
+        assert any(
+            "Maximilian Rohr" in r.message and "high bidder" in r.message.lower()
+            for r in caplog.records
+        ), f"no alarm raised; got {[r.message for r in caplog.records]}"
+
+    def test_a_genuine_outbid_is_silent(self, learner, caplog):
+        _lost_auction(learner, "kimmich", "Joshua Kimmich", 60_447_397)
+        _transfer(learner, "kimmich", "Joshua Kimmich", 65_000_065)
+
+        with caplog.at_level(logging.WARNING, logger="rehoboam.bid_learner"):
+            learner.resolve_auction_winners()
+
+        assert not [r for r in caplog.records if "high bidder" in r.message.lower()]
+
+    def test_resolution_still_returns_the_filled_count(self, learner):
+        """The alarm must not change what the method is for."""
+        _lost_auction(learner, "rohr", "Maximilian Rohr", 12_305_344)
+        _transfer(learner, "rohr", "Maximilian Rohr", 10_621_111)
+
+        assert learner.resolve_auction_winners() == 1
+
+        with sqlite3.connect(learner.db_path) as conn:
+            row = conn.execute(
+                "SELECT winning_bid, winner_user_id FROM auction_outcomes"
+            ).fetchone()
+        assert row == (10_621_111, THEM)


### PR DESCRIPTION
## Description

Three August 2026 auctions were lost with our bid **above** what the winner paid:

| recorded (UTC) | player | our bid | winner paid | margin |
| -- | -- | --: | --: | --: |
| 2026-08-21 20:00 | Maximilian Rohr | 12,305,344 | 10,621,111 | **+1,684,233** |
| 2026-08-22 08:00 | Maximilian Rohr | 11,587,747 | 10,621,111 | **+966,636** |
| 2026-08-22 08:00 | Jan Gyamerah | 8,616,278 | 7,676,767 | **+939,511** |

**EUR 3,590,380 of losses that being outbid cannot explain.** All three were
Kickbase-listed (`league_transfers.seller_name` is null), where the highest bid
wins — so the offer was not present when the listing resolved.

It went unnoticed for a week because `auction_outcomes.won` is a boolean: it
can record *that* we lost, never that we lost while holding the best price.
`resolve_auctions` marks a bid lost by elimination — not in the squad, not in
active bids — without asking who took the player or for how much.

## Approach

`resolve_auction_winners` (REH-86) already learns the winning price from the
transfer feed a session or two later. **That is the first instant the anomaly
is knowable**, so the warning is raised there rather than left for someone to
think to query it.

```
WARNING auction anomaly: we were HIGH BIDDER and still lost Maximilian Rohr —
        ours EUR 12,305,344, winner paid EUR 10,621,111 (margin EUR 1,684,233).
        An offer that loses to a lower price was not present at resolution.
```

`BidLearner.high_bidder_losses()` exposes the same set, worst-margin-first.
Run against **real prod state** it returns exactly the three rows above and
nothing else.

Only attributed rows count. An unattributed loss is honestly unknown, and
guessing would turn the one signal that separates this failure from ordinary
competition into noise.

## This is instrumentation, not the fix

The root cause still needs the Function's Application Insights logs. Two things
narrowed while building this, both now recorded on REH-102:

**1. The over-commitment hypothesis in the ticket is REFUTED.** I proposed the
bot was offering beyond its wallet and Kickbase was dropping unfunded offers.
The data says no:

| batch (UTC) | offers outstanding | budget then | over-committed? |
| -- | --: | --: | -- |
| 2026-08-21 20:00 | 18,936,941 | 80,035,167 | no |
| 2026-08-22 08:00 | 32,327,907 | 85,162,497 | no |

Budget was 2.6-4.5x the outstanding offers. Whoever picks this up should not
spend time there.

**2. A better lead: `get_my_bids` has no dedicated endpoint.**

```python
# kickbase_client.py
all_market = self.get_market(league_id)
return [p for p in all_market if p.has_user_offer()]
```

It derives active bids from the **current market listing**. A player who leaves
that listing for *any* reason — sold, listing expired, relisted, a partial
fetch — disappears from `active_bid_ids`, and `resolve_auctions` calls it
"lost". So one boolean is conflating at least three different outcomes:
genuinely outbid, listing expired unsold, and our offer was dropped.

The batch shape in the data fits: 2 losses at exactly 20:00, then 3 at exactly
08:00, all lost. That is the shape of a mis-read, not three independent
auction defeats.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (adds the anomaly reader)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code quality improvement

## Testing

- [x] I have run the test suite locally (`pytest`)
- [x] I have added new tests for my changes
- [x] All tests pass
- [x] I have tested this manually

```
$ uv run pytest -q
1235 passed, 1 skipped in 4.11s     # +9 from this branch
```

9 new tests covering: the anomaly is reported; a genuine outbid (Kimmich,
outbid by EUR 4.55m) is not; a win is not; an unattributed loss is not; an
equal bid is not; ordering is worst-margin-first; the warning fires; a genuine
outbid stays silent; and `resolve_auction_winners` still returns its filled
count unchanged.

Manual verification against real prod `bid_learning.db`: 3 rows, EUR 3,590,380
total, matching the table above exactly.

## Code Quality

- [x] Style guidelines (Black, Ruff)
- [x] `pre-commit` passes
- [x] Docstrings added
- [x] Documentation updated

## Related Issues

Related to REH-102 — https://linear.app/jovily/issue/REH-102

Conversion metrics quoted in that ticket are understated until REH-103 (#86)
lands — Raum is a win that never reached `auction_outcomes`.

## Additional Notes

Independent of #85 and #86; branches off `main` and touches a different region
of `bid_learner.py` than #86 does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
