### PR TITLE
fix(notify): put Approve buttons on the message that actually arrives (REH-106)

### DIFF
--- a/deploy/azure_function/function_app.py
+++ b/deploy/azure_function/function_app.py
@@ -121,7 +121,13 @@ def _send_daily_summary(api, league, settings, session):
         watch.append(f"{len(at_limit)} club(s) at the {MAX_PLAYERS_PER_CLUB}-player limit")
 
     learner = BidLearner()
-    pending = [(p["player_name"], int(p["bid"])) for p in learner.pending_proposals()]
+    # Keep the raw rows: the rendered summary needs name+bid, but the Telegram
+    # keyboard needs the proposal_id. REH-106 — without the id the summary said
+    # "approve <name>" and offered no way to do it, so proposals sat at
+    # `pending` until a rival bought the player.
+    pending_rows = learner.pending_proposals()
+    pending = [(p["player_name"], int(p["bid"])) for p in pending_rows]
+    approvals = [(p["proposal_id"], p["player_name"]) for p in pending_rows]
 
     executed = [
         f"{r.action} {r.player_name} for EUR {r.price:,}"
@@ -168,7 +174,12 @@ def _send_daily_summary(api, league, settings, session):
     # costs nothing, and needs no mail provider. Proton — the alternative that
     # was considered — requires a paid plan plus a custom domain, and Proton
     # Bridge binds to localhost, which an Azure Function can never reach.
-    if not send_message(settings.telegram_bot_token, settings.telegram_chat_id, header + body):
+    if not send_message(
+        settings.telegram_bot_token,
+        settings.telegram_chat_id,
+        header + body,
+        approvals=approvals,
+    ):
         logging.warning("daily summary: telegram delivery failed or not configured")
 
     # Email stays available for anyone who configures SMTP; absent config makes

--- a/rehoboam/auto_trader.py
+++ b/rehoboam/auto_trader.py
@@ -489,17 +489,29 @@ class AutoTrader:
             logger.exception("proposal: could not record %s", proposal_id)
             return False
 
-        send_proposal(
+        # The return value is worth logging: a proposal that fails to send is
+        # recorded but invisible, and the only way to act on it is the daily
+        # summary's keyboard (REH-106). Silence here made a delivery failure
+        # look identical to a proposal nobody chose to approve.
+        delivered = send_proposal(
             self.settings.telegram_bot_token,
             self.settings.telegram_chat_id,
             proposal_id,
             message,
         )
+        if not delivered:
+            logger.warning(
+                "proposal %s for %s was recorded but NOT delivered to Telegram; "
+                "it is actionable only from the daily summary",
+                proposal_id,
+                player.id,
+            )
         logger.info(
-            "proposal recorded id=%s player=%s bid=%d",
+            "proposal recorded id=%s player=%s bid=%d delivered=%s",
             proposal_id,
             player.id,
             int(rec.recommended_bid),
+            delivered,
         )
         return True
 

--- a/rehoboam/notify/telegram.py
+++ b/rehoboam/notify/telegram.py
@@ -18,6 +18,11 @@ _API = "https://api.telegram.org/bot{token}/sendMessage"
 # Telegram rejects anything longer than this in a single message.
 MAX_MESSAGE_CHARS = 4096
 
+# Most Approve/Reject rows to put on one summary. Nothing reaps a stale
+# proposal yet (REH-108), so the pending queue grows without bound; a wall of
+# buttons is unusable and risks Telegram refusing the markup outright.
+MAX_APPROVAL_BUTTONS = 8
+
 
 def _post(token: str, payload: dict, what: str, timeout: float) -> bool:
     """One sendMessage call. False on any failure — never raises."""
@@ -57,22 +62,94 @@ def _chunks(text: str, limit: int = MAX_MESSAGE_CHARS) -> list[str]:
     return out
 
 
-def send_message(token: str, chat_id: str, text: str, *, timeout: float = 10.0) -> bool:
-    """Send plain text with no buttons. True only if every part was accepted.
+def _approval_row(proposal_id: str, approve_label: str, reject_label: str) -> list[dict]:
+    """The one place the callback-data format is defined.
+
+    ``approve:<id>`` / ``reject:<id>`` is what `notify.approval.handle_callback`
+    parses. The id is what makes a callback idempotent — the handler claims the
+    proposal before doing anything expensive, so a replay is safe.
+    """
+    return [
+        {"text": approve_label, "callback_data": f"approve:{proposal_id}"},
+        {"text": reject_label, "callback_data": f"reject:{proposal_id}"},
+    ]
+
+
+def approval_keyboard(approvals: list[tuple[str, str]]) -> dict:
+    """One Approve/Reject row per pending proposal, labelled by player."""
+    return {
+        "inline_keyboard": [
+            _approval_row(pid, f"\u2705 {name}", f"\u274c {name}")
+            # Keep the TAIL, not the head. `pending_proposals()` is
+            # oldest-first, and measured poach latency is hours (Ndiaye 2h48m,
+            # Awortwie-Grant 8h30m on 2026-08-26), so an old pending proposal
+            # is almost certainly dead while a fresh one is still winnable.
+            for pid, name in approvals[-MAX_APPROVAL_BUTTONS:]
+        ]
+    }
+
+
+def _send_chunked(
+    token: str,
+    chat_id: str,
+    text: str,
+    *,
+    keyboard: dict | None,
+    what: str,
+    timeout: float,
+) -> bool:
+    """Send `text` in Telegram-sized parts, `keyboard` on the last part only.
+
+    Both senders go through here. `send_proposal` used to post in one shot, so
+    a proposal over the cap was refused with a 400 and never arrived — the
+    decision existed only as a `trade_proposals` row nobody could see.
+
+    Last chunk only: a keyboard repeated on every part makes one proposal
+    tappable from several messages, and every tap after the first returns
+    "already <status>", which reads as a broken button.
+    """
+    parts = _chunks(text)
+    ok = True
+    for i, part in enumerate(parts):
+        payload: dict = {"chat_id": chat_id, "text": part}
+        if keyboard and i == len(parts) - 1:
+            payload["reply_markup"] = keyboard
+        ok = _post(token, payload, what, timeout) and ok
+    return ok
+
+
+def send_message(
+    token: str,
+    chat_id: str,
+    text: str,
+    *,
+    approvals: list[tuple[str, str]] | None = None,
+    timeout: float = 10.0,
+) -> bool:
+    """Send text, optionally with Approve/Reject buttons. True if all accepted.
 
     Carries the daily summary. That started as an SMTP email, but Proton needs
     a paid plan plus a custom domain, and Proton Bridge binds to localhost so
     an Azure Function can never reach it — the summary reuses the channel that
     is already configured and verified.
+
+    ``approvals`` is ``[(proposal_id, player_name)]``, oldest first. REH-106:
+    without it the summary named what was awaiting approval and offered no way
+    to approve it, so proposals sat at `pending` until a rival bought the
+    player — indistinguishable, from the reader's side, from a dead webhook.
     """
     if not token or not chat_id:
         logger.info("telegram: no token or chat id configured — not sending")
         return False
 
-    ok = True
-    for part in _chunks(text):
-        ok = _post(token, {"chat_id": chat_id, "text": part}, "daily summary", timeout) and ok
-    return ok
+    return _send_chunked(
+        token,
+        chat_id,
+        text,
+        keyboard=approval_keyboard(approvals) if approvals else None,
+        what="daily summary",
+        timeout=timeout,
+    )
 
 
 def send_proposal(
@@ -87,21 +164,20 @@ def send_proposal(
 
     The buttons carry ``approve:<id>`` / ``reject:<id>`` as callback data, which
     is what the webhook parses. The id is what makes the callback idempotent.
+
+    The player's name is in the rendered text directly above, so the buttons
+    are labelled by action rather than by name — unlike the summary keyboard,
+    which lists several proposals at once and needs the name to disambiguate.
     """
     if not token or not chat_id:
         logger.info("telegram: no token or chat id configured — not sending")
         return False
 
-    payload = {
-        "chat_id": chat_id,
-        "text": text,
-        "reply_markup": {
-            "inline_keyboard": [
-                [
-                    {"text": "✅ Approve", "callback_data": f"approve:{proposal_id}"},
-                    {"text": "❌ Reject", "callback_data": f"reject:{proposal_id}"},
-                ]
-            ]
-        },
-    }
-    return _post(token, payload, f"proposal {proposal_id}", timeout)
+    return _send_chunked(
+        token,
+        chat_id,
+        text,
+        keyboard={"inline_keyboard": [_approval_row(proposal_id, "✅ Approve", "❌ Reject")]},
+        what=f"proposal {proposal_id}",
+        timeout=timeout,
+    )

--- a/tests/test_proposal_store.py
+++ b/tests/test_proposal_store.py
@@ -86,3 +86,44 @@ class TestListing:
         _record(learner, "p2")
         learner.mark_proposal("p2", "approved")
         assert [p["proposal_id"] for p in learner.pending_proposals()] == ["p1"]
+
+
+class TestTheSummaryCanBuildButtonsFromWhatIsStored:
+    """REH-106: the daily summary's keyboard is built in `function_app.py`,
+    which has no test coverage of its own. These pin the seam it depends on.
+
+    The summary reads `pending_proposals()` and turns each row into an
+    Approve/Reject button. If the columns it indexes ever move, the summary
+    breaks in production and the only symptom is proposals sitting at
+    `pending` forever — exactly the failure this ticket fixed.
+    """
+
+    def test_a_pending_row_carries_the_id_and_name_the_keyboard_needs(self, learner):
+        _record(learner)
+        (row,) = learner.pending_proposals()
+        # The exact expressions in _send_daily_summary.
+        assert (row["proposal_id"], row["player_name"]) == ("p1", "Pavlović")
+        assert (row["player_name"], int(row["bid"])) == ("Pavlović", 32_608_485)
+
+    def test_those_rows_produce_callbacks_the_webhook_parses(self, learner):
+        from rehoboam.notify.telegram import approval_keyboard
+
+        _record(learner, pid="abc123")
+        approvals = [(p["proposal_id"], p["player_name"]) for p in learner.pending_proposals()]
+        data = [
+            b["callback_data"]
+            for row in approval_keyboard(approvals)["inline_keyboard"]
+            for b in row
+        ]
+        # `handle_callback` does data.partition(":") and looks the id up.
+        assert data == ["approve:abc123", "reject:abc123"]
+        action, _, pid = data[0].partition(":")
+        assert action == "approve"
+        assert learner.get_proposal(pid) is not None
+
+    def test_a_resolved_proposal_gets_no_button(self, learner):
+        """A button for something already executed would return
+        "already executed" and read as a broken webhook."""
+        _record(learner)
+        learner.mark_proposal("p1", "approved")
+        assert learner.pending_proposals() == []

--- a/tests/test_telegram_notifier.py
+++ b/tests/test_telegram_notifier.py
@@ -7,7 +7,7 @@ best-effort pattern. These tests pin that a dead Telegram is survivable.
 import logging
 from unittest.mock import MagicMock, patch
 
-from rehoboam.notify.telegram import send_message, send_proposal
+from rehoboam.notify.telegram import MAX_APPROVAL_BUTTONS, send_message, send_proposal
 
 
 class TestSuccess:
@@ -80,6 +80,64 @@ class TestPlainMessages:
             assert send_message("T", "C", "hello") is False
 
 
+class TestApprovalButtonsOnTheSummary:
+    """REH-106: the message Marco actually reads each morning had no button.
+
+    `send_proposal` carries buttons, but it fires once, at proposal creation.
+    The daily summary — the message that arrives every day and lists what is
+    awaiting approval — went out as plain text reading "approve <name>" with
+    no way to do it. On locked matchdays no new proposal is created at all, so
+    days passed with only button-less summaries. Proposals sat at `pending`
+    while rivals bought the players out from under them.
+    """
+
+    def test_pending_proposals_become_approve_and_reject_buttons(self):
+        with patch("rehoboam.notify.telegram.requests.post") as post:
+            post.return_value = MagicMock(status_code=200)
+            send_message("T", "C", "summary", approvals=[("p1", "Okpala")])
+        markup = post.call_args[1]["json"]["reply_markup"]
+        data = [b["callback_data"] for row in markup["inline_keyboard"] for b in row]
+        assert "approve:p1" in data
+        assert "reject:p1" in data
+
+    def test_the_buttons_ride_on_the_last_chunk_only(self):
+        """A split summary must not repeat the keyboard on every part.
+
+        Duplicated keyboards mean the same proposal is tappable from several
+        messages; the second tap gets "already <status>" and reads as a bug.
+        The buttons belong on the message that ends the summary.
+        """
+        text = "\n".join(f"line {i} " + "x" * 80 for i in range(200))
+        with patch("rehoboam.notify.telegram.requests.post") as post:
+            post.return_value = MagicMock(status_code=200)
+            send_message("T", "C", text, approvals=[("p1", "Okpala")])
+        payloads = [c[1]["json"] for c in post.call_args_list]
+        assert len(payloads) > 1
+        assert all("reply_markup" not in p for p in payloads[:-1])
+        assert "reply_markup" in payloads[-1]
+
+    def test_a_long_pending_queue_keeps_the_newest_proposals(self):
+        """Nothing reaps a stale proposal yet (REH-108), so the queue grows.
+
+        A wall of buttons is unusable and risks Telegram refusing the markup
+        outright. Which end to drop is a domain call, not a formatting one:
+        measured poach latency is hours (Ndiaye 2h48m, Awortwie-Grant 8h30m),
+        so an old pending proposal is almost certainly dead while a fresh one
+        is still winnable. `pending_proposals()` is oldest-first, so the cap
+        keeps the tail.
+        """
+        approvals = [(f"p{i}", f"Player{i}") for i in range(25)]
+        with patch("rehoboam.notify.telegram.requests.post") as post:
+            post.return_value = MagicMock(status_code=200)
+            send_message("T", "C", "summary", approvals=approvals)
+        markup = post.call_args[1]["json"]["reply_markup"]
+        rows = markup["inline_keyboard"]
+        assert len(rows) == MAX_APPROVAL_BUTTONS
+        data = [b["callback_data"] for row in rows for b in row]
+        assert "approve:p24" in data, "newest proposal must be actionable"
+        assert "approve:p0" not in data, "oldest is dropped, not the newest"
+
+
 class TestLongMessagesAreSplit:
     """Telegram rejects anything over 4096 characters.
 
@@ -103,6 +161,24 @@ class TestLongMessagesAreSplit:
             post.return_value = MagicMock(status_code=200)
             send_message("T", "C", "short")
         assert post.call_count == 1
+
+    def test_a_long_proposal_is_split_and_still_carries_its_buttons(self):
+        """`send_proposal` never chunked, unlike `send_message`.
+
+        Telegram rejects a message over the cap with a 400, so an oversized
+        proposal was never delivered at all — the decision existed only as a
+        row in `trade_proposals` that nobody could see or approve. Only a
+        `logger.warning` recorded it.
+        """
+        text = "\n".join(f"line {i} " + "x" * 80 for i in range(200))
+        with patch("rehoboam.notify.telegram.requests.post") as post:
+            post.return_value = MagicMock(status_code=200)
+            assert send_proposal("T", "C", "p1", text) is True
+        payloads = [c[1]["json"] for c in post.call_args_list]
+        assert len(payloads) > 1
+        assert all(len(p["text"]) <= 4096 for p in payloads)
+        assert "reply_markup" in payloads[-1], "the tap target must survive splitting"
+        assert all("reply_markup" not in p for p in payloads[:-1])
 
     def test_one_failed_chunk_makes_the_whole_send_false(self):
         text = "\n".join("y" * 200 for _ in range(60))


### PR DESCRIPTION
## Reported as "the webhook is no longer working"

It wasn't. The webhook was healthy end-to-end — verified in prod: `08:09:24 → HTTP 200 → correct answer → 274ms`, `getWebhookInfo` clean with no `last_error` ever recorded. The approval **loop** had the hole.

Two Telegram senders existed:

| Sender | Buttons? | Fires when |
|---|---|---|
| `send_proposal` | **yes** | once, at proposal creation |
| `send_message` (daily summary) | **no** | every morning |

So the message that arrives every day rendered:

```
NEEDS YOU (2)
  approve Okpala          EUR    2,087,829
  approve Awortwie-Grant  EUR      584,877
```

as plain text — instructing an action it provided no means to perform. And because `_get_matchday_phase` returns `locked` at 0-1 days to match and `run_full_session` exits at Step 3, both 08-27 and 08-28 created no proposal at all: no button-bearing message since **08-26**, while button-less "2 awaiting approval" summaries kept arriving.

Both stuck proposals are still `pending`, which is *positive proof* no callback ever ran — `handle_callback` claims `approved` before doing anything expensive, so any tap that reached it would have moved the row.

## Changes

- **`send_message` takes `approvals=[(proposal_id, player_name)]`** and attaches an Approve/Reject keyboard. Same `approve:<id>` / `reject:<id>` callback data the webhook already parses — no handler change.
- **Buttons ride the last chunk only.** A keyboard repeated on every part makes one proposal tappable from several messages, and every tap after the first returns "already \<status\>" — which reads as a broken button.
- **`send_proposal` now chunks too.** It posted in one shot, so a proposal over 4096 chars was refused with a 400 and never arrived — the decision existed only as a `trade_proposals` row nobody could see. Both senders now share `_send_chunked`; `_approval_row` is the single definition of the callback-data format.
- **Keyboard caps at 8, keeping the *tail*.** Nothing reaps a stale proposal yet (REH-108) so the queue grows unbounded. Which end to drop is a domain call: measured poach latency is hours (Ndiaye 2h48m, Awortwie-Grant 8h30m), so an old pending proposal is almost certainly dead while a fresh one is still winnable. `pending_proposals()` is oldest-first.
- **`_propose_buy` stops discarding `send_proposal`'s return value.** Silence made a delivery failure look identical to a proposal nobody approved.

## Verification

TDD throughout — 4 RED tests watched fail first:
1. `TypeError: unexpected keyword argument 'approvals'`
2. keyboard attached to every chunk, not just the last
3. uncapped queue dropped the *newest* proposals
4. `assert 1 > 1` — the unchunked proposal

Then: **1332 pass**, 1 skipped; ruff/black/bandit clean.

**Against real prod data** — the keyboard build was run over the actual `bid_learning.db`, producing `approve:ad42a49ed5c4` (Awortwie-Grant) and `approve:2e6e0fa60c0e` (Okpala) with correct labels.

**Live smoke against the real Telegram API** — this changes the API payload shape, which mocked tests cannot validate (a malformed `reply_markup` returns 400 and the message silently doesn't arrive — the same class of failure as the bug being fixed). Telegram accepted the keyboard: `True`. Safety-checked first: neither player is currently listed, so an Approve tap can only return "no longer on the market".

Replay gate is not applicable — this is a notification change, not a scoring or decision one.

## Caveats

- `function_app.py` has no test coverage, so the seam it depends on is pinned in `test_proposal_store.py` instead. Those three are **characterization tests of an existing contract, not TDD-driven** — they passed on first run by design.
- The summary lists every pending proposal in text but only the newest 8 get buttons. Moot at the current queue depth of 2; REH-108 (expiry) is the real fix for a long queue.

Closes REH-106.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EA4tBxaBhK4DjMpcYVsPvf