### PR TITLE
feat(learning): reconstruct flip entry context, and answer what it was for (REH-104)

### DIFF
--- a/rehoboam/bid_learner.py
+++ b/rehoboam/bid_learner.py
@@ -79,6 +79,12 @@ class FlipOutcome:
     average_points: float | None = None
     position: str | None = None
     was_injured: bool = False
+    # REH-104 entry context. Reconstructed from `player_mv_history` rather than
+    # captured at buy time, so closed flips can be backfilled and the entry rule
+    # becomes measurable on history. See `learning/entry_context.py`.
+    trend_pct_at_buy: float | None = None
+    mv_at_buy: int | None = None
+    pct_below_peak_30d_at_buy: float | None = None
 
 
 # --- EP overbid recommender (REH-89) --------------------------------------
@@ -561,6 +567,20 @@ class BidLearner:
             except sqlite3.OperationalError:
                 pass  # already present
 
+            # REH-104: entry context for a flip. `trend_at_buy` has existed
+            # since this table was created and was NULL in all 151 rows —
+            # `record_flip_outcome` runs at sell time and had nothing to write.
+            # Added in place so prod rows can be backfilled rather than lost.
+            for _col, _type in (
+                ("trend_pct_at_buy", "REAL"),
+                ("mv_at_buy", "INTEGER"),
+                ("pct_below_peak_30d_at_buy", "REAL"),
+            ):
+                try:
+                    conn.execute(f"ALTER TABLE flip_outcomes ADD COLUMN {_col} {_type}")
+                except sqlite3.OperationalError:
+                    pass  # already present
+
             # REH-22: drop legacy tables that no live code references.
             # `position_bidding_stats` was orphaned by REH-27 (writer + reader
             # methods deleted). The other three are stale residue from
@@ -625,9 +645,9 @@ class BidLearner:
                 INSERT OR IGNORE INTO flip_outcomes (
                     player_id, player_name, buy_price, sell_price, profit, profit_pct,
                     hold_days, buy_date, sell_date, trend_at_buy, average_points, position,
-                    was_injured
+                    was_injured, trend_pct_at_buy, mv_at_buy, pct_below_peak_30d_at_buy
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
                 (
                     outcome.player_id,
@@ -643,6 +663,9 @@ class BidLearner:
                     outcome.average_points,
                     outcome.position,
                     1 if outcome.was_injured else 0,
+                    outcome.trend_pct_at_buy,
+                    outcome.mv_at_buy,
+                    outcome.pct_below_peak_30d_at_buy,
                 ),
             )
             conn.commit()
@@ -957,6 +980,61 @@ class BidLearner:
             )
             conn.commit()
             return cur.rowcount > 0
+
+    def mv_history_for(self, player_id: str) -> list[tuple[float, int]]:
+        """Every recorded market value for one player, as (epoch, value).
+
+        Feeds `learning.entry_context.entry_context`. Returns a plain list of
+        tuples rather than rows so the reconstruction stays pure and testable
+        without a database.
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            return [
+                (float(ts), int(mv))
+                for ts, mv in conn.execute(
+                    "SELECT snapshot_at, market_value FROM player_mv_history "
+                    "WHERE player_id = ? ORDER BY snapshot_at",
+                    (str(player_id),),
+                )
+            ]
+
+    def backfill_flip_entry_context(self) -> int:
+        """Fill entry context on closed flips that have none. Returns rows written.
+
+        Idempotent by construction: only rows where `mv_at_buy IS NULL` are
+        touched, so a rerun cannot overwrite a value captured live, and a flip
+        with no usable market-value history is left NULL rather than faked —
+        an unknown entry must stay distinguishable from a real zero reading
+        ("bought exactly at the 30-day peak").
+        """
+        from rehoboam.learning.entry_context import entry_context
+
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            pending = conn.execute(
+                "SELECT id, player_id, buy_date FROM flip_outcomes WHERE mv_at_buy IS NULL"
+            ).fetchall()
+
+            written = 0
+            for row in pending:
+                ctx = entry_context(self.mv_history_for(row["player_id"]), row["buy_date"])
+                if ctx.mv_at_buy is None:
+                    continue
+                conn.execute(
+                    "UPDATE flip_outcomes SET trend_at_buy = COALESCE(trend_at_buy, ?), "
+                    "trend_pct_at_buy = ?, mv_at_buy = ?, pct_below_peak_30d_at_buy = ? "
+                    "WHERE id = ?",
+                    (
+                        ctx.trend_at_buy,
+                        ctx.trend_pct_at_buy,
+                        ctx.mv_at_buy,
+                        ctx.pct_below_peak_30d_at_buy,
+                        row["id"],
+                    ),
+                )
+                written += 1
+            conn.commit()
+            return written
 
     def record_player_mv_snapshot(self, rows: list[dict]) -> int:
         """Bulk-persist one row per held player into ``player_mv_history``.

--- a/rehoboam/cli.py
+++ b/rehoboam/cli.py
@@ -1,6 +1,7 @@
 """CLI interface for Rehoboam — minimal surface for auto + diagnostics."""
 
 import logging
+import sqlite3
 from datetime import datetime
 from pathlib import Path
 
@@ -517,6 +518,41 @@ def enrich_corpus(
         table.add_row("Historical positions unresolved", str(stats.positions_unresolved))
     console.print(table)
     console.print(f"[dim]Corpus: {corpus.db_path}[/dim]")
+
+
+@app.command("backfill-flip-entry-context")
+def backfill_flip_entry_context(
+    learning_db: Path = typer.Option(  # noqa: B008
+        Path("logs/bid_learning.db"), help="Path to the learning DB"
+    ),
+):
+    """Reconstruct what the market looked like when each closed flip was bought (REH-104).
+
+    `flip_outcomes.trend_at_buy` has existed since the table was created and was
+    NULL in every row: `record_flip_outcome` runs at sell time and the entry
+    context was never stored. This derives it from `player_mv_history`, which
+    already holds the snapshots, so historical flips become measurable without
+    waiting for a season of new ones.
+
+    Purely local — no API calls. Idempotent: rows that already have context are
+    left alone, and a flip with no usable MV history stays NULL rather than
+    being filled with a fabricated zero.
+    """
+    from rehoboam.bid_learner import BidLearner
+
+    if not learning_db.exists():
+        console.print(f"[red]Learning DB not found: {learning_db}[/red]")
+        raise typer.Exit(1)
+
+    learner = BidLearner(db_path=learning_db)
+    written = learner.backfill_flip_entry_context()
+    console.print(f"[green]Annotated {written} flip(s) with entry context[/green]")
+
+    with sqlite3.connect(learning_db) as conn:
+        total, annotated = conn.execute(
+            "SELECT COUNT(*), COUNT(mv_at_buy) FROM flip_outcomes"
+        ).fetchone()
+    console.print(f"[dim]{annotated} of {total} flips now carry entry context[/dim]")
 
 
 @app.command("backfill-history")

--- a/rehoboam/learning/entry_context.py
+++ b/rehoboam/learning/entry_context.py
@@ -1,0 +1,123 @@
+"""What the market looked like when we bought a player (REH-104).
+
+`flip_outcomes.trend_at_buy` has existed since the table was created and has
+been NULL for every row. `LearningTracker.record_flip_outcome` runs at SELL
+time, and `tracked_purchases` stores only price and date — the entry context
+was simply never available to write. REH-34 ("which buy traits predict a
+profitable flip?") has been blocked on that gap.
+
+This reconstructs the context from `player_mv_history` instead of capturing it
+at buy time. Two reasons. The buy path is the code that spends real money and
+does not need another field threaded through it; and reconstruction can be
+applied to flips that have ALREADY closed, so the 151 rows of history become
+measurable now rather than after a season of new trades.
+
+The definitions mirror `services/trend_service.py` deliberately: `trend_pct` is
+the 14-day change and the direction thresholds are +/-5% (trend_service.py:328).
+A reconstruction on any other basis would not correspond to the rule that
+actually gated the buy, which is `profit_trader`'s `trend == "rising" and
+trend_pct > 5`.
+
+Pure — it takes rows and returns a value, so it is exhaustively testable and
+the live path and the backfill cannot drift apart.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+DAY_SECONDS = 86400.0
+
+#: How far a snapshot may sit from the instant we want before it stops being
+#: evidence. Measured: all 151 historical flips have an MV point within 0.45
+#: days of their buy, so 3 days is loose enough to never bind in practice and
+#: tight enough that a stale value can never masquerade as the entry price.
+DEFAULT_TOLERANCE_DAYS = 3.0
+
+#: Trend lookback and peak window, both matching the live trend service.
+TREND_LOOKBACK_DAYS = 14.0
+PEAK_WINDOW_DAYS = 30.0
+
+#: trend_service.py:328-333 — the same boundaries, so a reconstructed direction
+#: means what the bot meant by it at decision time.
+RISING_THRESHOLD_PCT = 5.0
+FALLING_THRESHOLD_PCT = -5.0
+
+
+@dataclass(frozen=True)
+class EntryContext:
+    """The entry conditions of one purchase. Every field is optional: thin MV
+    history is normal for a newly listed player, and a missing field must read
+    as "not known" rather than as a zero that would pollute the aggregates."""
+
+    mv_at_buy: int | None = None
+    trend_pct_at_buy: float | None = None
+    trend_at_buy: str | None = None
+    #: Distance from the highest market value in the 30 days up to the buy.
+    #: Always <= 0. Zero means we bought AT the 30-day peak — the condition the
+    #: REH-104 spike found in 30% of flips, whose median then fell 14.2%.
+    pct_below_peak_30d_at_buy: float | None = None
+
+
+def _nearest(rows: list[tuple[float, int]], target: float, tolerance_days: float) -> int | None:
+    """Market value of the snapshot closest to `target`, or None if all are stale."""
+    best: tuple[float, int] | None = None
+    limit = tolerance_days * DAY_SECONDS
+    for ts, mv in rows:
+        gap = abs(ts - target)
+        if gap <= limit and (best is None or gap < best[0]):
+            best = (gap, mv)
+    return best[1] if best else None
+
+
+def entry_context(
+    mv_rows: Iterable[tuple[float, int]],
+    buy_date: float,
+    *,
+    tolerance_days: float = DEFAULT_TOLERANCE_DAYS,
+) -> EntryContext:
+    """Reconstruct the entry conditions of a purchase from recorded values.
+
+    `mv_rows` is any iterable of ``(snapshot_epoch, market_value)``; order does
+    not matter. Rows dated after `buy_date` are ignored for the peak window —
+    including them would let the field see the outcome it is meant to predict.
+    """
+    rows = [(float(ts), int(mv)) for ts, mv in mv_rows]
+    if not rows:
+        return EntryContext()
+
+    mv_at_buy = _nearest(rows, buy_date, tolerance_days)
+    if mv_at_buy is None:
+        return EntryContext()
+
+    trend_pct: float | None = None
+    trend: str | None = None
+    reference = _nearest(rows, buy_date - TREND_LOOKBACK_DAYS * DAY_SECONDS, tolerance_days)
+    if reference:  # a zero or missing reference has no meaningful percentage
+        raw_pct = (mv_at_buy - reference) / reference * 100.0
+        # Classify on the raw value and round only for storage. Rounding first
+        # collapses +5.001% onto the 5.0 boundary and reports it as "stable",
+        # which would mislabel exactly the marginal entries this field exists
+        # to study.
+        if raw_pct > RISING_THRESHOLD_PCT:
+            trend = "rising"
+        elif raw_pct < FALLING_THRESHOLD_PCT:
+            trend = "falling"
+        else:
+            trend = "stable"
+        trend_pct = round(raw_pct, 2)
+
+    pct_below_peak: float | None = None
+    window_start = buy_date - PEAK_WINDOW_DAYS * DAY_SECONDS
+    in_window = [mv for ts, mv in rows if window_start <= ts <= buy_date]
+    peak = max(in_window, default=0)
+    if peak > 0:
+        pct_below_peak = round((mv_at_buy - peak) / peak * 100.0, 2)
+
+    return EntryContext(
+        mv_at_buy=mv_at_buy,
+        trend_pct_at_buy=trend_pct,
+        trend_at_buy=trend,
+        pct_below_peak_30d_at_buy=pct_below_peak,
+    )

--- a/rehoboam/learning/tracker.py
+++ b/rehoboam/learning/tracker.py
@@ -27,6 +27,7 @@ from datetime import datetime
 from pathlib import Path
 
 from ..bid_learner import AuctionOutcome, BidLearner, FlipOutcome
+from .entry_context import EntryContext, entry_context
 from .migration import migrate_json_state_if_needed
 
 logger = logging.getLogger(__name__)
@@ -443,6 +444,20 @@ class LearningTracker:
             profit_pct = (profit / buy_price * 100) if buy_price > 0 else 0
             hold_days = int((sell_date - buy_date) / (24 * 3600))
 
+            # REH-104: what the market looked like when we bought. Best-effort
+            # and separately guarded — the P&L row is the thing that must not be
+            # lost, and a player with no recorded MV history is a normal case
+            # (newly listed), not an error.
+            entry = EntryContext()
+            try:
+                entry = entry_context(self.bid_learner.mv_history_for(player.id), buy_date)
+            except Exception:
+                logger.warning(
+                    "entry context unavailable for %s — recording flip without it",
+                    player.id,
+                    exc_info=True,
+                )
+
             outcome = FlipOutcome(
                 player_id=player.id,
                 player_name=player_name,
@@ -456,6 +471,10 @@ class LearningTracker:
                 average_points=getattr(player, "average_points", None),
                 position=getattr(player, "position", None),
                 was_injured=(player.status != 0) if hasattr(player, "status") else False,
+                trend_at_buy=entry.trend_at_buy,
+                trend_pct_at_buy=entry.trend_pct_at_buy,
+                mv_at_buy=entry.mv_at_buy,
+                pct_below_peak_30d_at_buy=entry.pct_below_peak_30d_at_buy,
             )
             self.bid_learner.record_flip(outcome)
             self.bid_learner.delete_tracked_purchase(player.id)

--- a/tests/test_flip_entry_context.py
+++ b/tests/test_flip_entry_context.py
@@ -1,0 +1,111 @@
+"""Entry context for a flip, reconstructed from recorded market values (REH-104).
+
+`flip_outcomes.trend_at_buy` has existed since the table was created and has
+been NULL for all 151 rows: `LearningTracker.record_flip_outcome` runs at SELL
+time and `tracked_purchases` never stored the entry context, so there was
+nothing to write. That is why REH-34 ("which buy traits predict a profitable
+flip?") has never been answerable.
+
+Rather than thread new fields through the buy path — the code that spends real
+money, and a change that would only help flips from now on — the context is
+reconstructed from `player_mv_history`, which already holds 40,214 snapshots
+across 295 players back to 2025-05-09. Every one of the 151 historical flips
+has an MV point within 0.45 days of its buy date, so the existing rows can be
+backfilled and the entry rule becomes measurable immediately.
+
+The definitions deliberately mirror `services/trend_service.py`: `trend_pct` is
+the 14-day change and the direction thresholds are +/-5%. A reconstruction on
+any other basis would not correspond to the rule that actually gated the buy
+(`profit_trader` requires `trend == "rising" and trend_pct > 5`).
+"""
+
+import pytest
+
+from rehoboam.learning.entry_context import EntryContext, entry_context
+
+DAY = 86400.0
+BUY = 1_700_000_000.0
+
+
+def rows(*pairs):
+    """(days_before_buy, market_value) -> the (epoch, mv) shape the reader yields."""
+    return [(BUY - d * DAY, mv) for d, mv in pairs]
+
+
+class TestMarketValueAtBuy:
+    def test_it_takes_the_snapshot_nearest_the_buy(self):
+        ctx = entry_context(rows((0.2, 5_000_000), (9, 4_000_000)), BUY)
+        assert ctx.mv_at_buy == 5_000_000
+
+    def test_a_snapshot_beyond_the_tolerance_is_not_used(self):
+        """Stale MV is worse than no MV: it would silently mis-state the entry."""
+        ctx = entry_context(rows((30, 5_000_000)), BUY)
+        assert ctx.mv_at_buy is None
+
+    def test_no_rows_yields_an_empty_context_rather_than_raising(self):
+        assert entry_context([], BUY) == EntryContext()
+
+
+class TestTrendAtBuy:
+    def test_a_rise_over_fourteen_days_is_rising(self):
+        ctx = entry_context(rows((0, 113_000), (14, 100_000)), BUY)
+        assert ctx.trend_pct_at_buy == pytest.approx(13.0)
+        assert ctx.trend_at_buy == "rising"
+
+    def test_a_fall_over_fourteen_days_is_falling(self):
+        ctx = entry_context(rows((0, 90_000), (14, 100_000)), BUY)
+        assert ctx.trend_at_buy == "falling"
+
+    def test_a_small_move_is_stable(self):
+        ctx = entry_context(rows((0, 103_000), (14, 100_000)), BUY)
+        assert ctx.trend_at_buy == "stable"
+
+    @pytest.mark.parametrize(
+        "mv_now,expected",
+        [(105_000, "stable"), (105_001, "rising"), (95_000, "stable"), (94_999, "falling")],
+    )
+    def test_the_thresholds_match_trend_service_exactly(self, mv_now, expected):
+        """+/-5% on the 14d change, per trend_service.py:328-333. A different
+        boundary would not correspond to the rule that gated the buy."""
+        ctx = entry_context(rows((0, mv_now), (14, 100_000)), BUY)
+        assert ctx.trend_at_buy == expected
+
+    def test_no_fourteen_day_reference_leaves_the_trend_unknown(self):
+        ctx = entry_context(rows((0, 100_000)), BUY)
+        assert ctx.trend_pct_at_buy is None
+        assert ctx.trend_at_buy is None
+
+
+class TestDistanceBelowThePeak:
+    """The measure the spike says matters. Median MV rose +13.2% in the 14 days
+    before a buy and fell -14.2% in the 30 after: the bot buys tops. This is the
+    field that makes "do we profit when buying BELOW the recent peak?" answerable.
+    """
+
+    def test_buying_at_the_peak_reports_zero(self):
+        ctx = entry_context(rows((0, 100_000), (10, 90_000), (20, 80_000)), BUY)
+        assert ctx.pct_below_peak_30d_at_buy == pytest.approx(0.0)
+
+    def test_buying_below_the_peak_reports_a_negative_distance(self):
+        ctx = entry_context(rows((0, 90_000), (10, 100_000)), BUY)
+        assert ctx.pct_below_peak_30d_at_buy == pytest.approx(-10.0)
+
+    def test_the_window_ignores_a_peak_older_than_thirty_days(self):
+        ctx = entry_context(rows((0, 90_000), (45, 500_000)), BUY)
+        assert ctx.pct_below_peak_30d_at_buy == pytest.approx(0.0)
+
+    def test_snapshots_after_the_buy_are_never_used(self):
+        """Look-ahead would make the field predict its own outcome."""
+        after = [(BUY + 5 * DAY, 900_000)]
+        ctx = entry_context(rows((0, 90_000), (10, 100_000)) + after, BUY)
+        assert ctx.pct_below_peak_30d_at_buy == pytest.approx(-10.0)
+
+
+class TestDegenerateInput:
+    def test_a_zero_market_value_does_not_divide_by_zero(self):
+        ctx = entry_context(rows((0, 100_000), (14, 0)), BUY)
+        assert ctx.trend_pct_at_buy is None
+
+    def test_rows_out_of_order_are_handled(self):
+        ctx = entry_context(rows((14, 100_000), (0, 113_000))[::-1], BUY)
+        assert ctx.trend_at_buy == "rising"

--- a/tests/test_flip_entry_context_persistence.py
+++ b/tests/test_flip_entry_context_persistence.py
@@ -1,0 +1,172 @@
+"""Persisting and backfilling flip entry context (REH-104).
+
+The pure reconstruction lives in `learning/entry_context.py`; this covers the
+storage seam around it — the three new `flip_outcomes` columns, the MV reader
+the reconstruction consumes, and the backfill that makes the 151 rows of
+existing history measurable.
+"""
+
+import sqlite3
+
+import pytest
+
+from rehoboam.bid_learner import BidLearner, FlipOutcome
+
+DAY = 86400.0
+BUY = 1_700_000_000.0
+
+
+@pytest.fixture
+def learner(tmp_path):
+    return BidLearner(db_path=tmp_path / "bids.db")
+
+
+def _flip(learner, pid="p1", **over):
+    fields = {
+        "player_id": pid,
+        "player_name": "Tester",
+        "buy_price": 10_000_000,
+        "sell_price": 9_000_000,
+        "profit": -1_000_000,
+        "profit_pct": -10.0,
+        "hold_days": 6,
+        "buy_date": BUY,
+        "sell_date": BUY + 6 * DAY,
+    }
+    fields.update(over)
+    learner.record_flip(FlipOutcome(**fields))
+
+
+def _mv(learner, pid, *pairs):
+    """Seed player_mv_history: (days_before_buy, market_value)."""
+    learner.record_player_mv_snapshot(
+        [{"player_id": pid, "market_value": mv, "snapshot_at": BUY - d * DAY} for d, mv in pairs]
+    )
+
+
+def _rows(learner):
+    """Read flip_outcomes straight from the file — a persistence test should
+    assert on what actually landed on disk, not through another accessor."""
+    with sqlite3.connect(learner.db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        return [dict(r) for r in conn.execute("SELECT * FROM flip_outcomes")]
+
+
+class TestTheColumnsRoundTrip:
+    def test_entry_context_is_stored_and_read_back(self, learner):
+        _flip(
+            learner,
+            trend_at_buy="rising",
+            trend_pct_at_buy=13.2,
+            mv_at_buy=9_400_000,
+            pct_below_peak_30d_at_buy=-2.5,
+        )
+        (row,) = _rows(learner)
+        assert row["trend_at_buy"] == "rising"
+        assert row["trend_pct_at_buy"] == pytest.approx(13.2)
+        assert row["mv_at_buy"] == 9_400_000
+        assert row["pct_below_peak_30d_at_buy"] == pytest.approx(-2.5)
+
+    def test_a_flip_recorded_without_context_stores_nulls_not_zeros(self, learner):
+        """A zero would be a real reading — 'bought exactly at the peak'. An
+        unknown entry must stay distinguishable from that or the aggregates lie."""
+        _flip(learner)
+        (row,) = _rows(learner)
+        assert row["trend_pct_at_buy"] is None
+        assert row["pct_below_peak_30d_at_buy"] is None
+
+
+class TestTheMarketValueReader:
+    def test_it_returns_the_players_snapshots_as_epoch_value_pairs(self, learner):
+        _mv(learner, "p1", (0, 5_000_000), (14, 4_400_000))
+        rows = learner.mv_history_for("p1")
+        assert sorted(rows) == [(BUY - 14 * DAY, 4_400_000), (BUY, 5_000_000)]
+
+    def test_an_unknown_player_yields_nothing_rather_than_raising(self, learner):
+        assert learner.mv_history_for("nobody") == []
+
+
+class TestTheBackfill:
+    def test_it_populates_a_row_that_has_no_context(self, learner):
+        _flip(learner, pid="p1")
+        _mv(learner, "p1", (0, 9_400_000), (14, 8_300_000), (10, 10_000_000))
+        assert learner.backfill_flip_entry_context() == 1
+        (row,) = _rows(learner)
+        assert row["trend_at_buy"] == "rising"
+        assert row["mv_at_buy"] == 9_400_000
+        # peak in the 30d window is 10,000,000 → we bought 6% under it
+        assert row["pct_below_peak_30d_at_buy"] == pytest.approx(-6.0)
+
+    def test_it_leaves_a_row_that_already_has_context_alone(self, learner):
+        """Idempotent, so a rerun cannot overwrite a value captured live."""
+        _flip(learner, pid="p1", trend_at_buy="falling", mv_at_buy=1)
+        _mv(learner, "p1", (0, 9_400_000), (14, 8_300_000))
+        assert learner.backfill_flip_entry_context() == 0
+        (row,) = _rows(learner)
+        assert row["trend_at_buy"] == "falling"
+
+    def test_a_flip_with_no_market_value_history_is_skipped_not_faked(self, learner):
+        _flip(learner, pid="ghost")
+        assert learner.backfill_flip_entry_context() == 0
+        (row,) = _rows(learner)
+        assert row["mv_at_buy"] is None
+
+    def test_it_is_idempotent_across_reruns(self, learner):
+        _flip(learner, pid="p1")
+        _mv(learner, "p1", (0, 9_400_000), (14, 8_300_000))
+        assert learner.backfill_flip_entry_context() == 1
+        assert learner.backfill_flip_entry_context() == 0
+
+
+class TestTheLiveSellPathRecordsContext:
+    """A flip closed by the bot should land with context already attached, so
+    the backfill is only ever needed for history."""
+
+    @staticmethod
+    def _player(pid="p1"):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            id=pid,
+            first_name="Test",
+            last_name="Player",
+            average_points=42.0,
+            position="Midfielder",
+            status=0,
+        )
+
+    def _tracker(self, learner):
+        from rehoboam.learning.tracker import LearningTracker
+
+        return LearningTracker(learner)
+
+    def test_a_closed_flip_carries_its_entry_context(self, learner):
+        _mv(learner, "p1", (0, 9_400_000), (14, 8_300_000), (10, 10_000_000))
+        learner.add_tracked_purchase(
+            player_id="p1",
+            player_name="Test Player",
+            buy_price=10_000_000,
+            buy_date=BUY,
+            source="real",
+        )
+        self._tracker(learner).record_flip_outcome(self._player(), sell_price=9_000_000)
+
+        (row,) = _rows(learner)
+        assert row["trend_at_buy"] == "rising"
+        assert row["mv_at_buy"] == 9_400_000
+        assert row["pct_below_peak_30d_at_buy"] == pytest.approx(-6.0)
+
+    def test_missing_market_value_history_still_records_the_flip(self, learner):
+        """Context is a learning nicety; losing the P&L row would be a real loss."""
+        learner.add_tracked_purchase(
+            player_id="ghost",
+            player_name="Ghost",
+            buy_price=10_000_000,
+            buy_date=BUY,
+            source="real",
+        )
+        self._tracker(learner).record_flip_outcome(self._player("ghost"), sell_price=9_000_000)
+
+        (row,) = _rows(learner)
+        assert row["profit"] == -1_000_000
+        assert row["mv_at_buy"] is None


### PR DESCRIPTION
## The gap

`flip_outcomes.trend_at_buy` has existed since the table was created and was **NULL in all 151 rows**. `record_flip_outcome` runs at *sell* time and `tracked_purchases` stores only price and date — there was never anything to write. REH-34 ("which buy traits predict a profitable flip?") has been blocked on this since it was filed.

## Approach: reconstruct, don't capture

Derived from `player_mv_history` rather than threaded through the buy path. Two reasons: that path is the code that **spends real money** and doesn't need another field routed through it; and reconstruction applies to flips that have *already closed*, so the whole history became measurable immediately instead of after a season of new trades. All 151 flips have an MV snapshot within **0.45 days** of their buy date.

New `learning/entry_context.py` is pure — MV rows + buy date → `mv_at_buy`, `trend_pct_at_buy`, `trend_at_buy`, `pct_below_peak_30d_at_buy`. Definitions mirror `services/trend_service.py` exactly (14-day change, ±5% thresholds), because a reconstruction on any other basis wouldn't correspond to the rule that actually gated the buy.

## What it says

Run over the real 151 flips:

| trend at buy | n | total P&L | win rate |
|---|---:|---:|---:|
| **rising** | 82 | **+€3,186,601** | **40.2%** |
| stable | 35 | **−€47,736,647** | **5.7%** |
| falling | 30 | −€10,179,260 | 20.0% |

**The rising-trend rule was right.** REH-71's headline −€55.3M is almost entirely `stable` (−€47.7M at a 5.7% win rate — two winners in 35 trades) and `falling`. Restricted to rising entries the channel was mildly *profitable*. `flip_buys_require_rising_trend` already defaults `True` (shipped 24 Aug), so the losing classes are already blocked in production.

### It also refutes the hypothesis that prompted the work

A spike found median MV **+13.2%** in the 14 days before a buy and **−14.2%** in the 30 after, which I read as "the bot buys tops because it buys rising trends". The annotated data says otherwise: peak-proximity shows **no clean signal** — every band loses, and "at the peak" (−€17.6M) is *better* than "5–15% below" (−€18.3M). Those medians are dominated by the stable/falling entries, not caused by the rising rule. Building an exit-signal engine on that hypothesis would have been building on sand.

## Details

- Three columns added in place via the `ALTER`/`OperationalError` idiom already used for `trade_proposals.tier`, so prod rows are backfilled rather than lost.
- `record_flip_outcome` populates them for new flips, separately guarded — a context lookup failure must never cost the P&L row.
- `rehoboam backfill-flip-entry-context`: local only, no API calls, idempotent. A flip with no usable MV history stays NULL rather than getting a fabricated zero — **0.0 is a real reading** ("bought AT the 30-day peak") and must stay distinguishable from "unknown".

## Testing

TDD throughout. 17 RED tests for the pure function — including a boundary case that **caught a real bug**: rounding before classifying collapsed +5.001% onto the 5.0 threshold and labelled it "stable", exactly the marginal entries the field exists to study. Then 10 more for persistence, backfill idempotency, and the live sell path.

**1399 pass.** ruff clean. No replay gate — this writes learning columns and changes no decision.

## Not in scope

No change to entry rules, no 2-slot trading desk, no exit signals. This makes the entry rule *measurable*; changing it is the next ticket and needed this data to be evaluable at all.

Part of REH-104; unblocks REH-34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EA4tBxaBhK4DjMpcYVsPvf