### PR TITLE
fix(emergency): fill the eleven, not the ranking (REH-113)

### DIFF
--- a/rehoboam/auto_trader.py
+++ b/rehoboam/auto_trader.py
@@ -1191,9 +1191,17 @@ class AutoTrader:
         active_bid_ids = set(ctx.my_bid_amounts.keys())
         budget_remaining = int(ctx.current_budget)
 
-        # Score each candidate: gap-filling positions first, then by EP.
-        # Tuple sort: (-fills_gap, -marginal_ep_gain) so gap fills sort to front.
-        scored = []
+        # REH-113: choose the BASKET that scores the most points, not the
+        # best-ranked player affordable right now. An empty slot is -100 per
+        # slot regardless of who fills it, so `select_emergency_basket`
+        # maximises `total_ep + 100 x count` on ASK price and spends the
+        # leftover as overbid afterwards. The old greedy walk ignored the
+        # penalty entirely and bought 3 of 4 on 2026-08-31, missing the fourth
+        # by 1,168,502 of overbid it had already committed elsewhere.
+        from .services.emergency_basket import EmergencyCandidate, select_emergency_basket
+
+        by_id: dict[str, object] = {}
+        candidates: list[EmergencyCandidate] = []
         for rec in buy_recs:
             # REH-85 pacing can legitimately size recommended_bid to 0 (its
             # reserve rule consumed the whole spendable budget). An empty
@@ -1217,21 +1225,54 @@ class AutoTrader:
             # at kickoff that the emergency path explicitly avoids. The
             # affordability check still applies to the fallback bid — the
             # exemption is from pacing, not from the budget guard.
-            if bid > budget_remaining:
-                continue
-            fills_gap = 1 if rec.player.position in gap_positions else 0
-            scored.append((fills_gap, rec.marginal_ep_gain or 0.0, bid, rec))
+            # The floor is the asking price — a bid below it cannot win — and
+            # the ceiling is the paced bid the gate will accept. Selection
+            # happens between the two.
+            ask = int(rec.player.price) or int(bid)
+            by_id[rec.player.id] = rec
+            candidates.append(
+                EmergencyCandidate(
+                    id=rec.player.id,
+                    name=rec.player.last_name,
+                    ask=ask,
+                    max_bid=max(int(bid), ask),
+                    ep=float(rec.marginal_ep_gain or 0.0),
+                    fills_gap=rec.player.position in gap_positions,
+                    position=rec.player.position,
+                )
+            )
 
-        scored.sort(key=lambda t: (-t[0], -t[1]))
+        picks = select_emergency_basket(candidates, slots_short, budget_remaining)
 
-        if not scored:
+        if not picks:
             console.print(
                 "[red]No affordable wash-trade-clean candidates " "to fill empty slot(s)[/red]"
             )
             return results
 
+        logger.info(
+            "emergency-basket slots_short=%d budget=%d picked=%d spend=%d | %s",
+            slots_short,
+            budget_remaining,
+            len(picks),
+            sum(p.bid for p in picks),
+            ", ".join(f"{p.candidate.name}@{p.bid:,}" for p in picks),
+        )
+
+        # The basket is the plan; the rest of the board is the reserve behind
+        # it. A gate refusal means "try the next candidate", not "field
+        # nobody", so an unchosen candidate must still be reachable when a
+        # pick is refused — otherwise the slot stays empty at -100.
+        chosen_ids = {p.candidate.id for p in picks}
+        attempts: list[tuple[object, int]] = [(by_id[p.candidate.id], p.bid) for p in picks]
+        attempts += [
+            (by_id[c.id], c.max_bid)
+            for c in sorted(candidates, key=lambda c: -c.ep)
+            if c.id not in chosen_ids
+        ]
+
         bought = 0
-        for _gap, _ep, bid, rec in scored:
+        for rec, bid in attempts:
             if bought >= slots_short:
                 break
             if bid > budget_remaining:

--- a/rehoboam/services/emergency_basket.py
+++ b/rehoboam/services/emergency_basket.py
@@ -1,0 +1,210 @@
+"""Which players to buy when the squad cannot field a legal eleven.
+
+Pure, like `safety_gate`, so the choice that spends the whole budget in one
+session can be tested exhaustively rather than observed in production.
+
+**The objective is `total_ep + 100 x players_bought`.** An empty lineup slot
+costs -100 points at kickoff, every matchday, and that penalty is per SLOT —
+it does not care who fills it. Ranking candidates by expected points and
+walking the list greedily ignores the term entirely, which is how the
+2026-08-31 session bought three players and left the fourth slot empty:
+
+    Nadir        ask  2,571,571   bid  2,957,306  (+15%)   EP 35.0
+    Ebnoutalib   ask 12,712,298   bid 15,252,298  (+20%)   EP 61.2   fills gap
+    El-Faouzi    ask 14,778,365   bid 19,208,365  (+30%)   EP 94.5
+    Avdullahu    ask 16,904,943   bid 21,974,943  (+30%)   EP 70.5
+
+Four cheapest asks total 46,967,177 against a 55,485,928 budget and fit. Four
+cheapest *bids* total 56,654,430 and miss by 1,168,502. So the basket is sized
+on the asking price — the most slots that fit — and the leftover is spent
+afterwards as overbid, best players first. The overbid buys a better chance at
+one auction; the slot it costs is a certain -100.
+
+Writing the objective out rather than hard-coding "more players always wins"
+matters at the edges: cardinality dominates exactly while EP spreads stay
+under the penalty, and correctly stops dominating when one exceeds it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from itertools import combinations
+
+#: What an unfilled lineup slot costs at kickoff. The league rule, not a knob.
+EMPTY_SLOT_PENALTY = 100.0
+
+#: Above this many candidates, fall back to a greedy walk. Exact enumeration
+#: is 2**n; `recommend_buys` returns 8, so the exact path is what actually
+#: runs, and the bound only stops a future widening of the pool from hanging
+#: a live trading session.
+_EXACT_ENUMERATION_LIMIT = 18
+
+
+@dataclass(frozen=True)
+class EmergencyCandidate:
+    """One buyable player, priced two ways.
+
+    `ask` is what the listing costs — the floor, since a bid below it cannot
+    win. `max_bid` is what the pacing/bidding stack sized for this player,
+    which is the ceiling the safety gate will accept.
+    """
+
+    id: str
+    name: str
+    ask: int
+    max_bid: int
+    ep: float
+    fills_gap: bool = False
+    position: str = ""
+
+
+@dataclass(frozen=True)
+class EmergencyPick:
+    """A chosen candidate and the bid to place for them."""
+
+    candidate: EmergencyCandidate
+    bid: int
+
+
+@dataclass(frozen=True)
+class _Basket:
+    members: tuple[EmergencyCandidate, ...]
+    value: float = field(compare=False, default=0.0)
+
+
+def _priority(c: EmergencyCandidate) -> float:
+    """What one player contributes to `_value`, for ordering one at a time.
+
+    Shared by the greedy fallback and the overbid distribution so neither can
+    disagree with the selector about what a pick is worth. A gap filler counts
+    the penalty twice for the reason `_value` gives.
+    """
+    return c.ep + EMPTY_SLOT_PENALTY + (EMPTY_SLOT_PENALTY if c.fills_gap else 0.0)
+
+
+def _value(members: tuple[EmergencyCandidate, ...]) -> float:
+    """Expected points delivered: their scoring, plus the penalties avoided.
+
+    Covering a position below its formation minimum counts as a slot in its
+    own right. A position gap is what makes an eleven *illegal* rather than
+    merely weaker — eleven players and no goalkeeper still fields ten — so a
+    gap filler earns the penalty twice: once for the body, once for making
+    the slot fillable at all. Without that term a higher-EP surplus defender
+    outranks the only available forward, which is how a squad reaches eleven
+    bodies and still takes -100.
+    """
+    ep = sum(c.ep for c in members)
+    slots = EMPTY_SLOT_PENALTY * len(members)
+    gaps = EMPTY_SLOT_PENALTY * len({c.position for c in members if c.fills_gap})
+    return ep + slots + gaps
+
+
+def _rank_key(members: tuple[EmergencyCandidate, ...]) -> tuple:
+    """Sort key for picking the best basket. Higher is better.
+
+    Cost breaks ties so an equal-value basket does not spend more than it
+    needs to — the remainder is another player's bid.
+    """
+    return (_value(members), -sum(c.ask for c in members))
+
+
+def _best_exact(
+    candidates: list[EmergencyCandidate], slots_short: int, budget: int
+) -> tuple[EmergencyCandidate, ...]:
+    best: tuple[EmergencyCandidate, ...] = ()
+    for size in range(1, min(slots_short, len(candidates)) + 1):
+        for combo in combinations(candidates, size):
+            if sum(c.ask for c in combo) > budget:
+                continue
+            if not best or _rank_key(combo) > _rank_key(best):
+                best = combo
+    return best
+
+
+def _best_greedy(
+    candidates: list[EmergencyCandidate], slots_short: int, budget: int
+) -> tuple[EmergencyCandidate, ...]:
+    """Feasibility-preserving greedy, for a pool too large to enumerate.
+
+    Takes candidates in value order but refuses any that would leave too
+    little to afford the cheapest remaining fillers — the check that keeps
+    cardinality intact, and precisely what the plain greedy walk lacked.
+    """
+    order = sorted(candidates, key=lambda c: (-_priority(c), c.ask))
+    by_price = sorted(candidates, key=lambda c: c.ask)
+
+    target = 0
+    running = 0
+    for c in by_price:
+        if target >= slots_short:
+            break
+        if running + c.ask > budget:
+            break
+        running += c.ask
+        target += 1
+
+    chosen: list[EmergencyCandidate] = []
+    remaining = budget
+    for c in order:
+        if len(chosen) >= target:
+            break
+        still_needed = target - len(chosen) - 1
+        pool = [x for x in by_price if x.id != c.id and x not in chosen]
+        cheapest = sum(x.ask for x in pool[:still_needed])
+        if c.ask + cheapest <= remaining:
+            chosen.append(c)
+            remaining -= c.ask
+    return tuple(chosen)
+
+
+def _spend_leftover(members: tuple[EmergencyCandidate, ...], budget: int) -> list[EmergencyPick]:
+    """Raise bids from ask toward `max_bid`, best players first.
+
+    Bidding the whole basket at bare ask would forfeit winnable auctions, and
+    an auction lost leaves the slot empty anyway. Spent in `_priority` order so
+    the players most worth holding get the best chance — gap fillers first,
+    since losing one leaves a formation that cannot legally be fielded.
+    """
+    leftover = budget - sum(c.ask for c in members)
+    picks: dict[str, int] = {c.id: c.ask for c in members}
+    for c in sorted(members, key=lambda c: -_priority(c)):
+        if leftover <= 0:
+            break
+        headroom = max(0, c.max_bid - c.ask)
+        spend = min(headroom, leftover)
+        picks[c.id] += spend
+        leftover -= spend
+    return [EmergencyPick(candidate=c, bid=picks[c.id]) for c in members]
+
+
+def select_emergency_basket(
+    candidates: list[EmergencyCandidate], slots_short: int, budget: int
+) -> list[EmergencyPick]:
+    """Choose the basket of buys that scores the most points this matchday.
+
+    Args:
+        candidates: Buyable players, already filtered for wash trades and
+            existing bids by the caller.
+        slots_short: How many players an eleven is missing.
+        budget: Money available to commit, in euros.
+
+    Returns:
+        The chosen players with the bid to place for each, ask <= bid <=
+        max_bid, totalling no more than `budget`. Empty when nothing is
+        affordable.
+    """
+    if slots_short <= 0 or budget <= 0:
+        return []
+
+    affordable = [c for c in candidates if 0 < c.ask <= budget]
+    if not affordable:
+        return []
+
+    if len(affordable) <= _EXACT_ENUMERATION_LIMIT:
+        members = _best_exact(affordable, slots_short, budget)
+    else:
+        members = _best_greedy(affordable, slots_short, budget)
+
+    if not members:
+        return []
+    return _spend_leftover(members, budget)

--- a/tests/test_emergency_basket.py
+++ b/tests/test_emergency_basket.py
@@ -1,0 +1,209 @@
+"""Filling the eleven is worth more than winning any one auction (REH-113).
+
+`_run_emergency_squad_fill` walked its ranked list greedily and stopped when
+the money ran out. On 2026-08-31, four slots short with EUR 55,485,928, it
+bought three and left a slot empty — a standing -100 — because the bids it
+walked past were inflated:
+
+    Nadir        ask  2,571,571   bid  2,957,306  (+15%)   EP 35.0
+    Ebnoutalib   ask 12,712,298   bid 15,252,298  (+20%)   EP 61.2   fills gap
+    El-Faouzi    ask 14,778,365   bid 19,208,365  (+30%)   EP 94.5
+    Avdullahu    ask 16,904,943   bid 21,974,943  (+30%)   EP 70.5
+    Nusa         ask 26,183,029   bid 34,033,029  (+30%)   EP 86.1
+
+Four cheapest ASKS total 46,967,177 and fit. Four cheapest BIDS total
+56,654,430 and do not, by 1,168,502. The overbid buys a better chance at one
+auction; the slot it costs is a certain -100.
+
+So the basket is chosen on ask price — the most slots that fit — and the
+leftover is then spent as overbid on the players most worth winning. Choosing
+by `total_ep + 100 * count` makes that automatic rather than a rule of thumb:
+cardinality dominates exactly while EP spreads stay under the penalty, and
+stops dominating if one ever exceeds it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rehoboam.services.emergency_basket import (
+    EMPTY_SLOT_PENALTY,
+    EmergencyCandidate,
+    select_emergency_basket,
+)
+
+BUDGET = 55_485_928
+
+# The real 2026-08-31 board, minus the two players we already had bids on.
+NADIR = EmergencyCandidate("15478", "Nadir", ask=2_571_571, max_bid=2_957_306, ep=35.0)
+EBNOUTALIB = EmergencyCandidate(
+    "10004", "Ebnoutalib", ask=12_712_298, max_bid=15_252_298, ep=61.2, fills_gap=True
+)
+EL_FAOUZI = EmergencyCandidate("2967", "El-Faouzi", ask=14_778_365, max_bid=19_208_365, ep=94.5)
+AVDULLAHU = EmergencyCandidate("11162", "Avdullahu", ask=16_904_943, max_bid=21_974_943, ep=70.5)
+NUSA = EmergencyCandidate("9507", "Nusa", ask=26_183_029, max_bid=34_033_029, ep=86.1)
+BAUMANN = EmergencyCandidate("524", "Baumann", ask=17_811_538, max_bid=19_236_461, ep=20.5)
+
+BOARD = [NADIR, EBNOUTALIB, EL_FAOUZI, AVDULLAHU, NUSA, BAUMANN]
+
+
+class TestTheRealAugust31Board:
+    def test_it_fills_all_four_slots(self):
+        picks = select_emergency_basket(BOARD, slots_short=4, budget=BUDGET)
+
+        assert len(picks) == 4, [p.candidate.name for p in picks]
+
+    def test_it_stays_inside_the_budget(self):
+        picks = select_emergency_basket(BOARD, slots_short=4, budget=BUDGET)
+
+        assert sum(p.bid for p in picks) <= BUDGET
+
+    def test_it_covers_the_striker_gap(self):
+        picks = select_emergency_basket(BOARD, slots_short=4, budget=BUDGET)
+
+        assert any(p.candidate.fills_gap for p in picks)
+
+    def test_it_beats_what_the_greedy_walk_bought(self):
+        """Greedy took Ebnoutalib + El-Faouzi + Nadir: 3 slots, EP 190.7."""
+        picks = select_emergency_basket(BOARD, slots_short=4, budget=BUDGET)
+        greedy_value = 190.7 + EMPTY_SLOT_PENALTY * 3
+        value = sum(p.candidate.ep for p in picks) + EMPTY_SLOT_PENALTY * len(picks)
+
+        assert value > greedy_value
+
+
+class TestTheObjective:
+    def test_cardinality_beats_a_single_better_player(self):
+        """Two modest bodies (+200 penalty avoided) beat one strong one."""
+        star = EmergencyCandidate("s", "Star", ask=90, max_bid=100, ep=95.0)
+        a = EmergencyCandidate("a", "A", ask=50, max_bid=50, ep=10.0)
+        b = EmergencyCandidate("b", "B", ask=50, max_bid=50, ep=10.0)
+
+        picks = select_emergency_basket([star, a, b], slots_short=2, budget=100)
+
+        assert sorted(p.candidate.id for p in picks) == ["a", "b"]
+
+    def test_an_ep_gap_wider_than_the_penalty_wins(self):
+        """The penalty is 100, so a 250-point player outweighs a second body."""
+        star = EmergencyCandidate("s", "Star", ask=90, max_bid=90, ep=250.0)
+        a = EmergencyCandidate("a", "A", ask=50, max_bid=50, ep=10.0)
+        b = EmergencyCandidate("b", "B", ask=50, max_bid=50, ep=10.0)
+
+        picks = select_emergency_basket([star, a, b], slots_short=2, budget=100)
+
+        assert [p.candidate.id for p in picks] == ["s"]
+
+    def test_it_never_buys_more_than_the_slots_that_are_short(self):
+        picks = select_emergency_basket(BOARD, slots_short=1, budget=BUDGET)
+
+        assert len(picks) == 1
+
+    def test_an_unaffordable_board_returns_nothing(self):
+        pricey = EmergencyCandidate("x", "X", ask=10_000, max_bid=10_000, ep=50.0)
+
+        assert select_emergency_basket([pricey], slots_short=3, budget=500) == []
+
+    def test_an_empty_board_returns_nothing(self):
+        assert select_emergency_basket([], slots_short=4, budget=BUDGET) == []
+
+
+class TestTheLeftoverBecomesOverbid:
+    def test_no_bid_exceeds_the_paced_maximum(self):
+        picks = select_emergency_basket(BOARD, slots_short=4, budget=BUDGET)
+
+        for p in picks:
+            assert p.bid <= p.candidate.max_bid
+            assert p.bid >= p.candidate.ask
+
+    def test_spare_budget_is_spent_on_overbid_not_left_idle(self):
+        """Bidding every pick at bare ask would forfeit winnable auctions."""
+        picks = select_emergency_basket(BOARD, slots_short=4, budget=BUDGET)
+
+        assert sum(p.bid for p in picks) > sum(p.candidate.ask for p in picks)
+
+    def test_a_rich_budget_pays_every_paced_bid_in_full(self):
+        picks = select_emergency_basket(BOARD, slots_short=4, budget=500_000_000)
+
+        for p in picks:
+            assert p.bid == p.candidate.max_bid
+
+
+@pytest.mark.parametrize("slots", [1, 2, 3, 4, 5])
+def test_the_basket_is_always_affordable_and_within_slots(slots):
+    picks = select_emergency_basket(BOARD, slots_short=slots, budget=BUDGET)
+
+    assert len(picks) <= slots
+    assert sum(p.bid for p in picks) <= BUDGET
+    assert len({p.candidate.id for p in picks}) == len(picks)
+
+
+class TestAPositionGapOutranksRawEP:
+    """A position below its formation minimum makes the eleven ILLEGAL.
+
+    Caught by `test_prioritises_gap_positions_over_raw_ep` when gap coverage
+    was only a tie-break on value: a surplus defender with 25 EP outranked the
+    only forward with 12, and the squad reached eleven bodies still fielding
+    ten. Pinned here so the objective, not just the wiring, holds the line.
+    """
+
+    def test_the_only_forward_beats_a_better_surplus_defender(self):
+        defender = EmergencyCandidate(
+            "def_top", "DefTop", ask=1_000_000, max_bid=1_000_000, ep=25.0, position="Defender"
+        )
+        forward = EmergencyCandidate(
+            "fwd_gap",
+            "FwdGap",
+            ask=1_000_000,
+            max_bid=1_000_000,
+            ep=12.0,
+            fills_gap=True,
+            position="Forward",
+        )
+
+        picks = select_emergency_basket([defender, forward], slots_short=1, budget=5_000_000)
+
+        assert [p.candidate.id for p in picks] == ["fwd_gap"]
+
+    def test_two_forwards_do_not_double_count_one_gap(self):
+        """The gap bonus is per POSITION covered, not per gap-filling player."""
+        fw1 = EmergencyCandidate(
+            "f1", "F1", ask=10, max_bid=10, ep=1.0, fills_gap=True, position="Forward"
+        )
+        fw2 = EmergencyCandidate(
+            "f2", "F2", ask=10, max_bid=10, ep=1.0, fills_gap=True, position="Forward"
+        )
+        gk = EmergencyCandidate(
+            "g1", "G1", ask=10, max_bid=10, ep=1.0, fills_gap=True, position="Goalkeeper"
+        )
+
+        picks = select_emergency_basket([fw1, fw2, gk], slots_short=2, budget=20)
+
+        covered = {p.candidate.position for p in picks}
+        assert covered == {"Forward", "Goalkeeper"}, "should spread across gaps, not stack one"
+
+
+class TestTheOverbidFollowsTheSameObjective:
+    """Leftover must be spent by the value the selector actually used.
+
+    Observed on the 2026-08-31 board: Ebnoutalib, the only forward and the
+    single player making the eleven legal, was bid at bare ask while a surplus
+    midfielder took the overbid. Losing that auction leaves an illegal
+    formation, so it is the one most worth winning — `_value` counts the gap
+    at 100 and the distribution has to agree, or the two disagree about what
+    the basket is for.
+    """
+
+    def test_the_gap_filler_is_funded_before_a_higher_ep_surplus_player(self):
+        gap = EmergencyCandidate(
+            "gap", "Gap", ask=10_000, max_bid=14_000, ep=61.2, fills_gap=True, position="Forward"
+        )
+        surplus = EmergencyCandidate(
+            "sur", "Surplus", ask=10_000, max_bid=14_000, ep=94.5, position="Midfielder"
+        )
+        # Room for exactly one of the two overbids.
+        budget = 10_000 + 10_000 + 4_000
+
+        picks = {p.candidate.id: p.bid for p in select_emergency_basket([gap, surplus], 2, budget)}
+
+        assert picks["gap"] == 14_000, "the only gap filler must get the overbid first"
+        assert picks["sur"] == 10_000


### PR DESCRIPTION
> Replaces #97, which GitHub auto-closed when its base branch (#96) was deleted on merge. Same commit, retargeted to `main`.

## Ranking by points ignores the term that dominates

An empty lineup slot costs **-100 per slot**, and it does not care who fills it. `_run_emergency_squad_fill` walked its ranked list greedily and stopped when the money ran out, which ignores that term entirely.

Prod, 2026-08-31, four slots short with €55,485,928 — it bought **three**:

| Player | ask | bid | overbid | EP |
|---|---|---|---|---|
| Nadir | €2,571,571 | €2,957,306 | +15% | 35.0 |
| Ebnoutalib (fills gap) | €12,712,298 | €15,252,298 | +20% | 61.2 |
| El-Faouzi | €14,778,365 | **€19,208,365** | **+30%** | 94.5 |
| Avdullahu | €16,904,943 | **€21,974,943** | **+30%** | 70.5 |

Four cheapest **asks** total €46,967,177 and fit comfortably. Four cheapest **bids** total €56,654,430 and miss by **€1,168,502**. The fourth slot was lost entirely to overbid the greedy walk had already committed elsewhere — so reordering alone could not fix it.

## The change

`services/emergency_basket.py` is pure, like `safety_gate`, and maximises `total_ep + 100 × count` on **ask** price. The leftover is then spent as overbid, best players first.

Writing the objective out rather than hard-coding "more bodies always wins" matters at the edges: cardinality dominates exactly while EP spreads stay under the penalty, and correctly stops dominating when one exceeds it (there is a test for each side).

Covering a position below its formation minimum earns the penalty **in its own right** — a position gap makes the eleven *illegal* rather than merely weaker, and eleven players with no goalkeeper still field ten. Counted per position, not per player.

## Three defects found while building it

Two were caught by the **existing** suite, and both were real:

- `test_prioritises_gap_positions_over_raw_ep` — I had gap coverage as a *tie-break* on value, so a 25-EP surplus defender beat the only 12-EP forward. That is my own docstring's argument used against me; it belongs in the objective.
- `test_over_ceiling_candidate_is_skipped_and_the_next_one_is_bought` — the basket holds only `slots_short` members, so a gate refusal had nowhere to go. CLAUDE.md is explicit that this path walks its list rather than fielding nobody. The unchosen board is now the reserve behind the basket.

The third came from reading the first smoke output: **Ebnoutalib was bid at bare ask** — the only forward, the player making the eleven legal, given the *worst* chance of winning — because `_spend_leftover` ordered by EP while `_value` counted the gap at 100. Both now share one `_priority`.

## Verification

- 19 tests on the pure selector, including the real 2026-08-31 board
- **1459 passed, 1 skipped** with REH-111 and REH-112 merged in; ruff clean
- Replay **27,751 — unchanged**, predicted first (this path is unreachable from `rehoboam/replay/`)
- Live smoke against prod — **4/4 instead of 3/4**:

```
emergency-basket slots_short=4 budget=55,485,928 picked=4 spend=55,485,928 |
  Nadir@2,571,571  El-Faouzi@19,208,365  Ebnoutalib@15,252,298  Avdullahu@18,453,694
✓ Emergency fill: bought 4/4 player(s)
```

**+170.5 points per matchday** — Avdullahu's 70.5 EP plus the 100 that slot was costing.

## Worth a decision

It spends **100% of budget** (€0 left). Legal — the rule is ≥ 0 at kickoff — and the right priority while four slots are empty, but zero margin and nothing left for the rest of the session. These are bids, so €0 only happens if all four win. Easy to add a reserve if you would rather.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgdBR45xMFtj2zTgFL1VEn