### PR TITLE
fix(trade): open the flip window, and stop forcing flips into the losing bucket (REH-109)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,13 @@ SMTP_USER=
 SMTP_PASSWORD=
 ALERT_EMAIL_TO=
 
+# --- Profit flips (REH-109) --------------------------------------------------
+# Cap a flip's hold at the next kickoff. Off: Kickbase locks the eleven at
+# kickoff and squad changes land on the NEXT matchday, so holding a flip
+# through a match costs no points. The 1-3 day exits this used to force were
+# the 13%-win-rate bucket. Set true to restore the old behaviour.
+FLIP_HOLD_RESPECTS_MATCHDAY=false
+
 # --- Capital pacing (REH-85) ------------------------------------------------
 # Reserve enough budget after each buy to make the remaining moves needed.
 PACING_ENABLED=true

--- a/rehoboam/auto_trader.py
+++ b/rehoboam/auto_trader.py
@@ -97,18 +97,34 @@ def _build_buy_gate(
     )
 
 
-def _max_flip_hold_days(days_until_match: int | None) -> int | None:
-    """Cap on a profit-flip's hold_days to fit before the next matchday.
+def _max_flip_hold_days(
+    days_until_match: int | None, *, respect_matchday: bool = False
+) -> int | None:
+    """Cap on a profit-flip's hold_days. ``None`` means unconstrained.
 
-    A flip we can't sell before kickoff risks both an unsellable position and
-    the value drop that often follows uncertain matchday outcomes. Returns
-    ``None`` when the schedule is unknown (no constraint applied — the
-    matchday-phase logic already defaults to no-flips in that case).
+    REH-109: this used to return ``days_until_match - 1`` on the premise that a
+    flip we cannot sell before kickoff risks an unsellable position. That
+    premise is false. Kickbase locks the fielded eleven at kickoff and every
+    squad change lands on the FOLLOWING matchday, so holding a flip through a
+    match costs nothing in points. The constraint that genuinely survives is
+    budget-at-kickoff (REH-11), which is about cash and is enforced elsewhere.
 
-    The "−1 day" buffer leaves a safety margin for the sell to actually clear
-    given Kickbase's auction mechanics.
+    The cap was also actively expensive. Within rising-trend entries — the only
+    class `flip_buys_require_rising_trend` now admits, and the only profitable
+    one — outcomes by hold length were:
+
+        0-2d    23 flips   -EUR  9.67m   13.0% win
+        3-7d    22 flips   -EUR  4.67m   50.0% win
+        8-21d   25 flips   -EUR  9.34m   44.0% win
+        22d+    12 flips   +EUR 26.85m   66.7% win
+
+    Deriving the cap from the matchday forced a 1-3 day exit in the moderate
+    phase, which is precisely the 13%-win bucket.
+
+    ``respect_matchday`` restores the old behaviour, so the change is
+    revertible from .env without a deploy like every other flip knob.
     """
-    if days_until_match is None:
+    if not respect_matchday or days_until_match is None:
         return None
     return max(1, days_until_match - 1)
 
@@ -298,12 +314,23 @@ class AutoTrader:
                 reason=f"Match in {days_until_match}d — lineup only, no trading",
             )
         elif days_until_match is not None and days_until_match <= 4:
+            # REH-109: flips ARE allowed here. `allow_flips` used to be True
+            # only at >= 5 days, and measured against the real calendar that
+            # window was five hours wide — MD2's last fixture 2026-08-30T13:30Z,
+            # MD3's first 2026-09-04T18:30Z — which the 08:00/20:00 timer missed
+            # entirely. Zero flips since 2026-05-15 was the code path never
+            # executing, not a selection failure.
+            #
+            # Safe because the premise for excluding them was wrong: a trade
+            # near a matchday cannot disturb the eleven, which Kickbase locks at
+            # kickoff. `max_trades` stays halved — this reopens flipping, not
+            # full-rate squad churn.
             return MatchdayPhase(
                 days_until_match=days_until_match,
                 phase="moderate",
                 max_trades=max(self.max_trades_per_session // 2, 2),
-                allow_flips=False,
-                reason=f"Match in {days_until_match}d — lineup improvements only",
+                allow_flips=True,
+                reason=f"Match in {days_until_match}d — lineup improvements + flips",
             )
         elif days_until_match is not None:
             return MatchdayPhase(
@@ -772,7 +799,10 @@ class AutoTrader:
                 # Cap flip hold time so we don't enter a position we can't exit
                 # before the next matchday — being caught at kickoff with a
                 # half-finished flip risks the lineup penalty AND market drop.
-                max_hold_days = _max_flip_hold_days(ctx.matchday_phase.days_until_match)
+                max_hold_days = _max_flip_hold_days(
+                    ctx.matchday_phase.days_until_match,
+                    respect_matchday=self.settings.flip_hold_respects_matchday,
+                )
 
                 from .formation import validate_formation
                 from .scoring.decision import _would_create_dead_weight

--- a/rehoboam/config.py
+++ b/rehoboam/config.py
@@ -203,6 +203,18 @@ class Settings(BaseSettings):
             "overpaying at entry."
         ),
     )
+    flip_hold_respects_matchday: bool = Field(
+        default=False,
+        description=(
+            "REH-109: cap a flip's hold at the next kickoff. Off, because the "
+            "premise was false — Kickbase locks the eleven at kickoff and squad "
+            "changes land on the next matchday, so holding through a match "
+            "costs no points. It was also expensive: within rising-trend "
+            "entries the 1-3 day holds it forced won 13% and lost EUR 9.67m, "
+            "while 22d+ holds won 67% and made EUR 26.85m. True restores the "
+            "old behaviour without a deploy."
+        ),
+    )
     flip_buys_require_rising_trend: bool = Field(
         default=True,
         description=(

--- a/tests/test_flip_window.py
+++ b/tests/test_flip_window.py
@@ -1,0 +1,83 @@
+"""The flip window (REH-109).
+
+Zero flips since 2026-05-15. Not selection and not cash policy — the code path
+did not execute. `allow_flips` was True in one phase only (`days_until_match
+>= 5`), and measured against the real calendar on 2026-08-29 that window was
+five hours wide: MD2's last fixture at 2026-08-30T13:30Z, MD3's first at
+2026-09-04T18:30Z, so >= 5 days held only between 13:30 and 18:30 that Sunday.
+The timer runs 08:00 and 20:00 UTC and missed it by 90 minutes.
+
+Both gates rested on the same false premise — that a trade near a matchday
+disturbs the eleven. It cannot: Kickbase locks the lineup at kickoff, and any
+squad change lands on the FOLLOWING matchday. What genuinely survives is the
+budget-at-kickoff rule (REH-11), which is about cash, not slots, and is
+enforced elsewhere.
+
+Hold length is why the two changes must ship together. Within rising-trend
+entries — the only class the bot now buys, and the only profitable one — the
+0-2 day bucket wins 13% of the time and lost EUR 9.67m over 23 trades, while
+22d+ won 66.7% and made EUR 26.85m. Opening the window while
+`_max_flip_hold_days` still forces a 1-3 day exit would enable exactly the
+losing bucket.
+"""
+
+import pytest
+
+from rehoboam.auto_trader import _max_flip_hold_days
+
+
+def _phase(days, monkeypatch, **env):
+    monkeypatch.setenv("KICKBASE_EMAIL", "test@example.com")
+    monkeypatch.setenv("KICKBASE_PASSWORD", "test")
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+    from unittest.mock import MagicMock
+
+    from rehoboam.auto_trader import AutoTrader
+    from rehoboam.config import Settings
+
+    trader = AutoTrader(api=MagicMock(), settings=Settings(), dry_run=True)
+    return trader._get_matchday_phase(days)
+
+
+class TestTheWindowIsOpenForMostOfTheWeek:
+    @pytest.mark.parametrize("days", [2, 3, 4])
+    def test_flips_are_allowed_in_the_moderate_phase(self, days, monkeypatch):
+        """The change that makes the path executable at all. A Bundesliga round
+        gap of ~5 days means 2-4 days out is most of the tradeable week."""
+        assert _phase(days, monkeypatch).allow_flips is True
+
+    @pytest.mark.parametrize("days", [5, 9])
+    def test_the_aggressive_phase_still_allows_them(self, days, monkeypatch):
+        assert _phase(days, monkeypatch).allow_flips is True
+
+    @pytest.mark.parametrize("days", [0, 1])
+    def test_the_locked_phase_still_does_not_trade(self, days, monkeypatch):
+        """Deliberately unchanged. Nothing about flips justifies reopening the
+        phase that also governs max_trades right before a kickoff."""
+        p = _phase(days, monkeypatch)
+        assert p.allow_flips is False
+        assert p.max_trades == 0
+
+    def test_an_unknown_schedule_still_refuses_flips(self, monkeypatch):
+        """Fail closed: no fixture date means no budget-at-kickoff guard."""
+        assert _phase(None, monkeypatch).allow_flips is False
+
+
+class TestTheHoldCapNoLongerTracksTheMatchday:
+    def test_a_flip_is_not_forced_out_before_kickoff(self):
+        """The premise was that a flip must be sellable before the match. The
+        lineup locks at kickoff and squad changes land on the next matchday, so
+        there is no such deadline — and a 1-3 day forced hold is the 13%-win
+        bucket."""
+        assert _max_flip_hold_days(2) is None
+        assert _max_flip_hold_days(4) is None
+
+    def test_an_unknown_schedule_is_still_unconstrained(self):
+        assert _max_flip_hold_days(None) is None
+
+    def test_the_old_behaviour_is_reachable_for_rollback(self):
+        """Every behavioural pacing/flip knob in this codebase stays revertible
+        from .env without a deploy."""
+        assert _max_flip_hold_days(4, respect_matchday=True) == 3
+        assert _max_flip_hold_days(1, respect_matchday=True) == 1

--- a/tests/test_profit_dip_buying.py
+++ b/tests/test_profit_dip_buying.py
@@ -165,16 +165,24 @@ class TestLowerDipThreshold:
 
 
 class TestMaxFlipHoldDays:
+    """REH-109 turned the matchday cap OFF by default — the eleven is locked at
+    kickoff, so holding a flip through a match costs nothing, and the 1-3 day
+    exits it forced were the 13%-win-rate bucket. The arithmetic is retained
+    behind `respect_matchday` for rollback, and is still pinned below."""
+
     def test_unknown_schedule_no_cap(self):
         assert _max_flip_hold_days(None) is None
 
+    def test_the_matchday_no_longer_caps_a_hold_by_default(self):
+        assert _max_flip_hold_days(3) is None
+
     def test_3_days_until_match_cap_is_2(self):
         """3 days until match → flip must complete in ≤2 days (1d safety buffer)."""
-        assert _max_flip_hold_days(3) == 2
+        assert _max_flip_hold_days(3, respect_matchday=True) == 2
 
     def test_1_day_until_match_floors_at_1(self):
         """Even with very tight schedule, return at least 1 (don't return 0/negative)."""
-        assert _max_flip_hold_days(1) == 1
+        assert _max_flip_hold_days(1, respect_matchday=True) == 1
 
     def test_far_match_allows_long_holds(self):
-        assert _max_flip_hold_days(10) == 9
+        assert _max_flip_hold_days(10, respect_matchday=True) == 9


### PR DESCRIPTION
## Zero flips since 2026-05-15 — the code path never ran

Not selection, not cash policy. `allow_flips` was `True` in exactly one phase (`days_until_match >= 5`), and against the real calendar that window was **five hours wide**:

- MD2's last fixture: `2026-08-30T13:30Z` → window opens
- MD3's first fixture: `2026-09-04T18:30Z` → minus 5 days = window closes `2026-08-30T18:30Z`

The timer runs **08:00 and 20:00 UTC** and missed it by 90 minutes. Any midweek round (Pokal, European weeks) makes the window mathematically empty.

## The premise was false

Both the phase gate and `_max_flip_hold_days` assumed trading near a matchday disturbs the eleven. **It cannot** — Kickbase locks the fielded eleven at kickoff and every squad change lands on the *following* matchday, so holding a flip through a match costs nothing in points. What genuinely survives is budget-at-kickoff (REH-11), which is about cash, not slots, and is enforced elsewhere.

## Two changes, and they must ship together

Opening the window alone would have made things **worse**. `_max_flip_hold_days` returns `days_until_match − 1`, so a flip bought 2–4 days out gets a 1–3 day forced exit. Measured within rising-trend entries — the only class `flip_buys_require_rising_trend` admits, and the only profitable one (REH-104, PR #92):

| Hold | n | P&L | Win rate |
|---|---:|---:|---:|
| **0–2d** | 23 | **−€9.67M** | **13.0%** |
| 3–7d | 22 | −€4.67M | 50.0% |
| 8–21d | 25 | −€9.34M | 44.0% |
| **22d+** | 12 | **+€26.85M** | **66.7%** |

A 1–3 day forced hold *is* the 13% bucket. So:

- **`moderate` (2–4 days) now allows flips.** `max_trades` stays halved — this reopens flipping, not full-rate churn.
- **`_max_flip_hold_days` no longer derives a cap from the matchday**, retained behind `flip_hold_respects_matchday` (default `False`) for `.env` rollback without a deploy.

Deliberately unchanged: `locked` (0–1 days) and the unknown-schedule path. Nothing about flips justifies reopening the phase that governs spending right at a kickoff, and an unknown fixture date means no budget guard — so it fails closed.

## Testing

11 new tests (RED first). Three pre-existing tests in `test_profit_dip_buying.py` **updated, not weakened** — they pin the cap arithmetic, which is unchanged; they now exercise it via `respect_matchday=True`, with a new test covering the default.

**1411 pass.** ruff clean.

**No replay gate**, and that's deliberate: REH-88 records that the replay has its own buy/sell logic and does not exercise this phase gate, so a number from it would measure nothing here. Saying so rather than reporting a meaningless pass.

## Follow-up not included

`ProfitTrader(max_hold_days=7)` is still hardcoded in `trader.py:910`, so opportunities are still only generated with ≤7-day recommendations. Reaching the 22d+ bucket needs that raised too, and it wants its own measurement.

Closes REH-109.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EA4tBxaBhK4DjMpcYVsPvf