### PR TITLE
fix(bidding): stop cancelling Marco's bids, and use one ceiling (REH-115, REH-116)

### DIFF
--- a/rehoboam/auto_trader.py
+++ b/rehoboam/auto_trader.py
@@ -469,6 +469,51 @@ class AutoTrader:
         except Exception as e:  # pragma: no cover - defensive
             logger.debug("record_buy_decision failed: %s", e)
 
+    def _evaluate_open_bids(self, league, *, player_trends: dict) -> None:
+        """Re-read every live offer and withdraw the bot's own bad ones.
+
+        Two facts about the input shape drive everything here. `get_my_bids` is
+        `get_market` filtered by "do we hold an offer", so it returns offers
+        Marco placed by hand alongside the bot's — and it cannot say which is
+        which. And a bid the bot placed carries the tier it was priced under,
+        which is both the ceiling to judge it by (REH-111) and the proof of
+        provenance (REH-115).
+
+        Both reads are best-effort: a learning-side failure must leave the
+        phase working, not silently resume cancelling Marco's bids, so the
+        provenance set falls back to the tiers rather than to None.
+        """
+        from .bid_evaluator import BidEvaluator
+
+        bid_tiers: dict[str, str] = {}
+        bot_placed_ids: set[str] = set()
+        if self.learner is not None:
+            try:
+                pending = self.learner.get_pending_bids()
+                bot_placed_ids = {str(row["player_id"]) for row in pending}
+                bid_tiers = {
+                    str(row["player_id"]): row["tier"] for row in pending if row.get("tier")
+                }
+            except Exception:
+                logger.warning("could not read open-bid provenance", exc_info=True)
+                bot_placed_ids = set(bid_tiers)
+
+        evaluator = BidEvaluator(self.api, self.settings)
+        evaluations = evaluator.evaluate_active_bids(
+            league,
+            player_trends=player_trends,
+            for_profit=True,
+            bid_tiers=bid_tiers,
+            bot_placed_ids=bot_placed_ids,
+        )
+        if not evaluations:
+            return
+
+        evaluator.display_bid_evaluations(evaluations)
+        canceled = evaluator.cancel_bad_bids(league, evaluations, dry_run=self.dry_run)
+        if canceled:
+            console.print(f"[yellow]Canceled {canceled} bid(s) that no longer make sense[/yellow]")
+
     def _process_due_auto_approvals(self, league) -> None:
         """Execute emergency proposals whose approval deadline has passed.
 
@@ -2028,7 +2073,6 @@ class AutoTrader:
         self._reset_daily_limits_if_needed()
         if self.daily_spend < self.max_daily_spend:
             try:
-                from .bid_evaluator import BidEvaluator
                 from .league_compliance import LeagueComplianceChecker
                 from .trader import Trader
 
@@ -2055,35 +2099,7 @@ class AutoTrader:
                         f"[cyan]Bid compliance: {adjusted} adjusted, {canceled} canceled[/cyan]"
                     )
 
-                # REH-111: each open bid carries the tier it was priced under,
-                # so a squad upgrade is not re-read as a flip and cancelled for
-                # exceeding a flip's ceiling. Best-effort like every other
-                # learning read — no tiers means the previous behaviour, not a
-                # dead evaluation phase.
-                bid_tiers: dict[str, str] = {}
-                if self.learner is not None:
-                    try:
-                        bid_tiers = {
-                            str(row["player_id"]): row["tier"]
-                            for row in self.learner.get_pending_bids()
-                            if row.get("tier")
-                        }
-                    except Exception:
-                        logger.warning("could not read bid tiers", exc_info=True)
-
-                bid_evaluator = BidEvaluator(self.api, self.settings)
-                bid_evaluations = bid_evaluator.evaluate_active_bids(
-                    league, player_trends=player_trends, for_profit=True, bid_tiers=bid_tiers
-                )
-                if bid_evaluations:
-                    bid_evaluator.display_bid_evaluations(bid_evaluations)
-                    canceled_count = bid_evaluator.cancel_bad_bids(
-                        league, bid_evaluations, dry_run=self.dry_run
-                    )
-                    if canceled_count > 0:
-                        console.print(
-                            f"[yellow]Canceled {canceled_count} bid(s) that no longer make sense[/yellow]"
-                        )
+                self._evaluate_open_bids(league, player_trends=player_trends)
             except Exception as e:
                 console.print(f"[yellow]Bid compliance check failed: {e}[/yellow]")
 

--- a/rehoboam/bid_evaluator.py
+++ b/rehoboam/bid_evaluator.py
@@ -88,6 +88,7 @@ class BidEvaluator:
         player_trends: dict = None,
         for_profit: bool = True,
         bid_tiers: dict[str, str] | None = None,
+        bot_placed_ids: set[str] | None = None,
     ) -> list[BidEvaluation]:
         """
         Evaluate all active bids
@@ -99,11 +100,26 @@ class BidEvaluator:
             bid_tiers: Dict mapping player_id -> the tier the bid was priced
                 against, from `pending_bids`. A player absent from this map has
                 no recorded tier — see `untiered_price_ceiling`.
+            bot_placed_ids: Player ids the bot has an open bid on, from
+                `pending_bids`. Offers outside this set were placed by hand and
+                are never cancelled (REH-115). A recorded tier is itself proof
+                of provenance, so passing None falls back to `bid_tiers` —
+                which errs toward leaving a human's bid alone.
 
         Returns:
             List of BidEvaluation objects
         """
         bid_tiers = bid_tiers or {}
+
+        # REH-115: `get_my_bids` is `get_market` filtered by "do we hold an
+        # offer" and cannot say WHO placed it, so every offer Marco makes by
+        # hand arrives here looking like an unexplained bot bid. On 2026-09-01
+        # that cancelled his Conrad Harder offer at 34.4% over market value.
+        # A recorded tier proves the bot placed it; `pending_bids` membership
+        # proves it for rows predating the tier column.
+        bot_bids = set(bid_tiers)
+        if bot_placed_ids is not None:
+            bot_bids |= {str(pid) for pid in bot_placed_ids}
         evaluations = []
 
         # Get active bids
@@ -147,6 +163,8 @@ class BidEvaluator:
             # euro of market value still scores every week we hold it.
             tier = bid_tiers.get(bid_player.id)
             judge_as_flip = for_profit and tier is None
+            # Marco's own judgement is an input, not a candidate for review.
+            ours_to_cancel = bid_player.id in bot_bids
 
             # Decision logic
             recommendation = "KEEP"
@@ -155,7 +173,10 @@ class BidEvaluator:
             profit_potential = 0.0  # Initialize here
 
             # CANCEL conditions
-            if is_injured:
+            if not ours_to_cancel:
+                reason = "Placed manually — not the bot's bid to cancel"
+
+            elif is_injured:
                 recommendation = "CANCEL"
                 reason = f"Player is injured (status: {bid_player.status})"
 

--- a/rehoboam/bidding_strategy.py
+++ b/rehoboam/bidding_strategy.py
@@ -197,6 +197,33 @@ class SmartBidding:
         self.tier_solid_upgrade = tier_solid_upgrade
         self.full_commit_gain = full_commit_gain
 
+    def _max_overbid_pct(self, ep_tier: str, market_value: int) -> float:
+        """The overbid ceiling for this tier, as a percentage of market value.
+
+        REH-116. This used to be `elite_max_overbid_pct` (30.0) for must_have
+        and `max_overbid_pct` (20.0) otherwise — private constants sitting
+        alongside the `BidCeilingPolicy` that REH-99 introduced precisely so
+        the bidder and the gate could not disagree. The private ones bound
+        first, and were lower, so the policy never governed anything.
+
+        It cost Nusa on 2026-08-31: the learned model asked for 40.8%, the
+        private cap applied 30.0%, we bid 34,033,029, and stefan_m took him for
+        34,683,029. The policy ceiling was 35,347,089.
+
+        Derived as a percentage rather than compared in euros because the
+        policy is `mv + max(floor_eur, mv x pct)` — at the cheap end the floor
+        governs and permits MORE than the percentage, which is the Chiarodia
+        case. Converting keeps that headroom instead of flattening it away.
+
+        The constructor constants survive only as the no-policy fallback:
+        production always passes one, and a bidder with no ceiling at all is a
+        worse failure than a slightly wrong one.
+        """
+        if self.ceiling_policy is None or market_value <= 0:
+            return self.elite_max_overbid_pct if ep_tier == "must_have" else self.max_overbid_pct
+        ceiling = self.ceiling_policy.max_bid(int(market_value), ep_tier)
+        return max(0.0, (ceiling - market_value) / market_value * 100.0)
+
     def calculate_ep_bid(
         self,
         asking_price: int,
@@ -376,8 +403,8 @@ class SmartBidding:
         # by a falling market value — contestedness doesn't care about trend.
         overbid_pct += _contested_overbid_bump(ep_tier=ep_tier, offer_count=offer_count)
 
-        # Cap overbid (must_have tier gets elite cap)
-        max_overbid = self.elite_max_overbid_pct if ep_tier == "must_have" else self.max_overbid_pct
+        # The ceiling comes from the ONE policy the safety gate enforces.
+        max_overbid = self._max_overbid_pct(ep_tier, market_value)
         overbid_pct = min(overbid_pct, max_overbid)
 
         # Try EP-specific learned overbid if available.

--- a/tests/test_bidder_uses_the_ceiling_policy.py
+++ b/tests/test_bidder_uses_the_ceiling_policy.py
@@ -1,0 +1,131 @@
+"""One ceiling, not two — the bidder defers to the policy (REH-116).
+
+REH-99 introduced `BidCeilingPolicy` so `SmartBidding` and `safety_gate` could
+not disagree about how far above market value a bid may go. `SmartBidding`
+took the policy, and kept its own caps alongside it:
+
+    max_overbid = self.elite_max_overbid_pct if ep_tier == "must_have" else self.max_overbid_pct
+    overbid_pct = min(overbid_pct, max_overbid)
+
+`elite_max_overbid_pct` defaults to 30.0 while the policy's `must_have`
+ceiling is 35.0, and the private cap binds first. It cost a player:
+
+    Nusa, 2026-08-31.  MV 26,183,029.  Learned model asked 40.8%,
+    the private cap applied 30.0% -> we bid 34,033,029.
+    stefan_m paid 34,683,029 (+32.5%) and took him.
+    The policy ceiling is 35,347,089 — we would have won by 664,060.
+
+That is the sixth instance of "two components each holding a private copy of
+one rule" in this repo (REH-99, 100, 101, 107, 111). The cap is not a second
+safety net; it is a lower ceiling nobody knew was binding.
+
+The floor matters too: the policy is `mv + max(floor_eur, mv x pct)`, so at
+the cheap end it permits MORE than a flat percentage, which is the Chiarodia
+case REH-99 documented. A percentage-only cap silently re-imposes the bug.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rehoboam.bidding_strategy import SmartBidding
+from rehoboam.config import Settings
+
+SETTINGS = Settings(kickbase_email="test@example.com", kickbase_password="x")
+POLICY = SETTINGS.bid_ceiling_policy()
+
+# The real Nusa listing.
+NUSA_MV = 26_183_029
+NUSA_WINNER_PAID = 34_683_029
+
+
+class _LearnerAskingFor:
+    """A bid_learner that recommends `pct` — the real Nusa override was 40.8%.
+
+    Prod logged `stack=13.8% learned=40.8% applied=30.0%`: the learned model
+    asked for more than the private cap allowed, so the cap is what actually
+    priced the bid. Reproducing that needs the override path, not the stack.
+    """
+
+    def __init__(self, pct: float):
+        self.pct = pct
+
+    def get_ep_recommended_overbid(self, **_kw):
+        return {"recommended_overbid_pct": self.pct, "reason": "test override"}
+
+
+def _bidder(**kw):
+    return SmartBidding(ceiling_policy=POLICY, **kw)
+
+
+def _bid(bidder, *, market_value, marginal_ep_gain, budget=500_000_000):
+    return bidder.calculate_ep_bid(
+        asking_price=market_value,
+        market_value=market_value,
+        expected_points=marginal_ep_gain,
+        marginal_ep_gain=marginal_ep_gain,
+        confidence=0.9,
+        current_budget=budget,
+        player_id="9507",
+        trend_change_pct=1.4,
+        offer_count=2,
+    )
+
+
+class TestTheNusaAuction:
+    def test_a_must_have_may_be_bid_above_the_old_thirty_percent_cap(self):
+        """The private cap is gone; the policy's 35% governs.
+
+        Driven through the learned override, because that is what prod did:
+        `stack=13.8% learned=40.8% applied=30.0%`.
+        """
+        rec = _bid(
+            _bidder(bid_learner=_LearnerAskingFor(40.8)),
+            market_value=NUSA_MV,
+            marginal_ep_gain=86.1,
+        )
+
+        ceiling = POLICY.max_bid(NUSA_MV, "must_have")
+        assert rec.recommended_bid <= ceiling
+        assert rec.recommended_bid > int(
+            NUSA_MV * 1.30
+        ), "the 30% private cap must no longer bind a must_have"
+
+    def test_the_policy_ceiling_would_have_won_nusa(self):
+        """Not a claim about this bid — about the headroom that existed."""
+        assert POLICY.max_bid(NUSA_MV, "must_have") > NUSA_WINNER_PAID
+
+
+class TestTheCeilingIsNeverExceeded:
+    @pytest.mark.parametrize(
+        ("gain", "tier"),
+        [(5.0, "marginal"), (30.0, "solid_upgrade"), (45.0, "strong_upgrade"), (95.0, "must_have")],
+    )
+    @pytest.mark.parametrize("mv", [591_389, 5_466_049, 26_183_029, 44_220_901])
+    def test_every_tier_stays_inside_its_policy_ceiling(self, gain, tier, mv):
+        rec = _bid(_bidder(), market_value=mv, marginal_ep_gain=gain)
+
+        assert rec.recommended_bid <= POLICY.max_bid(mv, tier) or rec.recommended_bid == 0
+
+
+class TestTheCheapEndKeepsItsFloor:
+    def test_a_small_market_value_may_exceed_a_flat_percentage(self):
+        """`mv + max(floor, mv x pct)` — the Chiarodia case REH-99 fixed.
+
+        A percentage-only cap would hold a EUR 591,389 player to a few tens of
+        thousands over, which is how that auction was lost by EUR 109k.
+        """
+        mv = 591_389
+
+        ceiling = POLICY.max_bid(mv, "marginal")
+
+        assert ceiling - mv >= POLICY.floor_eur
+
+
+class TestWithoutAPolicy:
+    def test_a_bidder_with_no_policy_still_produces_a_bounded_bid(self):
+        """Nothing constructs one without a policy in production, but a bid
+        with no ceiling at all would be the worst possible failure mode."""
+        rec = _bid(SmartBidding(), market_value=NUSA_MV, marginal_ep_gain=86.1)
+
+        assert 0 <= rec.recommended_bid <= NUSA_MV * 2

--- a/tests/test_manual_bids_are_not_cancelled.py
+++ b/tests/test_manual_bids_are_not_cancelled.py
@@ -1,0 +1,189 @@
+"""The bot must not cancel a bid it did not place (REH-115).
+
+On 2026-09-01 the 08:00 session cancelled Marco's own offer on Conrad Harder:
+
+    Keep: 0  Cancel: 1
+    Reason: Bid 34.4% over market value - above its ceiling
+    Canceling bid on Conrad Harder...
+
+Harder has zero rows in `trade_proposals`, `pending_bids` and
+`auction_outcomes` — the bot never bid on him.
+
+`evaluate_active_bids` iterates every live offer, because `get_my_bids` is
+`get_market` filtered by "do we hold an offer" and cannot tell who placed it.
+REH-111 then judged each bid by its recorded tier, and a bid with none fell to
+`untiered_price_ceiling` — a flat 25% cap. Harder was 34.4% over, so it went.
+
+The TODO on that function framed untiered as "rows written before the column
+existed". That missed the other, permanent case: **a human placed it**. A
+manual bid can never carry a tier, so it would never stop being cancelled.
+
+The rule is simpler than the ceiling question it looked like: an offer with no
+`pending_bids` row is not the bot's to withdraw. Marco's judgement is an input,
+not a candidate for review.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rehoboam.bid_evaluator import BidEvaluator
+from rehoboam.config import Settings
+from rehoboam.kickbase_client import MarketPlayer
+
+LEAGUE = "1933872"
+
+
+def _settings():
+    return Settings(kickbase_email="test@example.com", kickbase_password="x")
+
+
+def _offer(player_id, market_value, our_bid, *, status=0, avg=60.0):
+    return MarketPlayer(
+        id=player_id,
+        first_name="Conrad",
+        last_name="Harder",
+        position="Forward",
+        team_id="15",
+        team_name="",
+        price=market_value,
+        market_value=market_value,
+        points=0,
+        average_points=avg,
+        status=status,
+        seller_user_id=None,
+        offer_count=1,
+        user_offer_price=our_bid,
+        user_offer_id="3616202",
+    )
+
+
+class _Api:
+    def __init__(self, offers):
+        self._offers = offers
+
+    def get_my_bids(self, league):
+        return list(self._offers)
+
+    def get_market(self, league):
+        return list(self._offers)
+
+
+# 34.4% over market value — past the flat 25% that cancelled it.
+HARDER = _offer("9999", market_value=10_000_000, our_bid=13_440_000)
+
+
+def _evaluate(offer, *, bot_placed_ids, bid_tiers=None, trends=None):
+    evaluator = BidEvaluator(_Api([offer]), _settings())
+    return evaluator.evaluate_active_bids(
+        LEAGUE,
+        player_trends=trends or {},
+        for_profit=True,
+        bid_tiers=bid_tiers or {},
+        bot_placed_ids=bot_placed_ids,
+    )[0]
+
+
+class TestAManualBidIsLeftAlone:
+    def test_the_real_harder_bid_is_kept(self):
+        """The exact 2026-09-01 cancellation, now a no-op."""
+        result = _evaluate(HARDER, bot_placed_ids=set())
+
+        assert result.recommendation == "KEEP", result.reason
+
+    def test_the_reason_says_why(self):
+        result = _evaluate(HARDER, bot_placed_ids=set())
+
+        assert "manual" in result.reason.lower() or "not placed by" in result.reason.lower()
+
+    def test_a_falling_manual_bid_is_still_kept(self):
+        """Flip economics are the bot's rules for the bot's bids."""
+        trends = {"9999": {"trend": "falling", "trend_pct": -30.0, "peak_value": 20_000_000}}
+
+        result = _evaluate(HARDER, bot_placed_ids=set(), trends=trends)
+
+        assert result.recommendation == "KEEP", result.reason
+
+    def test_a_manual_bid_on_an_injured_player_is_still_kept(self):
+        """Even the injury rule: Marco can see the injury and bid anyway."""
+        injured = _offer("9999", market_value=10_000_000, our_bid=13_440_000, status=1)
+
+        result = _evaluate(injured, bot_placed_ids=set())
+
+        assert result.recommendation == "KEEP", result.reason
+
+
+class TestTheBotStillPolicesItsOwnBids:
+    def test_an_untiered_bot_bid_is_still_evaluated(self):
+        """The guard keys on provenance, not on the tier being present."""
+        result = _evaluate(HARDER, bot_placed_ids={"9999"})
+
+        assert result.recommendation == "CANCEL"
+
+    def test_a_tiered_bot_bid_at_its_ceiling_is_kept(self):
+        """REH-111 still holds for bids the bot placed."""
+        result = _evaluate(HARDER, bot_placed_ids={"9999"}, bid_tiers={"9999": "must_have"})
+
+        assert result.recommendation == "KEEP", result.reason
+
+
+class TestTheDefaultIsSafe:
+    def test_omitting_the_set_does_not_silently_cancel_manual_bids(self):
+        """A caller that forgets the argument must not resume cancelling.
+
+        The production wiring passes it, but this is the money path — the
+        default has to fail toward leaving a human's bid alone.
+        """
+        evaluator = BidEvaluator(_Api([HARDER]), _settings())
+
+        result = evaluator.evaluate_active_bids(LEAGUE, player_trends={}, for_profit=True)[0]
+
+        assert result.recommendation == "KEEP", result.reason
+
+
+@pytest.mark.parametrize("pct", [26.0, 34.4, 80.0])
+def test_no_manual_bid_is_cancelled_at_any_overbid(pct):
+    offer = _offer("9999", market_value=10_000_000, our_bid=int(10_000_000 * (1 + pct / 100)))
+
+    assert _evaluate(offer, bot_placed_ids=set()).recommendation == "KEEP"
+
+
+class TestTheSessionPassesProvenance:
+    """A guard the session never populates is a guard that does nothing.
+
+    `auction_outcomes.winning_bid` sat NULL for a season because a writer
+    existed and nothing called it (REH-86). Same trap, so the wiring is proved.
+    """
+
+    def test_the_session_supplies_bot_placed_ids(self, tmp_path, monkeypatch):
+        from types import SimpleNamespace
+        from unittest.mock import patch
+
+        from rehoboam.auto_trader import AutoTrader
+        from rehoboam.bid_learner import BidLearner
+
+        monkeypatch.setenv("KICKBASE_EMAIL", "test@example.com")
+        monkeypatch.setenv("KICKBASE_PASSWORD", "test")
+        monkeypatch.chdir(tmp_path)
+
+        trader = AutoTrader(api=_Api([HARDER]), settings=_settings(), dry_run=True)
+        trader.learner = BidLearner(db_path=tmp_path / "bid_learning.db")
+        trader.learner.add_pending_bid(
+            player_id="849",
+            player_name="Kleindienst",
+            our_bid=1,
+            asking_price=1,
+            our_overbid_pct=0.0,
+            timestamp=1.0,
+        )
+
+        captured = {}
+
+        def _spy(self, league, player_trends=None, for_profit=True, **kwargs):
+            captured.update(kwargs)
+            return []
+
+        with patch.object(BidEvaluator, "evaluate_active_bids", _spy):
+            trader._evaluate_open_bids(SimpleNamespace(id="L"), player_trends={})
+
+        assert captured.get("bot_placed_ids") == {"849"}


### PR DESCRIPTION
Two defects found in the 2026-09-01 08:00 session.

## REH-115 — the bot cancelled a bid it did not place

```
Keep: 0  Cancel: 1
Reason: Bid 34.4% over market value - above its ceiling
Canceling bid on Conrad Harder...
```

Harder has **zero rows** in `trade_proposals`, `pending_bids` and `auction_outcomes`. That bid was Marco's.

`get_my_bids` is `get_market` filtered by "do we hold an offer" and **cannot say who placed it**, so a manual bid arrives looking like an unexplained bot bid. REH-111 then judged each bid by its recorded tier, and one with none fell to `untiered_price_ceiling` — a flat 25%. Harder was 34.4% over, so it went.

That TODO framed untiered as *"rows written before the column existed"*. It missed the permanent case: **a human placed it**. A manual bid can never carry a tier, so it would never stop being cancelled.

`bot_placed_ids` now comes from `pending_bids`, and an offer outside it is left alone — including the injury and falling-trend rules, which are the bot's rules for the bot's bids. A recorded tier is itself proof of provenance, so omitting the argument falls back to the tiers and errs toward leaving a human's bid alone.

## REH-116 — a sixth private copy of the bid ceiling

```python
max_overbid = self.elite_max_overbid_pct if ep_tier == "must_have" else self.max_overbid_pct
```

REH-99 introduced `BidCeilingPolicy` precisely so the bidder and the gate could not disagree. `SmartBidding` took the policy **and kept its own caps beside it** — and the private ones are lower, so the policy never governed anything.

It cost a player. Nusa, 2026-08-31:

| | |
|---|---|
| Market value | €26,183,029 |
| Learned model asked | **40.8%** |
| Private cap applied | **30.0%** → we bid €34,033,029 |
| stefan_m paid | €34,683,029 (+32.5%) |
| Policy ceiling | **€35,347,089** |

We would have won by **€664,060**.

Derived as a percentage from `policy.max_bid` rather than compared in euros, because the policy is `mv + max(floor_eur, mv × pct)` — at the cheap end the floor permits *more* than the percentage, and flattening that back to a percent cap silently re-imposes the Chiarodia loss REH-99 fixed. There is a test for that. The constructor constants survive only as the no-policy fallback.

## On the replay

Unchanged in **both** configurations — 27,751 plain, 25,000 `--with-competition`, identical buys and final budget — verified by stash-and-rerun on the same tree.

That is a null result **with a cause**, not a pass. The replay constructs `SmartBidding` **without a `bid_learner`**, so the learned-override branch never runs, and the override is exactly what the 30% cap was clipping. The replay's stack tops out near 28% and never reaches the cap. The real evidence is the production log line and the Nusa arithmetic above.

## Verification

- 21 new tests, watched fail first; the RED reproduced the exact production number (`applied 30.0% → 34,033,029`)
- **1502 passed, 1 skipped**; ruff clean
- Live smoke: must_have bids now price at **35.0%** (€34,966,475 on MV €25,901,093) where they were clipped to 30.0% yesterday
- `_evaluate_open_bids` extracted from `run_full_session` so the provenance wiring is proved rather than assumed (REH-86's lesson)

## Known and deliberately not changed

`league_compliance` is a second path that can cancel a bid and is not provenance-aware either. It only fires when a bid is *below* market value — a league-rule violation whose only legal outcomes are raise or cancel — so cancelling there is defensible. Flagging rather than changing it silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgdBR45xMFtj2zTgFL1VEn