### PR TITLE
fix(trade): trade during a matchday that has already kicked off (REH-110)

### DIFF
--- a/rehoboam/auto_trader.py
+++ b/rehoboam/auto_trader.py
@@ -303,8 +303,38 @@ class AutoTrader:
             self.last_reset = today
             console.print("[cyan]Daily limits reset[/cyan]")
 
-    def _get_matchday_phase(self, days_until_match: int | None) -> MatchdayPhase:
-        """Determine trading aggressiveness based on days to next match."""
+    def _get_matchday_phase(
+        self, days_until_match: int | None, *, matchday_in_progress: bool = False
+    ) -> MatchdayPhase:
+        """Determine trading aggressiveness based on days to next match.
+
+        REH-110: `matchday_in_progress` overrides the day count entirely. Once
+        the round's first fixture has kicked off, Kickbase has locked our
+        eleven and every squad change lands on the FOLLOWING matchday, so there
+        is no lineup left to protect. `days_until_match` still reads 0 all
+        weekend — it is `min()` of the fixtures still to come — which locked the
+        bot out of the Saturday and Sunday of every round for no benefit.
+
+        The budget-at-kickoff guard (REH-11) is deliberately untouched and keeps
+        reading `days_until_match`: that constraint is about cash, not slots,
+        and its conservative "earliest remaining fixture" meaning is correct.
+        """
+        # Applied ONLY where the day count would otherwise lock us out. Between
+        # rounds `days_until_match` can be large while a fixture is still inside
+        # the recent-past window, and blanket-overriding there would DEMOTE an
+        # aggressive phase to a moderate one — more information making the bot
+        # more restrictive, which the invariant test forbids.
+        if matchday_in_progress and days_until_match is not None and days_until_match <= 1:
+            return MatchdayPhase(
+                days_until_match=days_until_match,
+                phase="matchday_in_progress",
+                # The moderate allowance rather than the full one: the round in
+                # progress hides the NEXT round's kickoff, so we cannot see how
+                # much runway a purchase actually has.
+                max_trades=max(self.max_trades_per_session // 2, 2),
+                allow_flips=True,
+                reason="Matchday under way — lineup locked, trading + flips open",
+            )
         if days_until_match is not None and days_until_match <= 1:
             return MatchdayPhase(
                 days_until_match=days_until_match,
@@ -364,7 +394,10 @@ class AutoTrader:
 
         # Fetch matchday timing
         days = trader.get_days_until_match(league)
-        phase = self._get_matchday_phase(days)
+        # Set as a side effect of the call above, so the flag costs no second
+        # /myeleven fetch. Absent (None) whenever that fetch failed.
+        in_progress = bool(getattr(trader, "_last_matchday_in_progress", False))
+        phase = self._get_matchday_phase(days, matchday_in_progress=in_progress)
 
         console.print(f"[cyan]📅 {phase.reason}[/cyan]")
 

--- a/rehoboam/trader.py
+++ b/rehoboam/trader.py
@@ -16,7 +16,7 @@ has been removed.
 """
 
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from rich.console import Console
 
@@ -70,6 +70,40 @@ def _determine_emergency(squad: list) -> tuple[bool, str]:
     if fieldability["ok"]:
         return False, ""
     return True, fieldability["reason"]
+
+
+#: A Bundesliga round spans at most Friday to Monday. A fixture older than this
+#: belongs to a PREVIOUS round, so it must not be read as one in progress —
+#: otherwise a single un-rolled date would unlock trading permanently.
+MATCHDAY_ROUND_SPAN_DAYS = 4
+
+
+def matchday_in_progress(
+    fixtures: "list[datetime]",
+    now: "datetime",
+    *,
+    span_days: int = MATCHDAY_ROUND_SPAN_DAYS,
+) -> bool:
+    """Has the current matchday already kicked off? (REH-110)
+
+    True when any of our players' fixtures for this round is in the recent
+    past. Kickbase locks the fielded eleven at the round's first kickoff and
+    every squad change lands on the FOLLOWING matchday, so once that instant
+    passes there is no lineup left to protect and trading is free.
+
+    `get_days_until_match` cannot answer this: it takes `min()` of the fixtures
+    still to come, so on the Saturday of a round that began Friday evening it
+    reports 0 days and the bot locks itself out. Measured live 2026-08-29,
+    that cost the Saturday and Sunday of every matchday — two tradeable days a
+    week.
+
+    All fixtures in the past also returns True: that is the gap between rounds,
+    the safest moment to trade rather than the least.
+
+    Pure, so the round-boundary reasoning is testable without an API.
+    """
+    cutoff = now - timedelta(days=span_days)
+    return any(cutoff <= f < now for f in fixtures)
 
 
 def _parse_match_date(value) -> datetime | None:
@@ -177,6 +211,8 @@ class Trader:
                     parsed = _parse_match_date(entry.get("md"))
                     if parsed is not None:
                         candidates.append(parsed)
+
+        self._last_matchday_in_progress = matchday_in_progress(candidates, now)
 
         upcoming = [d for d in candidates if d >= now]
         if not upcoming:

--- a/tests/test_matchday_in_progress.py
+++ b/tests/test_matchday_in_progress.py
@@ -1,0 +1,88 @@
+"""Trading during a matchday that has already kicked off (REH-110).
+
+`get_days_until_match` takes `min()` of the fixtures still to come, so on a
+Saturday morning — with two players already having played on Friday evening —
+it reports "match in 0d" and the bot refuses to trade. But the eleven was
+locked at Friday's kickoff and every squad change now lands on the NEXT
+matchday, so there is nothing left to protect.
+
+Measured live 2026-08-29 09:34Z, straight from /myeleven:
+
+    Pavlović   md=2026-08-28T18:30:00Z   PAST   (-0.63d)
+    Führich    md=2026-08-28T18:30:00Z   PAST   (-0.63d)
+    Flekken    md=2026-08-29T13:30:00Z   FUTURE (+0.16d)
+    Stark      md=2026-08-30T13:30:00Z   FUTURE (+1.16d)
+
+A `md` in the past is proof the round has begun. That costs two tradeable days
+per week — the Saturday and Sunday of every matchday.
+
+The budget-at-kickoff guard (REH-11) is deliberately NOT changed: it keys off
+`get_days_until_match`, whose "earliest remaining fixture" meaning is the right
+one for cash and stays conservative.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from rehoboam.trader import matchday_in_progress
+
+NOW = datetime(2026, 8, 29, 9, 34, tzinfo=timezone.utc)
+
+
+def at(days: float) -> datetime:
+    return NOW + timedelta(days=days)
+
+
+class TestDetectingARoundInProgress:
+    def test_a_fixture_already_played_means_the_round_started(self):
+        """The live case: Pavlović played Friday, Flekken plays this afternoon."""
+        assert matchday_in_progress([at(-0.63), at(0.16), at(1.16)], NOW) is True
+
+    def test_all_fixtures_still_ahead_means_it_has_not(self):
+        assert matchday_in_progress([at(0.16), at(1.16)], NOW) is False
+
+    def test_a_finished_round_still_counts_as_free_to_trade(self):
+        """Every fixture played and the API has not rolled `md` forward yet.
+        Between rounds is the safest moment to trade, not the least safe."""
+        assert matchday_in_progress([at(-1.5), at(-0.6)], NOW) is True
+
+    def test_a_stale_fixture_from_a_previous_round_does_not_count(self):
+        """Otherwise one un-rolled date would unlock trading forever."""
+        assert matchday_in_progress([at(-9.0), at(0.16)], NOW) is False
+
+    def test_no_fixtures_at_all_is_not_a_round_in_progress(self):
+        assert matchday_in_progress([], NOW) is False
+
+
+class TestThePhaseUnlocks:
+    def _phase(self, days, monkeypatch, in_progress):
+        monkeypatch.setenv("KICKBASE_EMAIL", "test@example.com")
+        monkeypatch.setenv("KICKBASE_PASSWORD", "test")
+        from unittest.mock import MagicMock
+
+        from rehoboam.auto_trader import AutoTrader
+        from rehoboam.config import Settings
+
+        trader = AutoTrader(api=MagicMock(), settings=Settings(), dry_run=True)
+        return trader._get_matchday_phase(days, matchday_in_progress=in_progress)
+
+    def test_a_round_in_progress_trades_even_at_zero_days(self, monkeypatch):
+        """The whole point: Saturday and Sunday become tradeable again."""
+        p = self._phase(0, monkeypatch, True)
+        assert p.allow_flips is True
+        assert p.max_trades > 0
+
+    def test_it_still_locks_before_the_first_kickoff(self, monkeypatch):
+        """Friday afternoon, nothing played yet — the lineup is still live and
+        the -100 risk is real."""
+        p = self._phase(0, monkeypatch, False)
+        assert p.allow_flips is False
+        assert p.max_trades == 0
+
+    @pytest.mark.parametrize("days", [2, 4, 7])
+    def test_a_round_in_progress_never_reduces_what_was_allowed(self, days, monkeypatch):
+        before = self._phase(days, monkeypatch, False)
+        after = self._phase(days, monkeypatch, True)
+        assert after.max_trades >= before.max_trades
+        assert after.allow_flips or not before.allow_flips


### PR DESCRIPTION
## Two tradeable days lost every week

`get_days_until_match` takes `min()` of the fixtures **still to come**. On the Saturday of a round that began Friday evening, the earliest remaining fixture is hours away → reports `0` → phase `locked` → no trades, no flips, and `run_full_session` returns at Step 3 before the sell phase runs.

But Kickbase locks the fielded eleven at the round's first kickoff, and every squad change lands on the **following** matchday. There is no lineup left to protect — the phase was defending against a risk that ended on Friday.

Measured live 2026-08-29 09:34Z, straight from `/myeleven`:

```
Pavlović   md=2026-08-28T18:30:00Z   PAST   (-0.63d)
Führich    md=2026-08-28T18:30:00Z   PAST   (-0.63d)
Flekken    md=2026-08-29T13:30:00Z   FUTURE (+0.16d)
Stark      md=2026-08-30T13:30:00Z   FUTURE (+1.16d)
```

Two players had already played. The proof was in the payload the bot already fetches — it only ever looked at the fixtures ahead.

## The fix

New pure `trader.matchday_in_progress(fixtures, now)`: true when any fixture is in the recent past, bounded by `MATCHDAY_ROUND_SPAN_DAYS = 4` so one un-rolled date can't unlock trading permanently. All-fixtures-past also returns true — that's the gap between rounds, the *safest* moment to trade. Computed inside the existing `get_days_until_match` call, so no second `/myeleven` fetch.

**The override applies only where the day count would otherwise lock us out** (`days_until_match <= 1`). Between rounds the day count can be large while a fixture is still in the recent-past window, and a blanket override there **demoted an `aggressive` phase to `moderate`** — more information making the bot more restrictive. An invariant test in the RED batch caught that and now forbids it.

**The budget-at-kickoff guard (REH-11) is deliberately untouched** and still reads `get_days_until_match`. That constraint is about cash, not slots, and its conservative "earliest remaining fixture" meaning is correct — live it still reports `days_to_match=0` today.

## Live smoke, on the exact broken day

```
before: phase=locked                 flip_budget=0
after:  phase=matchday_in_progress   flip_budget=81,482,158
        "Sell Monitoring (trend-aware)" now runs; 1 trade pair found
```

With REH-109 (which opened `moderate` to flips), the tradeable week goes from a five-hour window the scheduler missed entirely to essentially every day except the hours before a round's first kickoff.

## Testing

10 new tests, RED first — 5 on the pure round-boundary logic (already played / all ahead / round finished / stale date / no fixtures) and 5 on the phase, including the invariant that a round in progress must never reduce what was already allowed.

**1421 pass.** ruff clean. No replay gate — REH-88 records the replay doesn't exercise this phase gate, so a number from it would measure nothing.

Closes REH-110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EA4tBxaBhK4DjMpcYVsPvf