### PR TITLE
fix(bidding): judge an open bid by the ceiling it was priced against (REH-111)

### DIFF
--- a/rehoboam/auto_trader.py
+++ b/rehoboam/auto_trader.py
@@ -1896,9 +1896,25 @@ class AutoTrader:
                         f"[cyan]Bid compliance: {adjusted} adjusted, {canceled} canceled[/cyan]"
                     )
 
+                # REH-111: each open bid carries the tier it was priced under,
+                # so a squad upgrade is not re-read as a flip and cancelled for
+                # exceeding a flip's ceiling. Best-effort like every other
+                # learning read — no tiers means the previous behaviour, not a
+                # dead evaluation phase.
+                bid_tiers: dict[str, str] = {}
+                if self.learner is not None:
+                    try:
+                        bid_tiers = {
+                            str(row["player_id"]): row["tier"]
+                            for row in self.learner.get_pending_bids()
+                            if row.get("tier")
+                        }
+                    except Exception:
+                        logger.warning("could not read bid tiers", exc_info=True)
+
                 bid_evaluator = BidEvaluator(self.api, self.settings)
                 bid_evaluations = bid_evaluator.evaluate_active_bids(
-                    league, player_trends=player_trends, for_profit=True
+                    league, player_trends=player_trends, for_profit=True, bid_tiers=bid_tiers
                 )
                 if bid_evaluations:
                     bid_evaluator.display_bid_evaluations(bid_evaluations)

--- a/rehoboam/bid_evaluator.py
+++ b/rehoboam/bid_evaluator.py
@@ -23,6 +23,39 @@ class BidEvaluation:
     profit_potential: float = 0.0
 
 
+def untiered_price_ceiling(market_value: int, policy) -> int:
+    """The price ceiling for an open bid with no recorded tier.
+
+    A bid reaches here when `pending_bids` has no tier for it: rows written
+    before REH-111 added the column, a bid placed straight through
+    `ExecutionService.buy` by a path that does not carry one, or a bid the DB
+    lost track of. The choice is a real trade-off and it governs real money:
+
+      * **Tightest (`Tier.MARGINAL`, 8%)** — mirrors `bid_ceiling.FALLBACK_TIER`,
+        whose stated rule is that a proposal must not buy itself a larger
+        ceiling by losing its tier. Consistent, but it cancels *more* than the
+        old flat cap did, so every legacy bid in flight gets withdrawn on the
+        next session — the exact failure REH-111 exists to stop.
+      * **Status quo (flat 25%)** — what shipped before REH-111. Cancels only
+        the must-have band, i.e. only the bids we most wanted to keep.
+      * **Widest (`Tier.MUST_HAVE`, 35%)** — never cancels a bid the bidder
+        could legally have placed. Safe against false cancels; lets a genuinely
+        overpriced untiered flip bid ride until it resolves or expires.
+
+    TODO(marco): pick the policy and replace the body. The placeholder below
+    preserves pre-REH-111 behaviour so nothing regresses while undecided.
+
+    Args:
+        market_value: The player's current market value, in euros.
+        policy: The `BidCeilingPolicy` from `Settings.bid_ceiling_policy()`;
+            use `policy.max_bid(market_value, tier)` to price against a tier.
+
+    Returns:
+        The highest bid, in euros, that may stand without being cancelled.
+    """
+    return int(market_value * 1.25)
+
+
 class BidEvaluator:
     """Evaluates active bids and recommends actions"""
 
@@ -35,8 +68,26 @@ class BidEvaluator:
         self.api = api
         self.settings = settings
 
+    def _price_ceiling(self, market_value: int, tier: str | None) -> int:
+        """The highest this bid may stand at before it counts as too expensive.
+
+        One definition, shared with the bidder and the gate (REH-99), so a bid
+        the bidder was allowed to place cannot be cancelled here for its price.
+        A flat cap cannot do this job: it sat at 25%, exactly the `strong`
+        ceiling, which made `must_have` the only tier the evaluator could
+        cancel — the highest-EP acquisitions, and nothing else (REH-111).
+        """
+        policy = self.settings.bid_ceiling_policy()
+        if tier is not None:
+            return policy.max_bid(market_value, tier)
+        return untiered_price_ceiling(market_value, policy)
+
     def evaluate_active_bids(
-        self, league, player_trends: dict = None, for_profit: bool = True
+        self,
+        league,
+        player_trends: dict = None,
+        for_profit: bool = True,
+        bid_tiers: dict[str, str] | None = None,
     ) -> list[BidEvaluation]:
         """
         Evaluate all active bids
@@ -45,10 +96,14 @@ class BidEvaluator:
             league: League object
             player_trends: Dict mapping player_id -> trend data
             for_profit: If True, evaluate as profit flips. If False, evaluate for lineup
+            bid_tiers: Dict mapping player_id -> the tier the bid was priced
+                against, from `pending_bids`. A player absent from this map has
+                no recorded tier — see `untiered_price_ceiling`.
 
         Returns:
             List of BidEvaluation objects
         """
+        bid_tiers = bid_tiers or {}
         evaluations = []
 
         # Get active bids
@@ -85,6 +140,14 @@ class BidEvaluator:
                 ((our_bid - market_value) / market_value) * 100 if market_value > 0 else 0
             )
 
+            # A bid carries the intent it was placed with (REH-111). Flip
+            # economics — a falling market-value trend, the appreciation floor
+            # — only decide a bid taken for appreciation. A tiered bid was
+            # priced for matchday points, and a must-have that never gains a
+            # euro of market value still scores every week we hold it.
+            tier = bid_tiers.get(bid_player.id)
+            judge_as_flip = for_profit and tier is None
+
             # Decision logic
             recommendation = "KEEP"
             reason = ""
@@ -96,7 +159,7 @@ class BidEvaluator:
                 recommendation = "CANCEL"
                 reason = f"Player is injured (status: {bid_player.status})"
 
-            elif is_falling and trend_pct < -10 and for_profit:
+            elif is_falling and trend_pct < -10 and judge_as_flip:
                 # Falling trend - but check if it's a mean reversion opportunity first
                 # Mean reversion: player far below peak (>50%) with good performance
                 # peak_value and current_value already extracted above (lines 74-75)
@@ -113,14 +176,18 @@ class BidEvaluator:
                     recommendation = "CANCEL"
                     reason = f"Falling trend ({trend_pct:.1f}%) - not good for flips"
 
-            elif for_profit and bid_vs_mv_pct > 25:
-                # For profit flips, don't bid >25% over market value (relaxed from 15%)
+            elif for_profit and our_bid > self._price_ceiling(market_value, tier):
+                # Above the ceiling this bid was actually priced against.
                 recommendation = "CANCEL"
-                reason = f"Bid {bid_vs_mv_pct:.1f}% over market value - too expensive for flip"
+                reason = f"Bid {bid_vs_mv_pct:.1f}% over market value - above its ceiling"
 
             # KEEP conditions
             else:
-                if for_profit:
+                if tier is not None:
+                    # Within the ceiling it was priced against, and held for
+                    # points rather than appreciation — nothing left to fail.
+                    reason = f"Priced as {tier} — within its ceiling"
+                elif judge_as_flip:
                     # Calculate expected profit potential
                     # Accept rising trends, stable good performers, or mean reversion plays
                     expected_appreciation = 0

--- a/rehoboam/bid_learner.py
+++ b/rehoboam/bid_learner.py
@@ -264,6 +264,17 @@ class BidLearner:
                 )
             """
             )
+            # REH-111: the ceiling the bid was priced against. `bid_evaluator`
+            # re-reads every open bid each session and cancelled anything above
+            # a flat 25% — exactly the `strong` ceiling, so `must_have` was the
+            # only tier it could cancel. Without the tier here it cannot tell a
+            # squad upgrade from a flip. Added separately so an existing prod
+            # table gains it in place; rows written before this read NULL.
+            try:
+                conn.execute("ALTER TABLE pending_bids ADD COLUMN tier TEXT")
+            except sqlite3.OperationalError:
+                pass  # already present
+
             conn.execute(
                 """
                 CREATE INDEX IF NOT EXISTS idx_pending_bids_timestamp
@@ -694,6 +705,7 @@ class BidLearner:
         market_value: int | None = None,
         player_value_score: float | None = None,
         sell_plan_player_ids: list[str] | None = None,
+        tier: str | None = None,
     ) -> None:
         """Record a freshly placed bid as pending (outcome TBD).
 
@@ -705,9 +717,10 @@ class BidLearner:
                 """
                 INSERT OR REPLACE INTO pending_bids (
                     player_id, player_name, our_bid, asking_price,
-                    our_overbid_pct, timestamp, market_value, player_value_score
+                    our_overbid_pct, timestamp, market_value, player_value_score,
+                    tier
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
                 (
                     player_id,
@@ -718,6 +731,7 @@ class BidLearner:
                     timestamp,
                     market_value,
                     player_value_score,
+                    tier,
                 ),
             )
             # Replace sell-plan rows: an INSERT OR REPLACE on pending_bids
@@ -744,7 +758,8 @@ class BidLearner:
             rows = conn.execute(
                 """
                 SELECT player_id, player_name, our_bid, asking_price,
-                       our_overbid_pct, timestamp, market_value, player_value_score
+                       our_overbid_pct, timestamp, market_value, player_value_score,
+                       tier
                 FROM pending_bids
                 ORDER BY timestamp ASC
             """

--- a/rehoboam/learning/tracker.py
+++ b/rehoboam/learning/tracker.py
@@ -92,6 +92,7 @@ class LearningTracker:
         player,
         our_bid: int,
         sell_plan_player_ids: list[str] | None = None,
+        tier: str | None = None,
     ) -> None:
         """Record a freshly-placed bid as pending (outcome TBD).
 
@@ -112,6 +113,7 @@ class LearningTracker:
                 timestamp=time.time(),
                 market_value=getattr(player, "market_value", 0),
                 sell_plan_player_ids=sell_plan_player_ids,
+                tier=tier,
             )
         except Exception as e:
             logger.warning("Failed to record bid placement: %s", e)

--- a/rehoboam/notify/approval.py
+++ b/rehoboam/notify/approval.py
@@ -40,7 +40,7 @@ def authorize(secret_header: str | None, expected: str) -> bool:
     return bool(expected) and hmac.compare_digest(secret_header or "", expected)
 
 
-def _record_bid_for_learning(learner, player, bid: int) -> None:
+def _record_bid_for_learning(learner, player, bid: int, tier: str | None = None) -> None:
     """Feed an approved buy into the loop the autonomous path already uses.
 
     ``ExecutionService.buy`` records every autonomous bid as pending so
@@ -55,7 +55,7 @@ def _record_bid_for_learning(learner, player, bid: int) -> None:
     try:
         from rehoboam.learning.tracker import LearningTracker
 
-        LearningTracker(learner).record_bid_placed(player, bid)
+        LearningTracker(learner).record_bid_placed(player, bid, tier=tier)
     except Exception:
         logger.warning("approval: could not record approved bid for learning", exc_info=True)
 
@@ -144,7 +144,7 @@ def handle_callback(
         return f"Buy failed: {exc}"
 
     learner.set_proposal_status(proposal_id, "executed")
-    _record_bid_for_learning(learner, live, int(proposal["bid"]))
+    _record_bid_for_learning(learner, live, int(proposal["bid"]), tier=proposal.get("tier"))
     return f"Bought {proposal['player_name']} for EUR {int(proposal['bid']):,}."
 
 

--- a/rehoboam/services/execution.py
+++ b/rehoboam/services/execution.py
@@ -167,7 +167,14 @@ class ExecutionService:
             success_msg=f"Buy order placed for {player.first_name} {player.last_name}",
             api_call=lambda: self.api.buy_player(league, player, price),
             on_success=lambda: self.tracker.record_bid_placed(
-                player, price, sell_plan_player_ids=sell_plan_player_ids
+                player,
+                price,
+                sell_plan_player_ids=sell_plan_player_ids,
+                # REH-111: the ceiling this bid was sized under, so the next
+                # session's `bid_evaluator` judges it by the same number rather
+                # than by a flip's. A profit flip carries `tier=None` and keeps
+                # being judged as a flip, which is correct.
+                tier=getattr(gate.tier, "value", gate.tier),
             ),
         )
 

--- a/tests/test_tier_aware_bid_evaluation.py
+++ b/tests/test_tier_aware_bid_evaluation.py
@@ -1,0 +1,152 @@
+"""An open bid must be judged by the ceiling it was priced against (REH-111).
+
+`bid_ceiling.py` (REH-99) lets a `must_have` bid reach market value +30%.
+`bid_evaluator.py` then re-read every open bid with `for_profit=True` and
+cancelled anything over +25% as "too expensive for flip" — a flip's economics
+applied to a bid that was never a flip. The bot withdrew its own best offers:
+
+    Kleindienst  2026-08-30 08:12  ours 24,748,891 on MV 19,038,891  (+30.0%)
+    Badé         2026-08-30 08:12  ours 17,126,503 on MV 13,176,503  (+30.0%)
+
+Both were cancelled by the 20:00 session that evening ("Keep: 1, Cancel: 2").
+Seven hours later Kupka took Kleindienst for 21,548,071 — 3,200,820 BELOW the
+bid we had just withdrawn. This is the mechanism behind the REH-102 alarm:
+losing while holding the best price, because the offer was gone.
+
+The property asserted here mirrors `test_bid_ceiling_agreement.py`: **anything
+the bidder was allowed to offer, the evaluator must be willing to leave
+standing.** Only a bid above its own tier's ceiling may be cancelled on price.
+"""
+
+import pytest
+
+from rehoboam.bid_evaluator import BidEvaluator
+from rehoboam.bid_learner import BidLearner
+from rehoboam.config import Settings
+from rehoboam.kickbase_client import MarketPlayer
+from rehoboam.services.bid_ceiling import Tier
+
+LEAGUE = "1933872"
+
+
+def _settings():
+    return Settings(kickbase_email="test@example.com", kickbase_password="x")
+
+
+def _listing(player_id: str, name: str, market_value: int, our_bid: int) -> MarketPlayer:
+    """A Kickbase-listed player carrying our open offer."""
+    return MarketPlayer(
+        id=player_id,
+        first_name="",
+        last_name=name,
+        position="Forward",
+        team_id="15",
+        team_name="",
+        price=market_value,
+        market_value=market_value,
+        points=0,
+        average_points=60.0,
+        status=0,
+        seller_user_id=None,
+        offer_count=1,
+        user_offer_price=our_bid,
+        user_offer_id="3616202",
+    )
+
+
+class _FakeApi:
+    """Only the two calls `BidEvaluator` makes."""
+
+    def __init__(self, listings):
+        self._listings = listings
+
+    def get_my_bids(self, league):
+        return list(self._listings)
+
+    def get_market(self, league):
+        return list(self._listings)
+
+
+# The real Kleindienst listing the bot cancelled itself out of.
+KLEINDIENST = _listing("849", "Kleindienst", market_value=19_038_891, our_bid=24_748_891)
+
+
+def _evaluate(listing, tiers):
+    evaluator = BidEvaluator(_FakeApi([listing]), _settings())
+    return evaluator.evaluate_active_bids(
+        LEAGUE, player_trends={}, for_profit=True, bid_tiers=tiers
+    )[0]
+
+
+class TestABidIsJudgedByItsOwnCeiling:
+    def test_a_must_have_bid_at_its_ceiling_is_kept(self):
+        """+30% is the must_have ceiling, so it is not 'too expensive'."""
+        result = _evaluate(KLEINDIENST, {"849": Tier.MUST_HAVE.value})
+
+        assert result.recommendation == "KEEP", result.reason
+
+    def test_a_marginal_bid_above_its_ceiling_is_still_cancelled(self):
+        """The guard must still fire — this is not a licence to overpay."""
+        result = _evaluate(KLEINDIENST, {"849": Tier.MARGINAL.value})
+
+        assert result.recommendation == "CANCEL"
+        assert "over market value" in result.reason
+
+    @pytest.mark.parametrize("tier", list(Tier))
+    def test_no_tier_is_cancelled_at_its_own_ceiling(self, tier):
+        """The agreement property, across every tier the bidder can assign."""
+        policy = _settings().bid_ceiling_policy()
+        mv = 19_038_891
+        listing = _listing("849", "Kleindienst", market_value=mv, our_bid=policy.max_bid(mv, tier))
+
+        result = _evaluate(listing, {"849": tier.value})
+
+        assert result.recommendation == "KEEP", result.reason
+
+
+class TestTheTierSurvivesTheRoundTrip:
+    """The evaluator can only honour a tier the DB actually kept."""
+
+    def test_a_recorded_tier_comes_back_out(self, tmp_path):
+        learner = BidLearner(db_path=tmp_path / "bid_learning.db")
+        learner.add_pending_bid(
+            player_id="849",
+            player_name="Tim Kleindienst",
+            our_bid=24_748_891,
+            asking_price=19_038_891,
+            our_overbid_pct=29.99,
+            timestamp=1_788_077_520.0,
+            market_value=19_038_891,
+            tier=Tier.MUST_HAVE.value,
+        )
+
+        assert learner.get_pending_bids()[0]["tier"] == "must_have"
+
+    def test_a_bid_recorded_without_a_tier_reads_back_as_none(self, tmp_path):
+        """Pre-REH-111 rows, and paths that do not carry a tier."""
+        learner = BidLearner(db_path=tmp_path / "bid_learning.db")
+        learner.add_pending_bid(
+            player_id="849",
+            player_name="Tim Kleindienst",
+            our_bid=24_748_891,
+            asking_price=19_038_891,
+            our_overbid_pct=29.99,
+            timestamp=1_788_077_520.0,
+            market_value=19_038_891,
+        )
+
+        assert learner.get_pending_bids()[0]["tier"] is None
+
+
+class TestTheApprovedBidRecordsItsTier:
+    """The approval path knows the tier — it must not drop it on the floor."""
+
+    def test_record_bid_placed_persists_the_tier(self, tmp_path):
+        from rehoboam.learning.tracker import LearningTracker
+
+        learner = BidLearner(db_path=tmp_path / "bid_learning.db")
+        listing = _listing("849", "Kleindienst", market_value=19_038_891, our_bid=24_748_891)
+
+        LearningTracker(learner).record_bid_placed(listing, 24_748_891, tier=Tier.MUST_HAVE.value)
+
+        assert learner.get_pending_bids()[0]["tier"] == "must_have"


### PR DESCRIPTION
## The bot was cancelling its own winning bids

`bid_ceiling.py` (REH-99) lets a `must_have` bid reach market value **+35%**, and the bidder routinely sizes at **+30%**. `auto_trader.py` then re-read every open bid with `for_profit=True` **hardcoded**, and `bid_evaluator.py:116` cancelled anything over a flat **25%** as "too expensive for flip".

The tier ceilings are marginal 8%, solid 15%, strong 25%, must_have 35%. The flip cap sits **exactly** on `strong` — so `must_have` was the only tier the evaluator could cancel. The bot was systematically withdrawing offers on precisely its highest-EP targets.

## Evidence from prod

`2026-08-30 20:00` — `Checking 3 active bid(s)` → **`Keep: 1, Cancel: 2`**:

| Player | Our bid | vs MV | Outcome |
|---|---|---|---|
| Hložek | €12,500,000 | +13.9% | kept |
| **Kleindienst** | **€24,748,891** | **+30.0%** | **cancelled** |
| **Badé** | **€17,126,503** | **+30.0%** | **cancelled** |

Seven hours later Kupka took Kleindienst for **€21,548,071** — €3,200,820 *below* the bid we had just withdrawn. Orban went the same way: ours €40,386,341, KickAss paid €31,750,000.

This is the mechanism behind REH-102's alarm ("losing while holding the best price — the offer was gone"). That alarm is observational and fires a session late, so it never prevented the recurrence.

A **second** rule did the same damage, surfaced by the new tests: the KEEP branch cancels any bid with `profit_potential < 8%` (`"Low profit potential: 0.0%"`). A must-have held for matchday points does not need to appreciate.

## The change

A bid now carries the intent it was placed with:

- `pending_bids` gains a `tier` column (in-place `ALTER`, pre-existing rows read NULL)
- threaded from **both** producers — the Telegram approval path and `ExecutionService.buy` (which takes it from the `BuyGate` it already builds)
- price is judged against that tier's ceiling; flip economics (falling trend, appreciation floor) apply only to bids placed as flips

REH-99's docstring says it existed to stop the bidder and the gate holding unconnected copies of one rule. It reconciled bidder↔gate but not bidder↔**evaluator**.

## Left as an explicit decision

`untiered_price_ceiling()` governs bids with no recorded tier (pre-REH-111 rows). Marked `TODO(marco)` with the three options and their trade-offs; the placeholder preserves pre-REH-111 behaviour rather than silently picking a policy.

## Verification

- 9 new tests, each watched fail first (`TypeError: unexpected keyword argument 'bid_tiers'`, then the low-profit rule as a second RED)
- **1430 passed, 1 skipped** on this branch alone; ruff clean
- Replay **27,751 — unchanged**. Predicted before running: `rehoboam/replay/` has zero references to `BidEvaluator` or `pending_bids`, so this is *provably inert on that instrument*, not a pass
- Live smoke against prod: the two real open bids (untiered) evaluate exactly as before — no unintended change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgdBR45xMFtj2zTgFL1VEn