### PR TITLE
fix(pacing): the reserve must leave one move spendable (REH-107)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,6 +81,14 @@ PACING_IN_SEASON_MIN_MOVES=2
 PACING_WINDOW_DAYS=90
 # Floor under the measured median move price (in EUR).
 PACING_MEDIAN_FLOOR_EUR=3000000
+# REH-101: hard ceiling on the reserve as a fraction of current budget, so it
+# can never demand more capital than the bot owns. 1.0 reproduces REH-85's
+# unbounded reserve; 0.0 disables the reserve entirely.
+PACING_MAX_RESERVE_FRACTION=0.5
+# REH-107: moves of typical size the reserve must always leave affordable. A
+# reserve exists to keep FUTURE moves possible; one that blocks the PRESENT
+# move funds nothing. 0.0 reproduces REH-101's behaviour.
+PACING_MIN_SPENDABLE_MOVES=1.0
 
 # --- Deployed behaviour (REH-100) ------------------------------------------
 # What the AZURE FUNCTION should do. Deliberately separate from DRY_RUN above,

--- a/docs/superpowers/specs/2026-08-28-reh-107-spendable-floor-results.md
+++ b/docs/superpowers/specs/2026-08-28-reh-107-spendable-floor-results.md
@@ -1,0 +1,116 @@
+# The reserve must leave one move spendable (REH-107): measured results
+
+Date: 2026-08-28
+Ticket: https://linear.app/jovily/issue/REH-107
+Follows: REH-85 (the reserve), REH-101 (bounding it by budget)
+Prior results: `docs/superpowers/specs/2026-08-26-reh-85-capital-pacing-results.md`
+
+## Verdict up front
+
+Ship at `pacing_min_spendable_moves=1.0`. It is **exactly neutral in the
+replay** (25,000 both sides) and repairs the live position, which is the
+regime the replay does not cover. A larger floor measures +309 points, which
+is below this instrument's noise floor and has no principled justification —
+recorded below, not shipped.
+
+## What was wrong
+
+REH-101 bounded the reserve by `budget * max_reserve_fraction`. Necessary — an
+unbounded reserve demanded more than the wallet held and refused every buy.
+But the bounded figure stops representing a whole number of moves. Live on
+2026-08-28:
+
+```
+reserve = min(2 moves x EUR 12.5m, 0.5 x EUR 21,720,227) = EUR 10,860,113
+```
+
+EUR 10.86m held back to fund "2 further moves" at a EUR 12.5m median — **0.87
+of one move**. It bought nothing later while blocking every upgrade above it.
+The session placed `bid=0` on the five highest-EP players on the board;
+Engelhardt (+45.0 EP) missed the cap by EUR 134,301.
+
+## The fix, and the shape it is deliberately NOT
+
+A third bound: `reserve <= budget - min_spendable_moves * median_move`.
+Whatever else it protects, the reserve must leave one typical move affordable.
+
+The ticket originally proposed flooring to whole moves,
+`floor(affordable / median) * median`. **That was wrong and was not
+implemented.** It restores the "whole number of moves" meaning but makes
+headroom a sawtooth in budget: crossing a move boundary drops the maximum bid
+by a full median, so gaining budget can shrink what the bot may bid. That is
+precisely the pathology REH-101 exists to prevent, and it is pinned by
+`TestRaisingCashIsStillNeverPunished` — a monotonicity sweep from EUR 5m to
+EUR 60m that the sawtooth form fails.
+
+## Where this fix operates
+
+At `max_reserve_fraction=0.5` the new bound binds only when
+`budget < 2 x median_move`. That is computable in advance, and it says the
+replay cannot see the shipped default:
+
+| position             |    budget |    median | binds below | binds?  |
+| -------------------- | --------: | --------: | ----------: | ------- |
+| replay, season start |  ~EUR 80m |  EUR 6.6m |   EUR 13.2m | no      |
+| live, 2026-08-28     | EUR 21.7m | EUR 12.5m |   EUR 25.0m | **yes** |
+
+The null replay result below was therefore **predicted before the sweep ran**,
+not discovered in it. Same discipline as REH-98 and REH-105.
+
+## The sweep
+
+All runs `uv run rehoboam replay-season --with-competition`, same local
+`logs/training_corpus.db` / `logs/bid_learning.db`, matching REH-85's method.
+
+| configuration                 |     points | vs main | buys | finish   |
+| ----------------------------- | ---------: | ------: | ---: | -------- |
+| `--no-pacing`                 |     24,141 |    -859 |    3 | 11 of 14 |
+| `0.0` (= REH-101, main today) |     25,000 |       — |    3 | 10 of 14 |
+| **`1.0` (shipped default)**   | **25,000** |   **0** |    3 | 10 of 14 |
+| `2.0`                         |     25,309 |    +309 |    3 | 10 of 14 |
+| `3.0`                         |     25,309 |    +309 |    3 | 10 of 14 |
+| `5.0`                         |     25,309 |    +309 |    3 | 10 of 14 |
+| `8.0`                         |     25,309 |    +309 |    3 | 10 of 14 |
+
+Reading:
+
+- **The shipped default is a pure no-op here**, as predicted. The replay is a
+  regression check for this change, not a demonstration of it.
+- The +309 at 2.0 saturates immediately and identically through 8.0, i.e. the
+  reserve is already fully relieved by 2.0 wherever it mattered. It is not a
+  gradient anyone is climbing.
+- +309 is 1.2%. REH-71 records a single faithfulness decision worth 6,162
+  points on this instrument; a delta twenty times smaller is not a signal.
+- Buy count is 3 in every row. REH-85's own acceptance criterion — buy count
+  must rise — still fails, for the reason documented there: this replay never
+  reaches 15/15, and the constraint at season start is the fraction, not the
+  floor. REH-107 does not claim to fix that.
+
+## Live verification
+
+`rehoboam status`, 2026-08-28, against the real market:
+
+```
+pacing session median_move=12500000 slots_to_fill=3 reserve=9220227
+               budget=21720227 max_fraction=0.50 min_spendable_moves=1.00
+```
+
+Reserve EUR 10,860,113 -> EUR 9,220,227, so `pace_cap` becomes exactly one
+median move:
+
+| player      | EP gain |        ask | before            | after                 |
+| ----------- | ------: | ---------: | ----------------- | --------------------- |
+| Jóhannesson |   +51.1 | 10,008,196 | capped 10,860,114 | 11,848,196 (uncapped) |
+| Engelhardt  |   +35.3 | 10,994,415 | **bid=0**         | **12,394,415**        |
+| Reitz       |   +34.3 | 13,087,545 | bid=0             | bid=0                 |
+| Veerman     |   +33.0 | 18,543,633 | bid=0             | bid=0                 |
+
+Reitz and above stay refused, correctly: they cost more than one typical move
+against this budget, which is the rule doing its job rather than failing.
+
+## Open
+
+`min_spendable_moves` is a `Settings` field and a `replay-season` flag, so
+re-tuning needs no deploy. Worth revisiting on an instrument that reaches
+15/15 — REH-88 (replay is blind to trade pairs) and REH-68 (full-fidelity
+replay) are the blockers on measuring the reserve properly.

--- a/rehoboam/cli.py
+++ b/rehoboam/cli.py
@@ -783,6 +783,16 @@ def replay_season(
             "pacing_window_days Settings value; override to sweep the knob."
         ),
     ),
+    pacing_min_spendable_moves: float | None = typer.Option(
+        None,
+        "--pacing-min-spendable-moves",
+        help=(
+            "REH-107: moves of typical size the reserve must always leave "
+            "affordable. Defaults to the shipped pacing_min_spendable_moves "
+            "Settings value; 0.0 reproduces REH-101's behaviour, higher "
+            "values free up more budget per buy."
+        ),
+    ),
 ) -> None:
     """Replay the full bot across 2025/26 and report the counterfactual finish."""
     from rehoboam.replay.driver import run_replay
@@ -818,6 +828,7 @@ def replay_season(
         pacing_min_moves=pacing_min_moves,
         pacing_window_days=pacing_window_days,
         pacing_max_reserve_fraction=pacing_max_reserve_fraction,
+        pacing_min_spendable_moves=pacing_min_spendable_moves,
     )
     console.print(report)
 

--- a/rehoboam/config.py
+++ b/rehoboam/config.py
@@ -399,6 +399,18 @@ class Settings(BaseSettings):
             "unbounded REH-85 behaviour; 0.0 disables the reserve entirely."
         ),
     )
+    pacing_min_spendable_moves: float = Field(
+        default=1.0,
+        ge=0.0,
+        description=(
+            "REH-107: moves of typical size the reserve must always leave "
+            "affordable. Bounding the reserve by a fraction of budget (REH-101) "
+            "keeps it affordable but stops it meaning a whole number of moves: "
+            "live on 2026-08-28 it held EUR 10.86m for '2 further moves' at a "
+            "EUR 12.5m median — 0.87 of one — and refused every upgrade above "
+            "it while buying nothing later. 0.0 reproduces REH-101 exactly."
+        ),
+    )
     pacing_median_floor_eur: int = Field(
         default=3_000_000,
         ge=0,

--- a/rehoboam/replay/driver.py
+++ b/rehoboam/replay/driver.py
@@ -249,6 +249,7 @@ def run_replay(
     pacing_min_moves: int | None = None,
     pacing_window_days: int | None = None,
     pacing_max_reserve_fraction: float | None = None,
+    pacing_min_spendable_moves: float | None = None,
 ) -> tuple[SeasonResult, str]:
     """Replay the whole season and return the result plus a formatted report.
 
@@ -336,6 +337,11 @@ def run_replay(
                     pacing_max_reserve_fraction
                     if pacing_max_reserve_fraction is not None
                     else float(_shipped_default("pacing_max_reserve_fraction"))
+                ),
+                min_spendable_moves=(
+                    pacing_min_spendable_moves
+                    if pacing_min_spendable_moves is not None
+                    else float(_shipped_default("pacing_min_spendable_moves"))
                 ),
                 pacing_enabled=pacing_enabled,
             )
@@ -476,6 +482,11 @@ def make_ep_bid_fn(
     median_move_fn: Callable[[float], int],
     in_season_min_moves: int,
     max_reserve_fraction: float,
+    # Defaulted, unlike `max_reserve_fraction` above: omitting it yields the
+    # SHIPPED behaviour, not the REH-107 bug, so the "require it so a new call
+    # site cannot reintroduce the defect by omission" rule does not apply here.
+    # `run_replay` always passes it explicitly from the shipped setting.
+    min_spendable_moves: float = 1.0,
     pacing_enabled: bool = True,
 ) -> Callable[[str, int, float, float, int, int], int]:
     """Bid with the bot's own bidding strategy (REH-68).
@@ -549,6 +560,7 @@ def make_ep_bid_fn(
                 median_move=median_move_fn(at),
                 budget=budget,
                 max_reserve_fraction=max_reserve_fraction,
+                min_spendable_moves=min_spendable_moves,
             )
             pacing_ctx = PacingContext(reserve=reserve, open_offers=0)
         rec = bidding.calculate_ep_bid(

--- a/rehoboam/services/pacing.py
+++ b/rehoboam/services/pacing.py
@@ -63,6 +63,7 @@ def capital_reserve(
     median_move: int,
     budget: int,
     max_reserve_fraction: float,
+    min_spendable_moves: float = 1.0,
 ) -> int:
     """Euros that must survive this buy, so the bot can keep operating.
 
@@ -96,6 +97,26 @@ def capital_reserve(
     make the next buy *harder* — one more slot costs a full median of reserve
     while the sale raises less than that. Against a fraction of the budget,
     raising cash raises the ceiling instead of lowering it.
+
+    REH-107 adds the third bound, `min_spendable_moves`. Bounding by a fraction
+    of the budget keeps the reserve affordable but stops it representing a
+    whole number of moves: live on 2026-08-28 it was EUR 10.86m held back to
+    fund "2 further moves" at a measured median of EUR 12.5m — 0.87 of one. It
+    bought nothing later while blocking every upgrade above it, and the session
+    placed no bid at all on the five best players on the board. Engelhardt,
+    +45.0 EP, missed the cap by EUR 134,301.
+
+    So the reserve is additionally capped at `budget - min_spendable_moves *
+    median_move`: whatever else it protects, it must leave one typical move
+    affordable. `0.0` reproduces REH-101 exactly, for A/B and rollback.
+
+    Deliberately continuous in `budget`, not a step function on whole moves.
+    Flooring the bounded figure to `floor(affordable / median) * median` — the
+    shape this ticket was first written around — restores the "whole number of
+    moves" meaning but makes headroom a sawtooth: crossing a move boundary
+    drops the maximum bid by a full median, so gaining budget can shrink what
+    the bot may bid. That is precisely the pathology REH-101 exists to prevent,
+    and `TestRaisingCashIsStillNeverPunished` pins it.
     """
     # Account for this buy filling one slot: reserve is for moves remaining
     # after it lands. Full squad (slots <= 0) falls back to in_season_min_moves.
@@ -104,7 +125,14 @@ def capital_reserve(
     wanted = max(0, moves) * max(0, median_move)
 
     affordable = int(max(0, budget) * max(0.0, max_reserve_fraction))
-    return min(wanted, affordable)
+
+    # REH-107: never hold back so much that a move of typical size becomes
+    # unaffordable. A reserve exists to keep FUTURE moves possible; one that
+    # blocks the PRESENT move funds nothing and costs the best upgrade going.
+    spendable_floor = int(max(0.0, min_spendable_moves) * max(0, median_move))
+    leaves_one_move = max(0, int(max(0, budget)) - spendable_floor)
+
+    return min(wanted, affordable, leaves_one_move)
 
 
 @dataclass(frozen=True)

--- a/rehoboam/trader.py
+++ b/rehoboam/trader.py
@@ -240,16 +240,18 @@ class Trader:
         open_offers = sum(int(getattr(b, "user_offer_price", 0) or 0) for b in my_bids)
         slots_to_fill = available_squad_slots(squad_size, len(my_bids))
         max_reserve_fraction = float(getattr(self.settings, "pacing_max_reserve_fraction", 0.5))
+        min_spendable_moves = float(getattr(self.settings, "pacing_min_spendable_moves", 1.0))
         reserve = capital_reserve(
             slots_to_fill=slots_to_fill,
             in_season_min_moves=int(self.settings.pacing_in_season_min_moves),
             median_move=median_move,
             budget=int(current_budget),
             max_reserve_fraction=max_reserve_fraction,
+            min_spendable_moves=min_spendable_moves,
         )
         logger.info(
             "pacing session median_move=%d slots_to_fill=%d reserve=%d open_offers=%d "
-            "n_prices=%d budget=%d max_fraction=%.2f",
+            "n_prices=%d budget=%d max_fraction=%.2f min_spendable_moves=%.2f",
             median_move,
             slots_to_fill,
             reserve,
@@ -257,6 +259,7 @@ class Trader:
             len(prices),
             int(current_budget),
             max_reserve_fraction,
+            min_spendable_moves,
         )
         return PacingContext(reserve=reserve, open_offers=open_offers)
 

--- a/tests/test_pacing_bounded_reserve.py
+++ b/tests/test_pacing_bounded_reserve.py
@@ -52,13 +52,19 @@ class TestTheBoundBites:
         assert reserve == MEDIAN
 
     def test_fraction_of_one_reproduces_the_unbounded_reserve(self):
-        """The REH-85 arithmetic must remain reachable, for A/B and rollback."""
+        """The REH-85 arithmetic must remain reachable, for A/B and rollback.
+
+        REH-107 added a second bound (`min_spendable_moves`), so reaching the
+        unbounded arithmetic now means switching BOTH off. The intent is
+        unchanged — this is still the escape hatch back to REH-85.
+        """
         reserve = capital_reserve(
             slots_to_fill=LIVE_SLOTS,
             in_season_min_moves=2,
             median_move=MEDIAN,
             budget=LIVE_BUDGET,
             max_reserve_fraction=1.0,
+            min_spendable_moves=0.0,
         )
 
         assert reserve == 2 * MEDIAN
@@ -108,13 +114,14 @@ class TestRaisingCashMustNotMakeBuyingHarder:
     """
 
     @staticmethod
-    def _headroom(budget: int, slots: int, fraction: float) -> int:
+    def _headroom(budget: int, slots: int, fraction: float, spendable: float = 1.0) -> int:
         reserve = capital_reserve(
             slots_to_fill=slots,
             in_season_min_moves=2,
             median_move=MEDIAN,
             budget=budget,
             max_reserve_fraction=fraction,
+            min_spendable_moves=spendable,
         )
         return PacingContext(reserve=reserve, open_offers=0).max_bid(
             budget_ceiling=budget, current_budget=budget
@@ -131,12 +138,15 @@ class TestRaisingCashMustNotMakeBuyingHarder:
         )
 
     def test_the_unbounded_reserve_is_what_broke_this(self):
-        """Pins the regression: at fraction 1.0 the pathology is still there.
+        """Pins the regression: with BOTH bounds off the pathology is still there.
 
         Without this the suite could not tell a real fix from a coincidence.
+        REH-107's floor is a second bound, so reproducing the original
+        pathology now means switching it off too — otherwise the floor alone
+        repairs the case and this test passes for the wrong reason.
         """
-        before = self._headroom(LIVE_BUDGET, LIVE_SLOTS, 1.0)
-        after = self._headroom(LIVE_BUDGET + 5_000_000, LIVE_SLOTS + 1, 1.0)
+        before = self._headroom(LIVE_BUDGET, LIVE_SLOTS, 1.0, spendable=0.0)
+        after = self._headroom(LIVE_BUDGET + 5_000_000, LIVE_SLOTS + 1, 1.0, spendable=0.0)
 
         assert after < before
 

--- a/tests/test_pacing_spendable_floor.py
+++ b/tests/test_pacing_spendable_floor.py
@@ -1,0 +1,170 @@
+"""REH-107: a reserve must never block a move of typical size.
+
+REH-85 sized the reserve as `moves * median_move`. REH-101 bounded it by
+`budget * max_reserve_fraction`, because a reserve larger than the wallet
+refuses every buy instead of degrading. Correct, but the bounded figure stops
+representing a whole number of moves: at 0.5 of a EUR 21.72m budget it is
+EUR 10.86m held back to fund "2 further moves" at a measured median of
+EUR 12.5m — it funds 0.87 of one.
+
+So it buys nothing later while blocking the best upgrade available today. A
+reserve that exists to keep future moves possible must not make the present
+move impossible; that is the incoherence this floor removes.
+
+The bound is a THIRD term rather than a replacement, and it is deliberately
+continuous in budget: REH-101's acceptance criterion is that raising cash never
+reduces headroom, so a step function keyed on whole moves — the shape this
+ticket first sketched — would have reintroduced exactly the pathology it fixed.
+See TestRaisingCashIsStillNeverPunished below.
+"""
+
+import pytest
+
+from rehoboam.services.pacing import PacingContext, capital_reserve
+
+# The live position on 2026-08-28, which is what the ticket is measured against.
+LIVE_BUDGET = 21_720_227
+LIVE_SLOTS = 3
+LIVE_MEDIAN = 12_500_000
+
+# Engelhardt: +45.0 EP, the largest marginal gain on the board that morning.
+ENGELHARDT_ASK = 10_994_415
+
+
+def _reserve(budget=LIVE_BUDGET, slots=LIVE_SLOTS, median=LIVE_MEDIAN, fraction=0.5, **kw):
+    return capital_reserve(
+        slots_to_fill=slots,
+        in_season_min_moves=2,
+        median_move=median,
+        budget=budget,
+        max_reserve_fraction=fraction,
+        **kw,
+    )
+
+
+class TestTheReserveNeverBlocksATypicalMove:
+    def test_a_median_move_stays_affordable(self):
+        """The whole point: what is held back must not exceed what is spare."""
+        assert LIVE_BUDGET - _reserve() >= LIVE_MEDIAN
+
+    def test_the_live_case_unblocks_the_best_upgrade_on_the_board(self):
+        """Engelhardt missed the old cap by EUR 134,301 and got bid=0."""
+        headroom = LIVE_BUDGET - _reserve()
+        assert headroom >= ENGELHARDT_ASK
+
+    def test_a_budget_below_one_move_reserves_nothing(self):
+        """Nothing can be both held back and spent. Holding wins nothing."""
+        assert _reserve(budget=8_000_000) == 0
+
+    def test_a_rich_bot_is_unaffected_because_the_floor_never_binds(self):
+        """The floor is a relief valve, not a new cap on a healthy budget."""
+        assert _reserve(budget=200_000_000, slots=2) == LIVE_MEDIAN
+
+
+class TestTheFloorIsSwitchable:
+    def test_zero_reproduces_the_reh_101_behaviour_exactly(self):
+        """Rollback affordance, matching how every other pacing knob works."""
+        assert _reserve(min_spendable_moves=0.0) == int(LIVE_BUDGET * 0.5)
+
+    def test_a_larger_floor_holds_back_less(self):
+        """Monotone in the knob, so a sweep reads in one direction."""
+        assert _reserve(min_spendable_moves=2.0) < _reserve(min_spendable_moves=1.0)
+
+
+class TestRaisingCashIsStillNeverPunished:
+    """REH-101's acceptance criterion, re-run across the floor's boundary.
+
+    A step function on whole moves would pass the live case and break here:
+    crossing a move boundary would drop headroom by a full median.
+    """
+
+    @staticmethod
+    def _headroom(budget, slots):
+        return PacingContext(reserve=_reserve(budget=budget, slots=slots), open_offers=0).max_bid(
+            budget_ceiling=budget, current_budget=budget
+        )
+
+    @pytest.mark.parametrize("sale_price", [1, 500_000, 5_000_000, 12_500_000, 40_000_000])
+    def test_headroom_never_falls_after_a_sale(self, sale_price):
+        before = self._headroom(LIVE_BUDGET, LIVE_SLOTS)
+        after = self._headroom(LIVE_BUDGET + sale_price, LIVE_SLOTS + 1)
+        assert after >= before
+
+    @pytest.mark.parametrize("budget", range(5_000_000, 60_000_001, 2_500_000))
+    def test_headroom_is_monotonic_in_budget_across_the_boundary(self, budget):
+        """Swept right through the floor's cliff-risk region."""
+        assert self._headroom(budget + 1_000_000, LIVE_SLOTS) >= self._headroom(budget, LIVE_SLOTS)
+
+
+class TestTheKnobIsTunableFromTheEnvironment:
+    """Every pacing tunable is a Settings field, per REH-85/REH-99 convention:
+    re-tunable mid-season from .env without a deploy."""
+
+    def _settings(self, monkeypatch, **env):
+        monkeypatch.setenv("KICKBASE_EMAIL", "test@example.com")
+        monkeypatch.setenv("KICKBASE_PASSWORD", "test")
+        for k, v in env.items():
+            monkeypatch.setenv(k, v)
+        from rehoboam.config import Settings
+
+        return Settings()
+
+    def test_the_default_leaves_exactly_one_move_spendable(self, monkeypatch):
+        assert self._settings(monkeypatch).pacing_min_spendable_moves == 1.0
+
+    def test_it_is_overridable(self, monkeypatch):
+        s = self._settings(monkeypatch, PACING_MIN_SPENDABLE_MOVES="2.5")
+        assert s.pacing_min_spendable_moves == 2.5
+
+    def test_zero_is_allowed_because_it_is_the_rollback(self, monkeypatch):
+        s = self._settings(monkeypatch, PACING_MIN_SPENDABLE_MOVES="0")
+        assert s.pacing_min_spendable_moves == 0.0
+
+    def test_a_negative_floor_is_refused(self, monkeypatch):
+        """Same reasoning as the other pacing knobs: surface a bad value
+        rather than let `max(0.0, ...)` quietly absorb it."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            self._settings(monkeypatch, PACING_MIN_SPENDABLE_MOVES="-1")
+
+
+class TestTheLiveSessionAppliesTheFloor:
+    """The knob is worthless if the session never reads it.
+
+    REH-85 shipped `pacing_max_reserve_fraction` and REH-101 had to add a
+    second call-site read for it; this pins the wiring so the same gap cannot
+    open again. Budget is chosen so the floor binds and the fraction does not
+    (budget < 2 x median), which is the only region where the two differ.
+    """
+
+    @staticmethod
+    def _trader(settings):
+        from unittest.mock import MagicMock
+
+        from rehoboam.trader import Trader
+
+        learner = MagicMock()
+        learner.recent_buy_prices.return_value = [10_800_000] * 9
+        return Trader(api=MagicMock(), settings=settings, bid_learner=learner)
+
+    def _settings(self, monkeypatch, **env):
+        monkeypatch.setenv("KICKBASE_EMAIL", "test@example.com")
+        monkeypatch.setenv("KICKBASE_PASSWORD", "test")
+        for k, v in env.items():
+            monkeypatch.setenv(k, v)
+        from rehoboam.config import Settings
+
+        return Settings()
+
+    def test_the_session_reserve_leaves_a_median_move_spendable(self, monkeypatch):
+        trader = self._trader(self._settings(monkeypatch))
+        ctx = trader._build_pacing_context(squad_size=12, my_bids=[], current_budget=20_000_000)
+        assert ctx is not None
+        assert 20_000_000 - ctx.reserve >= 10_800_000
+
+    def test_setting_the_knob_to_zero_restores_the_old_session_reserve(self, monkeypatch):
+        trader = self._trader(self._settings(monkeypatch, PACING_MIN_SPENDABLE_MOVES="0"))
+        ctx = trader._build_pacing_context(squad_size=12, my_bids=[], current_budget=20_000_000)
+        assert ctx is not None
+        assert ctx.reserve == 10_000_000  # the REH-101 fraction, unrelieved


### PR DESCRIPTION
## The defect

REH-101 bounded the reserve by `budget * max_reserve_fraction` — necessary, since an unbounded reserve demanded more than the wallet held and refused every buy. But the bounded figure stops representing a whole number of moves. Live 2026-08-28:

```
reserve = min(2 moves × EUR 12.5m, 0.5 × EUR 21,720,227) = EUR 10,860,113
```

€10.86M held back to fund "2 further moves" at a €12.5M median — **0.87 of one**. It bought nothing later while blocking everything above it: `bid=0` on the five highest-EP players on the board, with Engelhardt (+45.0 EP) missing the cap by **€134,301**.

## The fix

A third bound: `reserve <= budget - min_spendable_moves * median_move`. Whatever else it protects, the reserve must leave one typical move affordable. A reserve exists to keep *future* moves possible; one that blocks the *present* move funds nothing.

### Not the shape the ticket proposed

The ticket asked for flooring to whole moves, `floor(affordable / median) * median`. **That was wrong and is not what shipped.** It restores the "whole number of moves" meaning but makes headroom a **sawtooth** in budget — crossing a move boundary drops the maximum bid by a full median, so *gaining* budget shrinks what the bot may bid. That is precisely the pathology REH-101 exists to prevent.

`TestRaisingCashIsStillNeverPunished` pins it: a monotonicity sweep from €5M to €60M that the sawtooth form fails and the shipped continuous form passes.

## Measurement

`replay-season --with-competition`, matching REH-85's method.

| configuration | points | vs main | buys | finish |
|---|---:|---:|---:|---|
| `--no-pacing` | 24,141 | −859 | 3 | 11 of 14 |
| `0.0` (REH-101 = main today) | 25,000 | — | 3 | 10 of 14 |
| **`1.0` (shipped default)** | **25,000** | **0** | 3 | 10 of 14 |
| `2.0` / `3.0` / `5.0` / `8.0` | 25,309 | +309 | 3 | 10 of 14 |

**The null result was predicted before the sweep ran, not discovered in it.** At fraction 0.5 the new bound binds only below `2 × median` — €13.2M in the replay (budget ~€80M) versus €25.0M live (budget €21.7M). The replay's regime is outside where this fix operates, so it is a *regression check* here, not a demonstration.

The +309 at 2.0 saturates identically through 8.0 and is 1.2%. Against the 6,162 points REH-71 records for a single faithfulness decision on this instrument, that is not a signal — recorded in the results doc, not shipped, and it has no principled justification the way "one typical move" does.

## Live verification

`rehoboam status` against the real market:

```
pacing session median_move=12500000 slots_to_fill=3 reserve=9220227
               budget=21720227 max_fraction=0.50 min_spendable_moves=1.00
```

| player | EP gain | ask | before | after |
|---|---:|---:|---|---|
| Jóhannesson | +51.1 | 10,008,196 | capped 10,860,114 | **11,848,196** (uncapped) |
| Engelhardt | +35.3 | 10,994,415 | **bid=0** | **12,394,415** |
| Reitz | +34.3 | 13,087,545 | bid=0 | bid=0 |
| Veerman | +33.0 | 18,543,633 | bid=0 | bid=0 |

Reitz and above stay refused correctly — they cost more than one typical move against this budget, which is the rule working rather than failing.

## Notes

- `pacing_min_spendable_moves` is a Settings field (default 1.0; **0.0 is the REH-101 rollback**), read by `Trader._build_pacing_context` and logged, threaded through the replay driver, and exposed as `--pacing-min-spendable-moves` for sweeping. Added to `.env.example` along with `PACING_MAX_RESERVE_FRACTION`, which REH-101 never documented there.
- **Two REH-101 tests updated, not weakened.** Both exist to keep REH-85's unbounded arithmetic reachable for A/B and rollback. With a second bound now on by default, reaching it means switching *both* off — otherwise the new floor repairs the case and `test_the_unbounded_reserve_is_what_broke_this` passes for the wrong reason.
- REH-85's own acceptance criterion (buy count must rise) still fails at 3 buys in every row, for the reason documented there: this replay never reaches 15/15. REH-107 does not claim to fix that; REH-88 and REH-68 are the blockers on measuring the reserve properly.

1372 pass. ruff/black clean; mypy unchanged from baseline (6 errors, none in `pacing.py`).

Closes REH-107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EA4tBxaBhK4DjMpcYVsPvf