### PR TITLE
feat(approval): the emergency fill asks before it spends (REH-114)

### DIFF
--- a/rehoboam/auto_trader.py
+++ b/rehoboam/auto_trader.py
@@ -469,12 +469,80 @@ class AutoTrader:
         except Exception as e:  # pragma: no cover - defensive
             logger.debug("record_buy_decision failed: %s", e)
 
-    def _propose_buy(self, league, rec, ctx) -> bool:
+    def _process_due_auto_approvals(self, league) -> None:
+        """Execute emergency proposals whose approval deadline has passed.
+
+        Only the emergency fill stamps a deadline (REH-114). An ordinary
+        upgrade has `auto_approve_at` NULL and waits for a human forever, which
+        is the point — Marco approves squad trades. What cannot wait forever is
+        an empty lineup slot, because that is -100 every matchday whether or
+        not anyone taps.
+
+        Best-effort like the rest of the learning layer: a failure here must
+        not stop the session, and each proposal is claimed out of 'pending'
+        before execution so a retry cannot buy the same player twice.
+        """
+        if self.learner is None:
+            return
+        try:
+            due = self.learner.due_auto_approvals(now=time.time())
+        except Exception:
+            logger.warning("could not read auto-approval deadlines", exc_info=True)
+            return
+        if not due:
+            return
+
+        from .notify.approval import execute_proposal
+
+        for proposal in due:
+            pid = proposal["proposal_id"]
+            if self.dry_run:
+                console.print(
+                    f"[yellow]DRY RUN - would auto-approve {proposal['player_name']} "
+                    f"for EUR {int(proposal['bid']):,} (deadline passed)[/yellow]"
+                )
+                continue
+            # The claim is the replay guard, exactly as in the webhook.
+            if not self.learner.mark_proposal(pid, "approved"):
+                continue
+            try:
+                reply = execute_proposal(
+                    proposal,
+                    settings=self.settings,
+                    learner=self.learner,
+                    api=self.api,
+                    league=league,
+                )
+            except Exception:
+                logger.exception("auto-approval failed for %s", pid)
+                continue
+            console.print(f"[yellow]⏰ Auto-approved (deadline): {reply}[/yellow]")
+            logger.warning(
+                "auto-approval fired proposal=%s player=%s bid=%d — %s",
+                pid,
+                proposal["player_name"],
+                int(proposal["bid"]),
+                reply,
+            )
+
+    def _propose_buy(
+        self, league, rec, ctx, *, bid: int | None = None, auto_approve_at: float | None = None
+    ) -> bool:
         """Record and send a proposal instead of buying. True if recorded.
 
         The proposal is recorded FIRST and sent second, so a Telegram outage
         loses the notification but not the decision — it still surfaces in the
         daily email.
+
+        ``bid`` overrides `rec.recommended_bid` for callers that price the buy
+        themselves — the emergency basket lowers some picks toward the asking
+        price so one more slot fits (REH-113), and the proposal must show the
+        number that will actually be offered.
+
+        ``auto_approve_at`` stamps a deadline after which the proposal executes
+        unapproved. Only the emergency fill sets one: there the alternative to
+        spending is -100 per empty slot every matchday, so silence cannot mean
+        "do nothing" (REH-114). An ordinary upgrade waits indefinitely.
         """
         import uuid
 
@@ -506,7 +574,7 @@ class AutoTrader:
         message = render_proposal(
             player_name=f"{player.first_name} {player.last_name}".strip(),
             club=getattr(player, "team_name", "") or "unknown club",
-            bid=int(rec.recommended_bid),
+            bid=int(bid if bid is not None else rec.recommended_bid),
             market_value=int(player.market_value),
             ep=float(rec.score.expected_points),
             displaced_name=getattr(rec, "replaces_player_name", None) or "the weakest starter",
@@ -517,10 +585,12 @@ class AutoTrader:
             risks=risks,
         )
 
+        bid_amount = int(bid if bid is not None else rec.recommended_bid)
+
         if self.dry_run:
             console.print(
                 f"[yellow]DRY RUN - would propose {player.last_name} "
-                f"for EUR {int(rec.recommended_bid):,}[/yellow]"
+                f"for EUR {bid_amount:,}[/yellow]"
             )
             return True
 
@@ -540,10 +610,11 @@ class AutoTrader:
                 proposal_id=proposal_id,
                 player_id=player.id,
                 player_name=player.last_name,
-                bid=int(rec.recommended_bid),
+                bid=bid_amount,
                 market_value=int(player.market_value),
                 message=message,
                 tier=tier.value,
+                auto_approve_at=auto_approve_at,
             )
         except Exception:
             logger.exception("proposal: could not record %s", proposal_id)
@@ -1271,44 +1342,70 @@ class AutoTrader:
             if c.id not in chosen_ids
         ]
 
-        bought = 0
+        # REH-114: propose rather than spend. Marco approves squad trades, and
+        # on the 2026-08-31 board this path would have committed EUR 55,485,928
+        # across four players unattended. Every pick carries an auto-approve
+        # deadline, because a proposal nobody taps protects nothing and the
+        # slot is still -100 every matchday. Only the reserves behind the
+        # basket are dropped — proposing the whole board would bury the ask.
+        deadline = time.time() + float(self.settings.emergency_auto_approve_hours) * 3600.0
+        proposed = 0
         for rec, bid in attempts:
-            if bought >= slots_short:
+            if proposed >= slots_short:
                 break
             if bid > budget_remaining:
                 continue
 
-            # A gate refusal here means "try the next candidate", not "field
-            # nobody" — the loop simply continues down the ranked list. That is
-            # the whole reason this path takes a list rather than a single pick:
-            # an empty slot is -100. What it must NOT do is relax the budget
-            # rule to fill a slot, because a negative budget at kickoff scores
-            # zero for the entire matchday — a far bigger loss than -100.
-            result = self.execution.buy(
-                league,
-                rec.player,
-                bid,
-                f"Emergency lineup fill (squad short by {slots_short})",
-                current_budget=budget_remaining,
-                days_until_match=ctx.matchday_phase.days_until_match,
-                gate=_build_buy_gate(
-                    settings=self.settings,
-                    ctx=ctx,
-                    player=rec.player,
-                    spendable_budget=budget_remaining,
-                    free_slots=slots_short - bought,
-                    marginal_ep_gain=rec.marginal_ep_gain,
-                ),
+            # Pre-flight the same gate approval will apply. Without this the
+            # bot can ask Marco to approve a bid the gate then refuses — the
+            # exact broken Approve button REH-99 existed to fix — and burn one
+            # of the slots asking. A refusal means "try the next candidate",
+            # not "field nobody", so the walk continues down the reserves.
+            gate = _build_buy_gate(
+                settings=self.settings,
+                ctx=ctx,
+                player=rec.player,
+                spendable_budget=budget_remaining,
+                free_slots=slots_short - proposed,
+                marginal_ep_gain=rec.marginal_ep_gain,
             )
-            results.append(result)
-            if result.success:
-                bought += 1
-                budget_remaining -= bid
-                self.daily_spend += bid
-                # Track the position so subsequent picks deprioritize the gap.
-                gap_positions.discard(rec.player.position)
+            verdict = gate.check(player_id=rec.player.id, bid=bid)
+            if not verdict.ok:
+                console.print(
+                    f"[dim]Skip {rec.player.last_name} — " f"{'; '.join(verdict.reasons)}[/dim]"
+                )
+                continue
 
-        console.print(f"[green]✓ Emergency fill: bought {bought}/{slots_short} player(s)[/green]")
+            if self._propose_buy(league, rec, ctx, bid=bid, auto_approve_at=deadline):
+                proposed += 1
+                # Reserve the money against the rest of this basket, so four
+                # proposals cannot each assume the whole wallet.
+                budget_remaining -= bid
+                gap_positions.discard(rec.player.position)
+                results.append(
+                    AutoTradeResult(
+                        success=True,
+                        player_name=f"{rec.player.first_name} {rec.player.last_name}".strip(),
+                        # Not "BUY": no money has moved, and the session
+                        # summary sums BUY prices into `total_spent`.
+                        action="PROPOSE",
+                        price=bid,
+                        reason=f"Emergency lineup fill (squad short by {slots_short})",
+                        timestamp=time.time(),
+                    )
+                )
+
+        console.print(
+            f"[green]✓ Emergency fill: proposed {proposed}/{slots_short} player(s) "
+            f"— auto-approving in {self.settings.emergency_auto_approve_hours:.0f}h "
+            f"if not actioned[/green]"
+        )
+        logger.info(
+            "emergency-proposals slots_short=%d proposed=%d auto_approve_in_h=%.1f",
+            slots_short,
+            proposed,
+            float(self.settings.emergency_auto_approve_hours),
+        )
         return results
 
     def _wash_trade_block_seconds(self) -> float:
@@ -1705,6 +1802,11 @@ class AutoTrader:
         sell_results: list[AutoTradeResult] = []
         trade_results: list[AutoTradeResult] = []
         errors: list[str] = []
+
+        # REH-114: an emergency proposal that nobody actioned becomes a buy once
+        # its deadline passes. Runs before the emergency check below so a slot
+        # already paid for is not proposed a second time.
+        self._process_due_auto_approvals(league)
 
         # Step 1: Reconcile pending bids (won/lost) + execute deferred sell plans
         try:

--- a/rehoboam/bid_learner.py
+++ b/rehoboam/bid_learner.py
@@ -578,6 +578,16 @@ class BidLearner:
             except sqlite3.OperationalError:
                 pass  # already present
 
+            # REH-114: when an unapproved proposal becomes a buy anyway. Set
+            # only on emergency squad fills, where the alternative to spending
+            # is -100 per empty slot every matchday. NULL — the default, and
+            # every row written before this — means "waits for a human
+            # indefinitely", which is what an ordinary upgrade should do.
+            try:
+                conn.execute("ALTER TABLE trade_proposals ADD COLUMN auto_approve_at REAL")
+            except sqlite3.OperationalError:
+                pass  # already present
+
             # REH-104: entry context for a flip. `trend_at_buy` has existed
             # since this table was created and was NULL in all 151 rows —
             # `record_flip_outcome` runs at sell time and had nothing to write.
@@ -1892,6 +1902,7 @@ class BidLearner:
         market_value: int,
         message: str,
         tier: str | None = None,
+        auto_approve_at: float | None = None,
     ) -> None:
         """Persist a proposal awaiting approval.
 
@@ -1903,7 +1914,8 @@ class BidLearner:
             conn.execute(
                 "INSERT OR REPLACE INTO trade_proposals "
                 "(proposal_id, player_id, player_name, bid, market_value, message, "
-                " status, created_at, tier) VALUES (?, ?, ?, ?, ?, ?, 'pending', ?, ?)",
+                " status, created_at, tier, auto_approve_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?)",
                 (
                     proposal_id,
                     player_id,
@@ -1913,8 +1925,31 @@ class BidLearner:
                     message,
                     datetime.now().timestamp(),
                     tier,
+                    auto_approve_at,
                 ),
             )
+
+    def due_auto_approvals(self, *, now: float) -> list[dict]:
+        """Pending proposals whose auto-approve deadline has passed.
+
+        Only emergency fills carry a deadline, so an ordinary upgrade never
+        appears here however long it waits. `status = 'pending'` keeps a
+        rejected or already-executed row out — the deadline is a backstop for
+        silence, not an override of a decision Marco has already made.
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(
+                """
+                SELECT * FROM trade_proposals
+                WHERE status = 'pending'
+                  AND auto_approve_at IS NOT NULL
+                  AND auto_approve_at <= ?
+                ORDER BY auto_approve_at ASC
+                """,
+                (float(now),),
+            ).fetchall()
+        return [dict(r) for r in rows]
 
     def get_proposal(self, proposal_id: str) -> dict | None:
         """One proposal by id, or None."""

--- a/rehoboam/config.py
+++ b/rehoboam/config.py
@@ -432,6 +432,18 @@ class Settings(BaseSettings):
             "exactly when there is least evidence."
         ),
     )
+    emergency_auto_approve_hours: float = Field(
+        default=24.0,
+        description=(
+            "Hours an emergency squad-fill proposal waits for approval before "
+            "executing itself. The backstop is deliberately time-based rather "
+            "than tied to the matchday phase: `/myeleven` returning no upcoming "
+            "fixture is exactly the failure that produced a 7-player squad "
+            "(REH-112), so a phase trigger can wait forever on the same broken "
+            "lookup. Only emergency fills carry a deadline — an ordinary "
+            "upgrade waits for a human indefinitely."
+        ),
+    )
     overbid_pct_marginal: float = Field(
         default=8.0,
         description=(

--- a/rehoboam/notify/approval.py
+++ b/rehoboam/notify/approval.py
@@ -60,39 +60,22 @@ def _record_bid_for_learning(learner, player, bid: int, tier: str | None = None)
         logger.warning("approval: could not record approved bid for learning", exc_info=True)
 
 
-def handle_callback(
-    body: dict,
-    secret_header: str | None,
-    *,
-    settings,
-    learner,
-    api,
-    league,
-) -> str:
-    """Process one callback. Returns the text to show back in Telegram."""
-    if not authorize(secret_header, settings.telegram_webhook_secret):
-        logger.warning("approval: unauthorized callback rejected")
-        return "Unauthorized."
+def execute_proposal(proposal: dict, *, settings, learner, api, league) -> str:
+    """Re-validate a claimed proposal against the live market and buy it.
 
-    query = (body or {}).get("callback_query") or {}
-    data = query.get("data") or ""
-    action, _, proposal_id = data.partition(":")
-    if action not in {"approve", "reject"} or not proposal_id:
-        return "Unrecognised callback."
+    Split out of ``handle_callback`` so the Telegram tap and the emergency
+    auto-approve deadline (REH-114) run the SAME gate. Rehoboam has produced
+    four tickets of the shape "two components each holding a private copy of
+    one rule" (REH-99, 100, 107, 111); a second execute path would be the
+    fifth, and it is the path that spends money.
 
-    proposal = learner.get_proposal(proposal_id)
-    if proposal is None:
-        return f"Proposal {proposal_id} not found."
+    The caller is responsible for claiming the proposal out of 'pending'
+    first — that claim is the replay guard, and it must happen before any of
+    this work.
 
-    if action == "reject":
-        if not learner.mark_proposal(proposal_id, "rejected"):
-            return f"Proposal {proposal_id} was already {proposal['status']}."
-        return f"Rejected {proposal['player_name']}."
-
-    # Claim before doing anything expensive — this is the replay guard.
-    if not learner.mark_proposal(proposal_id, "approved"):
-        return f"Proposal {proposal_id} was already {proposal['status']}."
-
+    Returns the text to show whoever triggered it.
+    """
+    proposal_id = proposal["proposal_id"]
     try:
         market = {p.id: p for p in api.get_market(league)}
         live = market.get(proposal["player_id"])
@@ -146,6 +129,42 @@ def handle_callback(
     learner.set_proposal_status(proposal_id, "executed")
     _record_bid_for_learning(learner, live, int(proposal["bid"]), tier=proposal.get("tier"))
     return f"Bought {proposal['player_name']} for EUR {int(proposal['bid']):,}."
+
+
+def handle_callback(
+    body: dict,
+    secret_header: str | None,
+    *,
+    settings,
+    learner,
+    api,
+    league,
+) -> str:
+    """Process one callback. Returns the text to show back in Telegram."""
+    if not authorize(secret_header, settings.telegram_webhook_secret):
+        logger.warning("approval: unauthorized callback rejected")
+        return "Unauthorized."
+
+    query = (body or {}).get("callback_query") or {}
+    data = query.get("data") or ""
+    action, _, proposal_id = data.partition(":")
+    if action not in {"approve", "reject"} or not proposal_id:
+        return "Unrecognised callback."
+
+    proposal = learner.get_proposal(proposal_id)
+    if proposal is None:
+        return f"Proposal {proposal_id} not found."
+
+    if action == "reject":
+        if not learner.mark_proposal(proposal_id, "rejected"):
+            return f"Proposal {proposal_id} was already {proposal['status']}."
+        return f"Rejected {proposal['player_name']}."
+
+    # Claim before doing anything expensive — this is the replay guard.
+    if not learner.mark_proposal(proposal_id, "approved"):
+        return f"Proposal {proposal_id} was already {proposal['status']}."
+
+    return execute_proposal(proposal, settings=settings, learner=learner, api=api, league=league)
 
 
 def build_callback_response(body: dict, reply: str) -> dict:

--- a/tests/test_autonomous_buy_gate.py
+++ b/tests/test_autonomous_buy_gate.py
@@ -104,6 +104,21 @@ def _ctx(buy_recs, current_budget, *, squad=(), market=None, days_until_match=No
     )
 
 
+class _ProposalSpy:
+    """The emergency fill proposes rather than buys since REH-114."""
+
+    def __init__(self):
+        self.calls: list[tuple[str, int]] = []
+
+    def __call__(self, league, rec, ctx, *, bid=None, auto_approve_at=None):
+        self.calls.append((rec.player.id, int(bid if bid is not None else rec.recommended_bid)))
+        return True
+
+    @property
+    def ids(self) -> list[str]:
+        return [c[0] for c in self.calls]
+
+
 class TestEmergencyFillRefusal:
     """An empty slot is -100, so a refusal means 'try the next one'."""
 
@@ -124,12 +139,17 @@ class TestEmergencyFillRefusal:
             squad=squad,
         )
 
+        trader._propose_buy = spy = _ProposalSpy()
+
         results = trader._run_emergency_squad_fill(
             league=SimpleNamespace(id="L"), ctx=ctx, fresh_squad=squad, slots_short=1
         )
 
-        bought = [c.args[1].id for c in api.buy_player.call_args_list]
-        assert bought == ["clean"], "the refused candidate must not reach the API"
+        # REH-114: the fill proposes, so the ceiling is pre-flighted here rather
+        # than at execution — asking Marco to approve a bid the gate would then
+        # refuse is the broken Approve button REH-99 existed to fix.
+        assert spy.ids == ["clean"], "the refused candidate must not be proposed"
+        assert api.buy_player.call_count == 0, "squad buys wait for approval"
         assert any(r.success for r in results), "the slot must still be filled"
 
     def test_budget_rule_stays_hard_even_to_fill_a_slot(self, trader, api):

--- a/tests/test_emergency_fill_approval.py
+++ b/tests/test_emergency_fill_approval.py
@@ -1,0 +1,334 @@
+"""The emergency fill asks before it spends, but not forever (REH-114).
+
+Marco wants to approve squad trades. REH-112/113 made the emergency fill
+autonomous, and on the 2026-08-31 board that meant EUR 55,485,928 across four
+players with no Approve button — the right amount of money to want a say in.
+
+So emergency picks become proposals. The catch is that an empty lineup slot is
+-100 every matchday, and a proposal nobody taps protects nothing. The backstop
+is therefore **time-based, not phase-based**: `auto_approve_at` is stamped on
+the proposal and the next session executes it once that passes.
+
+Phase would be the natural trigger and is the wrong one. `/myeleven` returning
+no upcoming fixture is exactly what produced this situation (REH-112), so
+"auto-approve once the phase goes locked" can wait forever on the same broken
+lookup it exists to survive.
+"""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from rehoboam.auto_trader import AutoTrader
+from rehoboam.bid_learner import BidLearner
+from rehoboam.config import Settings
+from rehoboam.kickbase_client import MarketPlayer, Player
+
+LEAGUE = SimpleNamespace(id="1933872", name="PUMARUDEL")
+HOUR = 3600.0
+
+
+def _player(pid, position="Defender"):
+    return Player(
+        id=pid,
+        first_name="F",
+        last_name=f"P{pid}",
+        position=position,
+        team_id="1",
+        team_name="T",
+        market_value=1_000_000,
+        points=0,
+        average_points=50.0,
+    )
+
+
+def _market_player(pid, price, position="Forward"):
+    return MarketPlayer(
+        id=pid,
+        first_name="F",
+        last_name=f"M{pid}",
+        position=position,
+        team_id="7",
+        team_name="",
+        price=price,
+        market_value=price,
+        points=0,
+        average_points=60.0,
+        status=0,
+    )
+
+
+def _rec(pid, price, ep_gain, position="Forward"):
+    player = _market_player(pid, price, position)
+    return SimpleNamespace(
+        player=player,
+        recommended_bid=price,
+        marginal_ep_gain=ep_gain,
+        score=SimpleNamespace(expected_points=ep_gain, data_quality=None, position=position),
+        replaces_player_name=None,
+        replaces_player_ep=0.0,
+        sell_plan=None,
+    )
+
+
+def _ctx(buy_recs, budget):
+    return SimpleNamespace(
+        ep_result={
+            "buy_recs": list(buy_recs),
+            "trade_pairs": [],
+            "squad_scores": [],
+            "market_players": {r.player.id: r.player for r in buy_recs},
+        },
+        my_bid_amounts={},
+        my_bids=[],
+        squad=[],
+        current_budget=budget,
+        team_value=100_000_000,
+        flip_budget=budget,
+        executed_trade_count=0,
+        matchday_phase=SimpleNamespace(days_until_match=None, phase="moderate"),
+    )
+
+
+@pytest.fixture
+def trader(tmp_path, monkeypatch):
+    monkeypatch.setenv("KICKBASE_EMAIL", "test@example.com")
+    monkeypatch.setenv("KICKBASE_PASSWORD", "test")
+    monkeypatch.chdir(tmp_path)
+    t = AutoTrader(api=SimpleNamespace(), settings=Settings(), dry_run=False)
+    t.learner = BidLearner(db_path=tmp_path / "bid_learning.db")
+    return t
+
+
+class TestTheFillProposesRatherThanBuying:
+    def test_an_emergency_pick_is_recorded_as_a_proposal(self, trader):
+        squad = [_player(f"d{i}") for i in range(7)]
+        recs = [_rec("f1", 5_000_000, 60.0)]
+
+        with patch.object(AutoTrader, "_propose_buy", return_value=True) as propose:
+            trader._run_emergency_squad_fill(
+                league=LEAGUE, ctx=_ctx(recs, 50_000_000), fresh_squad=squad, slots_short=1
+            )
+
+        assert propose.called, "emergency fill must propose, not spend unattended"
+
+    def test_it_does_not_reach_the_execution_service(self, trader):
+        squad = [_player(f"d{i}") for i in range(7)]
+        recs = [_rec("f1", 5_000_000, 60.0)]
+        trader.execution = SimpleNamespace(
+            buy=lambda *a, **k: pytest.fail("emergency fill bought without approval")
+        )
+
+        with patch.object(AutoTrader, "_propose_buy", return_value=True):
+            trader._run_emergency_squad_fill(
+                league=LEAGUE, ctx=_ctx(recs, 50_000_000), fresh_squad=squad, slots_short=1
+            )
+
+
+class TestTheBackstopIsTimeBased:
+    def test_an_emergency_proposal_carries_an_auto_approve_deadline(self, trader):
+        """A slot nobody taps is still -100. The proposal expires INTO a buy."""
+        trader.learner.record_proposal(
+            proposal_id="p1",
+            player_id="f1",
+            player_name="Striker",
+            bid=5_000_000,
+            market_value=5_000_000,
+            message="m",
+            auto_approve_at=time.time() + 24 * HOUR,
+        )
+
+        row = trader.learner.get_proposal("p1")
+
+        assert row["auto_approve_at"] is not None
+
+    def test_a_due_proposal_is_returned_for_execution(self, trader):
+        trader.learner.record_proposal(
+            proposal_id="due",
+            player_id="f1",
+            player_name="Striker",
+            bid=5_000_000,
+            market_value=5_000_000,
+            message="m",
+            auto_approve_at=time.time() - HOUR,
+        )
+
+        due = trader.learner.due_auto_approvals(now=time.time())
+
+        assert [d["proposal_id"] for d in due] == ["due"]
+
+    def test_a_proposal_not_yet_due_is_left_alone(self, trader):
+        trader.learner.record_proposal(
+            proposal_id="later",
+            player_id="f1",
+            player_name="Striker",
+            bid=5_000_000,
+            market_value=5_000_000,
+            message="m",
+            auto_approve_at=time.time() + 6 * HOUR,
+        )
+
+        assert trader.learner.due_auto_approvals(now=time.time()) == []
+
+    def test_an_ordinary_proposal_never_auto_approves(self, trader):
+        """Only the -100 case earns a backstop. A plain upgrade waits forever."""
+        trader.learner.record_proposal(
+            proposal_id="plain",
+            player_id="f1",
+            player_name="Upgrade",
+            bid=5_000_000,
+            market_value=5_000_000,
+            message="m",
+        )
+
+        assert trader.learner.due_auto_approvals(now=time.time() + 365 * 24 * HOUR) == []
+
+    def test_an_already_resolved_proposal_is_not_re_executed(self, trader):
+        trader.learner.record_proposal(
+            proposal_id="done",
+            player_id="f1",
+            player_name="Striker",
+            bid=5_000_000,
+            market_value=5_000_000,
+            message="m",
+            auto_approve_at=time.time() - HOUR,
+        )
+        trader.learner.set_proposal_status("done", "rejected")
+
+        assert trader.learner.due_auto_approvals(now=time.time()) == []
+
+
+class _ApprovalApi:
+    """The five calls the approval path makes."""
+
+    def __init__(self, listing, budget=50_000_000, squad=()):
+        self.listing = listing
+        self.budget = budget
+        self.squad = list(squad)
+        self.bought: list[tuple[str, int]] = []
+
+    def get_market(self, league):
+        return [self.listing]
+
+    def get_squad(self, league):
+        return list(self.squad)
+
+    def get_my_bids(self, league):
+        return []
+
+    def get_team_info(self, league):
+        return {"budget": self.budget, "team_value": 100_000_000}
+
+    def buy_player(self, league, player, price):
+        self.bought.append((player.id, price))
+        return True
+
+
+class TestADueProposalExecutesThroughTheSameGate:
+    """One copy of the gate, not two.
+
+    REH-99/100/107/111 were all "two components each holding a private copy of
+    one rule". A second execute path for auto-approval would be the next one,
+    so the webhook and this share `execute_proposal`.
+    """
+
+    def _due(self, learner, bid=5_000_000):
+        learner.record_proposal(
+            proposal_id="due1",
+            player_id="f1",
+            player_name="Striker",
+            bid=bid,
+            market_value=5_000_000,
+            message="m",
+            tier="marginal",
+            auto_approve_at=time.time() - HOUR,
+        )
+
+    def test_it_reaches_the_api(self, trader):
+        from rehoboam.notify.approval import execute_proposal
+
+        self._due(trader.learner)
+        api = _ApprovalApi(_market_player("f1", 5_000_000))
+
+        execute_proposal(
+            trader.learner.get_proposal("due1"),
+            settings=trader.settings,
+            learner=trader.learner,
+            api=api,
+            league=LEAGUE,
+        )
+
+        assert api.bought == [("f1", 5_000_000)]
+        assert trader.learner.get_proposal("due1")["status"] == "executed"
+
+    def test_the_gate_still_refuses_an_unaffordable_bid(self, trader):
+        """The deadline overrides silence, never the budget rule."""
+        from rehoboam.notify.approval import execute_proposal
+
+        self._due(trader.learner, bid=90_000_000)
+        api = _ApprovalApi(_market_player("f1", 5_000_000), budget=10_000_000)
+
+        execute_proposal(
+            trader.learner.get_proposal("due1"),
+            settings=trader.settings,
+            learner=trader.learner,
+            api=api,
+            league=LEAGUE,
+        )
+
+        assert api.bought == [], "auto-approval must not buy past the gate"
+        assert trader.learner.get_proposal("due1")["status"] == "failed"
+
+    def test_a_vanished_listing_fails_rather_than_buying_something_else(self, trader):
+        from rehoboam.notify.approval import execute_proposal
+
+        self._due(trader.learner)
+        api = _ApprovalApi(_market_player("other", 5_000_000))
+
+        execute_proposal(
+            trader.learner.get_proposal("due1"),
+            settings=trader.settings,
+            learner=trader.learner,
+            api=api,
+            league=LEAGUE,
+        )
+
+        assert api.bought == []
+        assert trader.learner.get_proposal("due1")["status"] == "failed"
+
+
+class TestTheSessionActuallyChecksTheDeadline:
+    """A deadline nothing reads is a slot left empty (REH-86's lesson)."""
+
+    def test_a_due_proposal_is_executed_during_a_session(self, trader, tmp_path):
+        trader.learner.record_proposal(
+            proposal_id="due1",
+            player_id="f1",
+            player_name="Striker",
+            bid=5_000_000,
+            market_value=5_000_000,
+            message="m",
+            tier="marginal",
+            auto_approve_at=time.time() - HOUR,
+        )
+        api = _ApprovalApi(_market_player("f1", 5_000_000))
+        trader.api = api
+
+        trader._process_due_auto_approvals(LEAGUE)
+
+        assert api.bought == [("f1", 5_000_000)]
+
+    def test_run_full_session_calls_it(self, trader, monkeypatch):
+        with (
+            patch.object(AutoTrader, "_process_due_auto_approvals", return_value=None) as process,
+            patch.object(AutoTrader, "_build_session_context", side_effect=RuntimeError("stop")),
+            patch.object(AutoTrader, "_set_optimal_lineup", return_value=[]),
+        ):
+            trader.api = _ApprovalApi(_market_player("f1", 5_000_000))
+            trader.run_full_session(LEAGUE)
+
+        assert process.called, "the deadline is never read"

--- a/tests/test_min_hold_and_emergency_fill.py
+++ b/tests/test_min_hold_and_emergency_fill.py
@@ -192,10 +192,22 @@ def _ctx(buy_recs, current_budget, my_bid_amounts=None, days_until_match=None):
     fill logic).
     """
     return SimpleNamespace(
-        ep_result={"buy_recs": buy_recs, "trade_pairs": [], "squad_scores": []},
+        ep_result={
+            "buy_recs": buy_recs,
+            "trade_pairs": [],
+            "squad_scores": [],
+            # REH-114: the fill now pre-flights `safety_gate` before proposing,
+            # and `known_player_ids` is a security boundary — a candidate absent
+            # from the live market is refused. The old `_StubExecution` ignored
+            # the gate it was handed, so this fixture gap stayed invisible.
+            "market_players": {r.player.id: r.player for r in buy_recs},
+        },
         my_bid_amounts=my_bid_amounts or {},
+        my_bids=[],
+        squad=[],
+        team_value=100_000_000,
         current_budget=current_budget,
-        matchday_phase=SimpleNamespace(days_until_match=days_until_match),
+        matchday_phase=SimpleNamespace(days_until_match=days_until_match, phase="moderate"),
     )
 
 
@@ -208,9 +220,30 @@ def _rec(pid, position, price, ep_gain=10.0):
     )
 
 
+class _ProposalSpy:
+    """Records what the emergency fill proposed (REH-114: it no longer buys).
+
+    The fill routes picks through `_propose_buy` so Marco approves squad
+    trades. These tests are about SELECTION — wash trades, active bids,
+    affordability, gap priority — so the sink is stubbed and the choices are
+    asserted directly.
+    """
+
+    def __init__(self):
+        self.calls: list[tuple[str, int]] = []
+
+    def __call__(self, league, rec, ctx, *, bid=None, auto_approve_at=None):
+        self.calls.append((rec.player.id, int(bid if bid is not None else rec.recommended_bid)))
+        return True
+
+    @property
+    def ids(self) -> list[str]:
+        return [c[0] for c in self.calls]
+
+
 class TestEmergencySquadFill:
     def test_fills_to_eleven_when_short(self, trader):
-        trader.execution = _StubExecution()
+        trader._propose_buy = spy = _ProposalSpy()
 
         # Squad has 9 players (missing 1 GK + 1 forward = formation broken)
         squad = (
@@ -233,12 +266,11 @@ class TestEmergencySquadFill:
         )
 
         assert sum(1 for r in results if r.success) == 2
-        bought_ids = [pid for kind, pid, *_ in trader.execution.calls if kind == "buy"]
-        # Both bought slots are filled with affordable, non-active-bid candidates
-        assert len(bought_ids) == 2
+        # Both slots are proposed from affordable, non-active-bid candidates
+        assert len(spy.ids) == 2
 
     def test_skips_wash_trade_blocked_candidates(self, trader):
-        trader.execution = _StubExecution()
+        trader._propose_buy = spy = _ProposalSpy()
         squad = [_player(f"p{i}", "Defender") for i in range(10)]
 
         trader.learner.record_recent_sell(
@@ -258,12 +290,11 @@ class TestEmergencySquadFill:
             league=SimpleNamespace(id="L"), ctx=ctx, fresh_squad=squad, slots_short=1
         )
 
-        bought_ids = [pid for kind, pid, *_ in trader.execution.calls if kind == "buy"]
-        assert bought_ids == ["forward2"]
+        assert spy.ids == ["forward2"]
         assert sum(1 for r in results if r.success) == 1
 
     def test_skips_already_bid_candidates(self, trader):
-        trader.execution = _StubExecution()
+        trader._propose_buy = spy = _ProposalSpy()
         squad = [_player(f"p{i}", "Defender") for i in range(10)]
 
         buy_recs = [
@@ -280,11 +311,10 @@ class TestEmergencySquadFill:
             league=SimpleNamespace(id="L"), ctx=ctx, fresh_squad=squad, slots_short=1
         )
 
-        bought_ids = [pid for kind, pid, *_ in trader.execution.calls if kind == "buy"]
-        assert bought_ids == ["forward2"]
+        assert spy.ids == ["forward2"]
 
     def test_skips_unaffordable_candidates(self, trader):
-        trader.execution = _StubExecution()
+        trader._propose_buy = spy = _ProposalSpy()
         squad = [_player(f"p{i}", "Defender") for i in range(10)]
 
         buy_recs = [
@@ -297,11 +327,10 @@ class TestEmergencySquadFill:
             league=SimpleNamespace(id="L"), ctx=ctx, fresh_squad=squad, slots_short=2
         )
 
-        bought_ids = [pid for kind, pid, *_ in trader.execution.calls if kind == "buy"]
-        assert bought_ids == ["forward2"]
+        assert spy.ids == ["forward2"]
 
     def test_prioritises_gap_positions_over_raw_ep(self, trader):
-        trader.execution = _StubExecution()
+        trader._propose_buy = spy = _ProposalSpy()
         # 0 forwards, 5 defenders, 3 midfielders, 1 GK = 9 players, FW gap.
         squad = (
             [_player(f"def{i}", "Defender") for i in range(5)]
@@ -324,11 +353,10 @@ class TestEmergencySquadFill:
 
         # The gap-filling forward must come first, even though raw EP gain
         # would have ranked the defender above it.
-        bought_ids = [pid for kind, pid, *_ in trader.execution.calls if kind == "buy"]
-        assert bought_ids[0] == "fwd_gap"
+        assert spy.ids[0] == "fwd_gap"
 
     def test_no_buys_when_no_affordable_clean_candidates(self, trader):
-        trader.execution = _StubExecution()
+        trader._propose_buy = spy = _ProposalSpy()
         squad = [_player(f"p{i}", "Defender") for i in range(10)]
 
         buy_recs = [
@@ -341,4 +369,4 @@ class TestEmergencySquadFill:
         )
 
         assert results == []
-        assert trader.execution.calls == []
+        assert spy.ids == []

--- a/tests/test_pacing_session.py
+++ b/tests/test_pacing_session.py
@@ -167,6 +167,21 @@ def test_the_trend_recompute_does_not_discard_pacing(trader):
 # ---------------------------------------------------------------------------
 
 
+class _ProposalSpy:
+    """The emergency fill proposes rather than buys since REH-114."""
+
+    def __init__(self):
+        self.calls: list[tuple[str, int]] = []
+
+    def __call__(self, league, rec, ctx, *, bid=None, auto_approve_at=None):
+        self.calls.append((rec.player.id, int(bid if bid is not None else rec.recommended_bid)))
+        return True
+
+    @property
+    def ids(self) -> list[str]:
+        return [c[0] for c in self.calls]
+
+
 def _emergency_fill_ctx(recommended_bid: int):
     """A short squad (11/15, one gap slot) plus one candidate to fill it."""
     squad = [
@@ -241,14 +256,17 @@ def test_emergency_fill_buys_when_bid_is_already_sized(tmp_path, monkeypatch):
     the test that actually exercises the pacing risk.
     """
     api, trader = _autotrader_with_mock_api(tmp_path, monkeypatch)
+    trader._propose_buy = spy = _ProposalSpy()
     squad, target, ctx = _emergency_fill_ctx(recommended_bid=4_000_000)
 
     results = trader._run_emergency_squad_fill(
         league=SimpleNamespace(id="L"), ctx=ctx, fresh_squad=squad, slots_short=1
     )
     assert any(r.success for r in results), "the slot must be filled"
-    assert api.buy_player.call_count == 1
-    assert api.buy_player.call_args[0][2] == 4_000_000
+    # REH-114: the slot is claimed by a proposal, not a buy. The number that
+    # matters is unchanged — the bid pacing sized.
+    assert spy.calls == [("fill", 4_000_000)]
+    assert api.buy_player.call_count == 0, "squad buys wait for approval"
 
 
 def test_emergency_fill_is_not_starved_by_a_paced_zero_bid(tmp_path, monkeypatch):
@@ -262,6 +280,7 @@ def test_emergency_fill_is_not_starved_by_a_paced_zero_bid(tmp_path, monkeypatch
     bookkeeping.
     """
     api, trader = _autotrader_with_mock_api(tmp_path, monkeypatch)
+    trader._propose_buy = spy = _ProposalSpy()
     squad, target, ctx = _emergency_fill_ctx(recommended_bid=0)
 
     results = trader._run_emergency_squad_fill(
@@ -270,9 +289,7 @@ def test_emergency_fill_is_not_starved_by_a_paced_zero_bid(tmp_path, monkeypatch
     assert any(
         r.success for r in results
     ), "the slot must be filled despite the paced bid being zero"
-    assert api.buy_player.call_count == 1
-    # The fallback must actually place an offer -- at the asking price, not 0.
-    assert api.buy_player.call_args[0][2] == target.price
-    # The fallback must still respect the budget the emergency path is
-    # working with, not spend blindly past it.
-    assert api.buy_player.call_args[0][2] <= ctx.current_budget
+    # The fallback must propose at the asking price, not 0, and still respect
+    # the budget the emergency path is working with.
+    assert spy.calls == [("fill", target.price)]
+    assert spy.calls[0][1] <= ctx.current_budget


### PR DESCRIPTION
## You approve squad trades

REH-112/113 made the emergency squad fill autonomous, and on the 2026-08-31 board that meant **€55,485,928 across four players with no Approve button**. Emergency picks now route through `_propose_buy`.

Profit flips, trade pairs and instant sells are untouched — they stay autonomous.

## But a proposal nobody taps protects nothing

An empty lineup slot is **-100 every matchday**. So each emergency proposal carries an `auto_approve_at` deadline (default 24h, `EMERGENCY_AUTO_APPROVE_HOURS`) and the next session executes it once that passes.

The backstop is **time-based, not phase-based**, and that is deliberate: `/myeleven` returning no upcoming fixture is *exactly* the failure that produced a 7-player squad (REH-112), so "auto-approve once the phase goes locked" would wait forever on the same broken lookup it exists to survive.

Only emergency fills carry a deadline. `auto_approve_at` is NULL on an ordinary upgrade — and on every row written before this — so a plain squad improvement waits for you indefinitely.

## One gate, not two

`execute_proposal` is split out of `handle_callback` so the Telegram tap and the deadline run the **same** gate. This repo has produced four tickets of the shape *"two components each holding a private copy of one rule"* (REH-99, 100, 107, 111). A second execute path would be the fifth, and it is the path that spends money.

The fill also **pre-flights that gate before proposing**. Without it the bot can ask you to approve a bid the gate then refuses — the broken Approve button REH-99 existed to fix — and burn a slot asking. Live smoke caught one on the first run:

```
Skip Caci — club limit: already hold 3 player(s) from club 18 (max 3)
DRY RUN - would propose Andrés for EUR 6,561,005
✓ Emergency fill: proposed 3/3 player(s) — auto-approving in 24h if not actioned
```

The walk continued to a reserve and still filled 3/3.

## A hidden fixture gap

Three existing tests asserted through a `_StubExecution` that **ignored the gate it was handed**, which hid a context fixture with no `market_players` at all. Populating it makes those tests exercise the security boundary they claimed to. Proposals return `action="PROPOSE"` results so the session summary does not count them as spend.

## Verification

- 12 new tests, each watched fail first
- **1471 passed, 1 skipped**; ruff clean; 19 existing webhook tests still green after the extraction
- Live smoke against prod, shown above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgdBR45xMFtj2zTgFL1VEn