### PR TITLE
fix(scoring): treat Kickbase status 1 as out, not fully fit (REH-105)

### DIFF
--- a/rehoboam/kickbase_client.py
+++ b/rehoboam/kickbase_client.py
@@ -509,7 +509,7 @@ class KickbaseV4Client:
         Returns:
             dict with:
             - Team info: tid, tn (team name)
-            - Status: st (0=healthy, 2/4/256=injured/unavailable)
+            - Status: st (0=healthy, 1/2/4/256=injured/unavailable; 1 = out for weeks)
             - Lineup probability: prob (1=starter, 2-4=rotation, 5=unlikely)
             - Matchups: mdsum (past, current, future matches)
             - Performance: ph (recent match points)

--- a/rehoboam/matchup_analyzer.py
+++ b/rehoboam/matchup_analyzer.py
@@ -11,7 +11,7 @@ class PlayerStatus:
     is_healthy: bool
     is_likely_starter: bool
     lineup_probability: int  # 1-5 (1=starter, 5=unlikely)
-    status_code: int  # 0=healthy, 2/4/256=injured/unavailable
+    status_code: int  # 0=healthy, 1/2/4/256=injured/unavailable
     reason: str
 
 

--- a/rehoboam/scoring/v2/availability.py
+++ b/rehoboam/scoring/v2/availability.py
@@ -37,12 +37,31 @@ DEFAULT_SHRINKAGE_K = 20.0
 # be fitted alongside the transitions above. It is applied here at serving
 # time, explicitly unfitted, and kept separate from the fitted model.
 #
-# 0 = healthy, 2 = uncertain, 4 = short-term injury, 256 = long-term injury
-# (kickbase_client.py:488, scorer.py:424). v1 applied -30/-20/-10 point
-# penalties for these; the v2 migration dropped the signal entirely, which is
-# how a long-term-injured player came to be scored 47.2 EP and named in the
-# starting eleven on 2026-08-22.
-OUT_STATUSES: frozenset[int] = frozenset({4, 256})
+# CAREFUL -- two different integer namespaces meet in this module, and they
+# collide. `live_status` below is Kickbase's *injury* flag; the keys of the
+# probability dicts everywhere else are the fitted model's *played-status*
+# codes documented at the top of this file. Both use small ints, and they do
+# not agree: live 1 = injured, played 1 = not in squad; live 4 = injury,
+# played 4 = unused sub. Read every bare integer here as one or the other,
+# never as both.
+#
+# Kickbase live injury statuses, verified against `stxt` on the live market
+# 2026-08-28:
+#   0   = healthy
+#   1   = injured, out for weeks   ("Ankle injury - out for several weeks")
+#   2   = uncertain                ("doubtful for SGE (H) match")
+#   4   = short-term injury
+#   256 = long-term injury
+#
+# v1 applied -30/-20/-10 point penalties for these; the v2 migration dropped
+# the signal entirely, which is how a long-term-injured player came to be
+# scored 47.2 EP and named in the starting eleven on 2026-08-22.
+#
+# REH-105: status 1 was missing from both sets, so the most severely injured
+# code in the enumeration was the one scored as fully fit. It reached rank 1
+# on the live buy board on 2026-08-28. The omission is almost certainly the
+# namespace collision above -- 1 already means something else in this file.
+OUT_STATUSES: frozenset[int] = frozenset({1, 4, 256})
 UNCERTAIN_STATUSES: frozenset[int] = frozenset({2})
 DEFAULT_UNCERTAIN_START_MULTIPLIER = 0.5
 

--- a/tests/test_scoring_v2/test_availability_override.py
+++ b/tests/test_scoring_v2/test_availability_override.py
@@ -12,8 +12,14 @@ starter's mean and only stays calibrated because P(5) is the fitted ~82%
 rather than 100%. Forcing probability DOWNWARD drives EP toward zero and
 cannot inflate anything, so these overrides are downward-only by construction.
 
-Status codes (kickbase_client.py:488, scorer.py:424):
-    0 = healthy, 2 = uncertain, 4 = short-term injury, 256 = long-term injury
+Kickbase live injury status codes, verified against `stxt` on the live market
+2026-08-28:
+    0 = healthy, 1 = injured (out for weeks), 2 = uncertain,
+    4 = short-term injury, 256 = long-term injury
+
+Note these are NOT the played-status codes the probability dicts are keyed by
+(1 = not in squad, 3 = came on, 4 = unused sub, 5 = started). The two
+namespaces collide on 1 and 4; see the comment in availability.py.
 
 The v1 scorer applied -30/-20/-10 point penalties for these. v2 dropped the
 signal entirely, which is how a long-term-injured player came to be scored 47.2
@@ -40,6 +46,18 @@ class TestInjuryForcesDidNotPlay:
     def test_short_term_injury_removes_it_too(self):
         out = apply_availability_override(_even_probs(), live_status=4)
         assert out[5] == pytest.approx(0.0)
+
+    def test_out_for_weeks_injury_removes_it_too(self):
+        """Gantenbein: status 1, "Ankle injury - out for several weeks".
+
+        Returned as the #1 buy recommendation in the live 2026-08-28 session,
+        priced at a EUR 1,163,017 bid with a sell plan attached, because
+        status 1 was in neither override set and so scored as fully fit
+        (REH-105).
+        """
+        out = apply_availability_override(_even_probs(), live_status=1)
+        assert out[5] == pytest.approx(0.0)
+        assert out[1] == pytest.approx(1.0)
 
 
 class TestUncertainIsReducedNotBlocked:
@@ -77,14 +95,14 @@ class TestHealthyAndUnknownAreUntouched:
 
 
 class TestInvariants:
-    @pytest.mark.parametrize("status", [None, 0, 2, 4, 256, 9999])
+    @pytest.mark.parametrize("status", [None, 0, 1, 2, 4, 256, 9999])
     def test_the_override_never_raises_the_start_probability(self, status):
         """Downward-only. Raising P(start) would expose rate.py's ~24% overshoot."""
         before = _even_probs()
         after = apply_availability_override(before, live_status=status)
         assert after[5] <= before[5] + 1e-9
 
-    @pytest.mark.parametrize("status", [None, 0, 2, 4, 256, 9999])
+    @pytest.mark.parametrize("status", [None, 0, 1, 2, 4, 256, 9999])
     def test_probabilities_still_sum_to_one(self, status):
         after = apply_availability_override(_even_probs(), live_status=status)
         assert sum(after.values()) == pytest.approx(1.0)


### PR DESCRIPTION
## The defect

`OUT_STATUSES` was `{4, 256}`. Kickbase status **`1`** — "Ankle injury - out for several weeks", "sidelined for 2-3 weeks" — was in neither the out set nor the uncertain set, so the most severely injured code in the enumeration was the one scored as **fully available**.

```diff
-OUT_STATUSES: frozenset[int] = frozenset({4, 256})
+OUT_STATUSES: frozenset[int] = frozenset({1, 4, 256})
```

## What it cost, live

Prod run 2026-08-28 08:00 (`func-rehoboam`). Both `st=1` players came back as buy recommendations **with live bids and sell plans attached**:

```
BUY Gantenbein (Defender) price=1053017 EP=44.3 marginal=+29.1   <-- rank 1
  + sell Chandler for ~EUR 2362092 (EP=15.0)
BUY Omari      (Defender) price=3200088 EP=40.6 marginal=+4.6    <-- rank 5
  + sell Chandler for ~EUR 2362092 (EP=15.0)
```

Only the locked matchday phase stopped the bids going out. 3 of 43 market listings carried `st=1`.

## Why nothing else caught it

The second guard is also down: `MAX_LINEUP_PROB_FOR_BUY = 3` would have rejected all three (`prob=5`, "unlikely to start"), but `score_player_v2` hardcodes `lineup_probability=None`, so the filter cannot fire. That's REH-92, unchanged here — but it means there was no availability guard left on the buy path at all.

## Root cause: a namespace collision

This module uses `1` and `4` as *played-status* codes (not in squad / unused sub) with different meanings from the *live injury* codes the override reads. Same small integers, one file, no type distinction. The comment block now says so explicitly — that's what the next reader needs in order not to repeat it.

## Verification

| Gate | Result |
|---|---|
| RED first | Failed with `Obtained: 0.8` — injured player kept full start probability |
| Full suite | **1325 passed**, 1 skipped |
| ruff / black / bandit / pre-commit | all passed |
| mypy | 36 errors, **identical to baseline** (pre-existing, `config.py`) |
| Season replay | 27,751 both sides — **predicted null**, see below |
| Live smoke vs prod | Gantenbein and Omari **gone** from the buy board |

**On the replay:** `compose_ep` takes `live_status=None` in replay because Kickbase publishes no historical injury flags, so this change is invisible to that instrument *by construction*. Ran it stash-and-rerun anyway; an unchanged number confirms the fitted path was not touched. It is not a pass.

**The evidence that counts** is the live smoke. `ep_floor` skips went **7 → 9** — the injured pair weren't hard-filtered, their EP collapsed below `min_ep=35.0` once `P(start)` was zeroed, and the existing threshold did the rejecting. Kabak (+45.1) and Simpson-Pusey (+27.5) surfaced into the top 10 in their place. Lineup still fills 11/11.

## Deliberately not changed

- **Unknown codes still fail open** (`live_status=9999` → unchanged). That's a documented decision with a test behind it; an allow-list would reverse it and belongs in its own ticket.
- **`st=2` still only halves `P(start)`**, though its `stxt` often reads "misses [the next] match" outright. Tuning question needing measurement.

Closes REH-105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EA4tBxaBhK4DjMpcYVsPvf