### PR TITLE
feat(notify): one budget-aware overview instead of a message per player (REH-117)

### DIFF
--- a/rehoboam/auto_trader.py
+++ b/rehoboam/auto_trader.py
@@ -2,6 +2,7 @@
 
 import logging
 import time
+import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
 
@@ -127,6 +128,80 @@ def _max_flip_hold_days(
     if not respect_matchday or days_until_match is None:
         return None
     return max(1, days_until_match - 1)
+
+
+def _is_too_falling_to_propose(trend_7d_pct: float | None, settings) -> bool:
+    """True when a market value is sliding too steeply to ask about (REH-117).
+
+    Absence is not evidence: most market candidates have little or no MV
+    history, and `None` must not block them.
+    """
+    if trend_7d_pct is None:
+        return False
+    return float(trend_7d_pct) < float(settings.max_falling_trend_pct_to_buy)
+
+
+def _club_name(player, score=None) -> str:
+    """The player's club, or a bare team id rather than a guess.
+
+    The market payload carries `tid` and never `tn`, so `player.team_name` is
+    empty for every market listing. `PlayerScore.club` is populated from the
+    pipeline's team profile (REH-117). Falling back to "club 7" is deliberate:
+    it is at least lookupable, where "unknown club" told Marco nothing and a
+    guessed name would be worse than either.
+    """
+    club = (getattr(score, "club", "") or "").strip()
+    if club:
+        return club
+    club = (getattr(player, "team_name", "") or "").strip()
+    if club:
+        return club
+    tid = str(getattr(player, "team_id", "") or "").strip()
+    return f"club {tid}" if tid else "unknown club"
+
+
+def _proposal_line(
+    proposal_id: str, rec, bid: int, trend: float | None, risks: list[str], auto_approve_at
+):
+    """Everything the overview shows, from data the pipeline already has.
+
+    `PlayerScore` carries position, lineup probability, minutes trend, average
+    points and next opponent; `BuyRecommendation` carries the roster impact.
+    The old per-player message discarded all of it and printed "unknown club"
+    with no position, which is how a defender was proposed to a squad whose
+    actual hole was at striker (REH-117).
+    """
+    from .config import POSITION_MINIMUMS
+    from .notify.overview import ProposalLine
+
+    player = rec.player
+    score = getattr(rec, "score", None)
+    position = getattr(score, "position", "") or getattr(player, "position", "") or ""
+    impact = getattr(rec, "roster_impact", "") or ""
+    return ProposalLine(
+        proposal_id=proposal_id,
+        name=f"{player.first_name} {player.last_name}".strip() or player.last_name,
+        bid=int(bid),
+        ep=float(getattr(score, "expected_points", 0.0) or 0.0),
+        marginal_gain=float(getattr(rec, "marginal_ep_gain", 0.0) or 0.0),
+        position=position,
+        club=_club_name(player, score),
+        market_value=int(getattr(player, "market_value", 0) or 0),
+        is_emergency=auto_approve_at is not None,
+        fills_gap=impact == "fills_gap",
+        trend_7d_pct=trend,
+        season_avg=(
+            float(score.average_points)
+            if score is not None and getattr(score, "average_points", None) is not None
+            else None
+        ),
+        lineup_probability=getattr(score, "lineup_probability", None),
+        minutes_trend=getattr(score, "minutes_trend", None),
+        next_opponent=getattr(score, "next_opponent", None),
+        is_dgw=bool(getattr(score, "is_dgw", False)),
+        position_minimum=POSITION_MINIMUMS.get(position),
+        risks=tuple(risks),
+    )
 
 
 def _compute_flip_budget(
@@ -289,6 +364,10 @@ class AutoTrader:
         from .learning import LearningTracker
 
         self.learner = BidLearner()
+        # REH-117: one message per session, not one per player. Collected here
+        # and sent once by `_send_proposal_overview`.
+        self._session_proposals: list = []
+        self._session_batch_id: str = ""
         self.activity_feed_learner = ActivityFeedLearner()
         self.tracker = LearningTracker(self.learner)
 
@@ -592,7 +671,6 @@ class AutoTrader:
         import uuid
 
         from .notify.render import render_proposal
-        from .notify.telegram import send_proposal
         from .services.bid_ceiling import tier_for_marginal_gain
 
         proposal_id = uuid.uuid4().hex[:12]
@@ -608,6 +686,18 @@ class AutoTrader:
             )
         except Exception:
             logger.debug("proposal: no trend for %s", player.id, exc_info=True)
+
+        if _is_too_falling_to_propose(trend, self.settings):
+            console.print(
+                f"[dim]Skip {player.last_name} — market value falling " f"{trend:.1f}%/7d[/dim]"
+            )
+            logger.info(
+                "proposal-skip player=%s trend=%.1f%% below %.1f%% floor",
+                player.id,
+                trend,
+                float(self.settings.max_falling_trend_pct_to_buy),
+            )
+            return False
 
         risks: list[str] = []
         if getattr(rec.score, "data_quality", None) and rec.score.data_quality.grade != "A":
@@ -631,6 +721,12 @@ class AutoTrader:
         )
 
         bid_amount = int(bid if bid is not None else rec.recommended_bid)
+
+        # Collected before the dry-run exit so `status` renders the message
+        # Marco would actually receive, rather than a line saying one exists.
+        self._session_proposals.append(
+            _proposal_line(proposal_id, rec, bid_amount, trend, risks, auto_approve_at)
+        )
 
         if self.dry_run:
             console.print(
@@ -660,36 +756,81 @@ class AutoTrader:
                 message=message,
                 tier=tier.value,
                 auto_approve_at=auto_approve_at,
+                batch_id=self._session_batch_id,
             )
         except Exception:
             logger.exception("proposal: could not record %s", proposal_id)
             return False
 
-        # The return value is worth logging: a proposal that fails to send is
-        # recorded but invisible, and the only way to act on it is the daily
-        # summary's keyboard (REH-106). Silence here made a delivery failure
-        # look identical to a proposal nobody chose to approve.
-        delivered = send_proposal(
+        # REH-117: no send here. Six separate messages could not show that the
+        # proposals compete for one wallet, and on 2026-08-31 approving two of
+        # them stranded the other four on "budget would go negative". The
+        # session collects the board and sends it once, in `_send_proposal_overview`.
+        logger.info(
+            "proposal recorded id=%s player=%s bid=%d batch=%s",
+            proposal_id,
+            player.id,
+            bid_amount,
+            self._session_batch_id,
+        )
+        return True
+
+    def _send_proposal_overview(self, league, ctx) -> None:
+        """Send the session's whole proposal board as one message (REH-117).
+
+        Called once, at the end, so the message can show what the proposals do
+        to each other. Six separate messages could not: on 2026-08-31 approving
+        two of them consumed the wallet and the other four died on "budget
+        would go negative".
+
+        Best-effort — a delivery failure must not fail the session. The
+        proposals are already recorded, so the daily summary's keyboard remains
+        a way to act on them (REH-106).
+        """
+        if not self._session_proposals:
+            return
+
+        from .notify.overview import render_proposal_overview, split_by_budget
+        from .notify.telegram import send_overview
+
+        budget = int(getattr(ctx, "current_budget", 0) or 0)
+        recommended, alternatives = split_by_budget(self._session_proposals, budget)
+        text = render_proposal_overview(
+            squad_size=len(getattr(ctx, "squad", []) or []),
+            squad_cap=SQUAD_CAP,
+            budget=budget,
+            recommended=recommended,
+            alternatives=alternatives,
+        )
+        console.print(text)
+        if self.dry_run:
+            console.print("[yellow]DRY RUN - overview not sent[/yellow]")
+            return
+
+        delivered = send_overview(
             self.settings.telegram_bot_token,
             self.settings.telegram_chat_id,
-            proposal_id,
-            message,
+            text,
+            batch_id=self._session_batch_id,
+            recommended_count=len(recommended),
+            alternatives=[(line.proposal_id, line.name) for line in alternatives],
+        )
+        logger.info(
+            "proposal-overview batch=%s proposals=%d recommended=%d "
+            "spend=%d budget=%d delivered=%s",
+            self._session_batch_id,
+            len(self._session_proposals),
+            len(recommended),
+            sum(line.bid for line in recommended),
+            budget,
+            delivered,
         )
         if not delivered:
             logger.warning(
-                "proposal %s for %s was recorded but NOT delivered to Telegram; "
-                "it is actionable only from the daily summary",
-                proposal_id,
-                player.id,
+                "proposal overview %s recorded but NOT delivered; the proposals "
+                "are actionable only from the daily summary",
+                self._session_batch_id,
             )
-        logger.info(
-            "proposal recorded id=%s player=%s bid=%d delivered=%s",
-            proposal_id,
-            player.id,
-            int(rec.recommended_bid),
-            delivered,
-        )
-        return True
 
     def _settle_top5_obligation(self, league, ctx) -> None:
         """Discharge the league's Top-5 forced sale for the last finished matchday.
@@ -1821,6 +1962,11 @@ class AutoTrader:
             console.print("[yellow]DRY RUN MODE - No trades will be executed[/yellow]")
         console.print(f"{'=' * 70}")
 
+        # REH-117: one batch per session, so "Approve all" can take the set
+        # that was chosen to fit the budget together.
+        self._session_proposals = []
+        self._session_batch_id = uuid.uuid4().hex[:12]
+
         logger.info(
             "session-start league=%s dry_run=%s max_trades=%d max_spend=%d",
             getattr(league, "name", league.id),
@@ -2031,6 +2177,7 @@ class AutoTrader:
                     f"— setting lineup only, no trading[/yellow]"
                 )
 
+            self._send_proposal_overview(league, ctx)
             lineup = (
                 self._set_optimal_lineup(
                     league, errors, squad_scores=ctx.ep_result.get("squad_scores")
@@ -2115,6 +2262,8 @@ class AutoTrader:
         # Step 8: Set optimal lineup using EP pipeline scores from the session.
         # Players acquired mid-session (if any) are scored by the v2 fallback
         # inside _set_optimal_lineup.
+        self._send_proposal_overview(league, ctx)
+
         lineup = (
             self._set_optimal_lineup(league, errors, squad_scores=ctx.ep_result.get("squad_scores"))
             or []

--- a/rehoboam/bid_learner.py
+++ b/rehoboam/bid_learner.py
@@ -588,6 +588,14 @@ class BidLearner:
             except sqlite3.OperationalError:
                 pass  # already present
 
+            # REH-117: the session that proposed this, so one tap can approve
+            # the set that was chosen to fit the budget together. NULL means a
+            # proposal that stands alone and keeps its own single button.
+            try:
+                conn.execute("ALTER TABLE trade_proposals ADD COLUMN batch_id TEXT")
+            except sqlite3.OperationalError:
+                pass  # already present
+
             # REH-104: entry context for a flip. `trend_at_buy` has existed
             # since this table was created and was NULL in all 151 rows —
             # `record_flip_outcome` runs at sell time and had nothing to write.
@@ -1903,6 +1911,7 @@ class BidLearner:
         message: str,
         tier: str | None = None,
         auto_approve_at: float | None = None,
+        batch_id: str | None = None,
     ) -> None:
         """Persist a proposal awaiting approval.
 
@@ -1914,8 +1923,8 @@ class BidLearner:
             conn.execute(
                 "INSERT OR REPLACE INTO trade_proposals "
                 "(proposal_id, player_id, player_name, bid, market_value, message, "
-                " status, created_at, tier, auto_approve_at) "
-                "VALUES (?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?)",
+                " status, created_at, tier, auto_approve_at, batch_id) "
+                "VALUES (?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?)",
                 (
                     proposal_id,
                     player_id,
@@ -1926,8 +1935,34 @@ class BidLearner:
                     datetime.now().timestamp(),
                     tier,
                     auto_approve_at,
+                    batch_id,
                 ),
             )
+
+    def pending_in_batch(self, batch_id: str) -> list[dict]:
+        """Still-pending proposals from one session's recommended set.
+
+        Oldest first, which is the order the overview presented them in — the
+        set was chosen to fit the budget as a whole, so executing it in a
+        different order can strand the tail on "budget would go negative".
+
+        `status = 'pending'` keeps anything already tapped, rejected or
+        auto-approved out, which is what makes a second tap on "Approve all"
+        buy nothing more.
+        """
+        if not batch_id:
+            return []
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(
+                """
+                SELECT * FROM trade_proposals
+                WHERE batch_id = ? AND status = 'pending'
+                ORDER BY created_at ASC, rowid ASC
+                """,
+                (batch_id,),
+            ).fetchall()
+        return [dict(r) for r in rows]
 
     def due_auto_approvals(self, *, now: float) -> list[dict]:
         """Pending proposals whose auto-approve deadline has passed.

--- a/rehoboam/config.py
+++ b/rehoboam/config.py
@@ -432,6 +432,19 @@ class Settings(BaseSettings):
             "exactly when there is least evidence."
         ),
     )
+    max_falling_trend_pct_to_buy: float = Field(
+        default=-20.0,
+        description=(
+            "Steepest 7-day market-value fall a squad buy may still be proposed "
+            "at. Measured over 21 proposals, four went out badly falling — Itten "
+            "-27.0%, Stalmach -32.1%, Trimmel -20.1%, Ndiaye -19.5% — with the "
+            "number printed and no warning. Deliberately looser than the "
+            "overview's FALLING flag (-10%): a mild slide on a good player is a "
+            "judgement call Marco should get to make, while a value in free-fall "
+            "is usually the league pricing in an availability problem before we "
+            "have seen it. Profit flips keep their own rules."
+        ),
+    )
     emergency_auto_approve_hours: float = Field(
         default=24.0,
         description=(

--- a/rehoboam/notify/approval.py
+++ b/rehoboam/notify/approval.py
@@ -131,6 +131,45 @@ def execute_proposal(proposal: dict, *, settings, learner, api, league) -> str:
     return f"Bought {proposal['player_name']} for EUR {int(proposal['bid']):,}."
 
 
+def _execute_batch(batch_id: str, *, settings, learner, api, league) -> str:
+    """Execute one session's recommended set, in the order it was presented.
+
+    The set was chosen to fit the budget as a whole (`overview.split_by_budget`),
+    so order is load-bearing: running it out of order can strand the tail on
+    "budget would go negative", which is exactly the failure this replaces.
+
+    A gate refusal on one line does not abandon the rest. Each proposal is
+    re-validated against live state at execution, so a market value that moved
+    since the message was sent should cost that line and nothing else.
+    """
+    pending = learner.pending_in_batch(batch_id)
+    if not pending:
+        return "Nothing left to approve in that set."
+
+    bought: list[str] = []
+    refused: list[str] = []
+    for proposal in pending:
+        pid = proposal["proposal_id"]
+        # Claim each one individually — the replay guard is per proposal, so a
+        # retried callback re-enters here and finds an empty batch.
+        if not learner.mark_proposal(pid, "approved"):
+            continue
+        reply = execute_proposal(
+            proposal, settings=settings, learner=learner, api=api, league=league
+        )
+        if reply.startswith("Bought"):
+            bought.append(proposal["player_name"])
+        else:
+            refused.append(f"{proposal['player_name']}: {reply}")
+
+    parts = []
+    if bought:
+        parts.append(f"Bought {len(bought)}: {', '.join(bought)}.")
+    if refused:
+        parts.append(f"Skipped {len(refused)} — {'; '.join(refused)}")
+    return " ".join(parts) or "Nothing executed."
+
+
 def handle_callback(
     body: dict,
     secret_header: str | None,
@@ -147,9 +186,14 @@ def handle_callback(
 
     query = (body or {}).get("callback_query") or {}
     data = query.get("data") or ""
-    action, _, proposal_id = data.partition(":")
-    if action not in {"approve", "reject"} or not proposal_id:
+    action, _, target = data.partition(":")
+    if action not in {"approve", "reject", "approveall"} or not target:
         return "Unrecognised callback."
+
+    if action == "approveall":
+        return _execute_batch(target, settings=settings, learner=learner, api=api, league=league)
+
+    proposal_id = target
 
     proposal = learner.get_proposal(proposal_id)
     if proposal is None:

--- a/rehoboam/notify/overview.py
+++ b/rehoboam/notify/overview.py
@@ -1,0 +1,203 @@
+"""One message for a whole session's proposals, budget-aware (REH-117).
+
+Proposals used to go out one Telegram message per player. Nothing could then
+show how they interact, and they compete for one wallet: on 2026-08-31 Marco
+approved Nusa and Ebnoutalib, which consumed the budget, and Avdullahu, Reis
+and a second Avdullahu all failed on "budget would go negative".
+
+So the session sends one message: the set that fits, then everything else.
+
+The split is a WALK, not a knapsack. A knapsack would fit marginally more
+money, and would sometimes skip the second line to afford the fourth — which,
+in a list a human reads top to bottom, reads as a bug rather than as
+optimisation. The order has to be explicable: slot-filling emergencies first
+because they carry the -100, then by expected points, take what fits.
+
+Pure, so the message can be asserted directly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+#: Below this weekly market-value move a proposal is called out as falling.
+#: Itten went out at -27.0%/7d with the number printed and nothing flagged.
+FALLING_TREND_PCT = -10.0
+
+_POSITION_ABBR = {
+    "Goalkeeper": "GK",
+    "Defender": "DEF",
+    "Midfielder": "MID",
+    "Forward": "FWD",
+}
+
+
+@dataclass(frozen=True)
+class ProposalLine:
+    """One proposal, with everything the message needs to justify it.
+
+    The pipeline already computes all of this and the old renderer discarded
+    it — `PlayerScore` carries position, lineup probability, minutes trend,
+    average points and next opponent, and every proposal still said
+    "unknown club" with no position at all.
+    """
+
+    proposal_id: str
+    name: str
+    bid: int
+    ep: float
+    marginal_gain: float
+    position: str = ""
+    club: str = ""
+    market_value: int = 0
+    is_emergency: bool = False
+    fills_gap: bool = False
+    trend_7d_pct: float | None = None
+    season_avg: float | None = None
+    lineup_probability: int | None = None
+    minutes_trend: str | None = None
+    next_opponent: str | None = None
+    is_dgw: bool = False
+    squad_at_position: int | None = None
+    position_minimum: int | None = None
+    risks: tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def overbid_pct(self) -> float:
+        if self.market_value <= 0:
+            return 0.0
+        return (self.bid / self.market_value - 1.0) * 100.0
+
+    @property
+    def is_falling(self) -> bool:
+        return self.trend_7d_pct is not None and self.trend_7d_pct <= FALLING_TREND_PCT
+
+    @property
+    def pos_short(self) -> str:
+        return _POSITION_ABBR.get(self.position, self.position[:3].upper() or "???")
+
+
+def split_by_budget(
+    lines: list[ProposalLine], budget: int
+) -> tuple[list[ProposalLine], list[ProposalLine]]:
+    """Split proposals into (fits now, needs money first).
+
+    Ordered by what costs points to leave undone, then by expected points. An
+    unfilled lineup slot is -100 every matchday, and a position below its
+    formation minimum makes the eleven illegal rather than merely weaker — the
+    same argument `emergency_basket._value` makes when it counts gap coverage
+    at the slot penalty. The two orderings have to agree, or the message
+    recommends a surplus midfielder over the only available striker.
+
+    A line that does not fit is moved aside and the walk continues, so one
+    expensive pick does not strand the cheaper ones behind it.
+    """
+    ordered = sorted(lines, key=lambda x: (not (x.is_emergency or x.fills_gap), -x.ep, x.bid))
+
+    recommended: list[ProposalLine] = []
+    alternatives: list[ProposalLine] = []
+    remaining = int(budget)
+    for line in ordered:
+        if line.bid <= remaining:
+            recommended.append(line)
+            remaining -= line.bid
+        else:
+            alternatives.append(line)
+    return recommended, alternatives
+
+
+def _availability(line: ProposalLine) -> str:
+    bits: list[str] = []
+    if line.lineup_probability is not None:
+        bits.append(
+            {1: "starter", 2: "likely starter", 3: "rotation"}.get(
+                line.lineup_probability, "bench risk"
+            )
+        )
+    if line.minutes_trend:
+        bits.append(f"minutes {line.minutes_trend}")
+    if line.is_dgw:
+        bits.append("DOUBLE gameweek")
+    return " · ".join(bits)
+
+
+def _line_block(line: ProposalLine) -> list[str]:
+    """One proposal, four short lines. Position and club lead — they were the
+    two facts the old message never carried."""
+    club = line.club or "unknown club"
+    head = f"  {line.name} ({line.pos_short}, {club})  EUR {line.bid:,}"
+
+    form: list[str] = []
+    if line.season_avg is not None:
+        form.append(f"avg {line.season_avg:.0f}/game")
+    form.append(f"EP {line.ep:.0f}")
+    if line.next_opponent:
+        form.append(f"next {line.next_opponent}")
+
+    price = f"MV {line.market_value:,} · bid {line.overbid_pct:+.1f}%"
+    if line.trend_7d_pct is not None:
+        price += f" · trend {line.trend_7d_pct:+.1f}%/7d"
+        if line.is_falling:
+            price += "  <-- FALLING"
+
+    out = [head, f"      {' · '.join(form)}", f"      {price}"]
+
+    availability = _availability(line)
+    if availability:
+        out.append(f"      {availability}")
+
+    if line.is_emergency:
+        # NOT "displaces the weakest starter (0.0)" — with a short squad there
+        # is no incumbent, and the old message printed a placeholder and a zero.
+        out.append("      fills an empty lineup slot (worth +100)")
+    elif line.fills_gap and line.position:
+        out.append(f"      fills your {line.pos_short} gap")
+    elif line.squad_at_position is not None and line.position_minimum is not None:
+        out.append(
+            f"      you have {line.squad_at_position} {line.pos_short} "
+            f"(min {line.position_minimum})"
+        )
+
+    for risk in line.risks:
+        out.append(f"      ! {risk}")
+    return out
+
+
+def render_proposal_overview(
+    *,
+    squad_size: int,
+    squad_cap: int,
+    budget: int,
+    recommended: list[ProposalLine],
+    alternatives: list[ProposalLine],
+) -> str:
+    """The session's whole board, in one message.
+
+    `recommended` is expected to come from `split_by_budget` and to fit inside
+    `budget`; the total is printed either way so a caller that builds its own
+    set cannot quietly present an unaffordable one as affordable.
+    """
+    total = sum(line.bid for line in recommended)
+    lines = [
+        f"SQUAD {squad_size}/{squad_cap}   BUDGET EUR {budget:,}",
+        "",
+    ]
+
+    if recommended:
+        lines.append(f"RECOMMENDED — {len(recommended)} of {len(recommended) + len(alternatives)}")
+        for line in recommended:
+            lines += _line_block(line)
+            lines.append("")
+        lines.append(f"  total EUR {total:,}   leaves EUR {budget - total:,}")
+        if total > budget:
+            lines.append(f"  WARNING over budget by EUR {total - budget:,}")
+    else:
+        lines.append("RECOMMENDED — none fit the current budget")
+
+    if alternatives:
+        lines += ["", "ALTERNATIVES — need a sell first"]
+        for line in alternatives:
+            lines += _line_block(line)
+            lines.append("")
+
+    return "\n".join(lines).rstrip()

--- a/rehoboam/notify/telegram.py
+++ b/rehoboam/notify/telegram.py
@@ -75,6 +75,37 @@ def _approval_row(proposal_id: str, approve_label: str, reject_label: str) -> li
     ]
 
 
+def overview_keyboard(
+    batch_id: str, recommended_count: int, alternatives: list[tuple[str, str]]
+) -> dict:
+    """One button for the recommended set, then one row per alternative.
+
+    The set was chosen to fit the budget together, so it gets a single tap —
+    approving it player by player is what let Marco spend the wallet on the
+    wrong two and strand the rest on "budget would go negative".
+
+    Alternatives keep individual buttons: they do NOT fit alongside the set,
+    so tapping one is a deliberate choice to buy it instead, usually after a
+    sell. Same tail-keeping rule as `approval_keyboard` — poach latency is
+    hours, so the newest are the ones still winnable.
+    """
+    rows: list[list[dict]] = []
+    if recommended_count > 0 and batch_id:
+        rows.append(
+            [
+                {
+                    "text": f"\u2705 Approve all {recommended_count}",
+                    "callback_data": f"approveall:{batch_id}",
+                }
+            ]
+        )
+    rows += [
+        _approval_row(pid, f"\u2705 {name}", f"\u274c {name}")
+        for pid, name in alternatives[-MAX_APPROVAL_BUTTONS:]
+    ]
+    return {"inline_keyboard": rows}
+
+
 def approval_keyboard(approvals: list[tuple[str, str]]) -> dict:
     """One Approve/Reject row per pending proposal, labelled by player."""
     return {
@@ -148,6 +179,36 @@ def send_message(
         text,
         keyboard=approval_keyboard(approvals) if approvals else None,
         what="daily summary",
+        timeout=timeout,
+    )
+
+
+def send_overview(
+    token: str,
+    chat_id: str,
+    text: str,
+    *,
+    batch_id: str,
+    recommended_count: int,
+    alternatives: list[tuple[str, str]] | None = None,
+    timeout: float = 10.0,
+) -> bool:
+    """Send a session's whole proposal board as one message (REH-117).
+
+    Replaces one `send_proposal` per player. Six separate messages could not
+    show that they compete for one wallet, and nothing in any of them said the
+    budget would run out partway down.
+    """
+    if not token or not chat_id:
+        logger.info("telegram: no token or chat id configured — not sending")
+        return False
+
+    return _send_chunked(
+        token,
+        chat_id,
+        text,
+        keyboard=overview_keyboard(batch_id, recommended_count, alternatives or []),
+        what=f"proposal overview {batch_id}",
         timeout=timeout,
     )
 

--- a/rehoboam/scoring/models.py
+++ b/rehoboam/scoring/models.py
@@ -39,6 +39,7 @@ class PlayerScore:
     market_value: int
     average_points: float = 0.0
     position: str = ""
+    club: str = ""  # REH-117: the pipeline knows it; the proposal message needs it
     lineup_probability: int | None = None  # 1=starter, 2-3=rotation, 4-5=unlikely
     minutes_trend: str | None = None  # "increasing" | "decreasing" | "stable"
 

--- a/rehoboam/scoring/v2/adapter.py
+++ b/rehoboam/scoring/v2/adapter.py
@@ -349,8 +349,17 @@ def score_player_v2(
     if data.is_dgw:
         notes.append("DOUBLE GAMEWEEK ×1.8")
 
+    # REH-117: `team_strength` and `player_details` both carry the club name
+    # and both were dropped here, so every Telegram proposal read
+    # "unknown club" — the market payload has `tid` and never `tn`. Left blank
+    # when genuinely unknown: a wrong club actively misleads.
+    club = getattr(data.team_strength, "team_name", "") or ""
+    if not club and isinstance(data.player_details, dict):
+        club = data.player_details.get("tn", "") or ""
+
     return PlayerScore(
         player_id=player.id,
+        club=club,
         expected_points=round(ep, 2),
         data_quality=DataQuality(
             grade="A" if quality_key in rate.quality else "C",

--- a/tests/test_approve_all_batch.py
+++ b/tests/test_approve_all_batch.py
@@ -27,7 +27,12 @@ BATCH = "batch0001"
 
 
 def _settings():
-    return Settings(kickbase_email="test@example.com", kickbase_password="x")
+    """An explicit webhook secret — `authorize` rejects an empty one, and
+    reading it from the ambient environment made these pass locally off a
+    developer `.env` and fail in CI with "Unauthorized."."""
+    s = Settings(kickbase_email="test@example.com", kickbase_password="x")
+    s.telegram_webhook_secret = "s3cret"
+    return s
 
 
 def _listing(pid, price):

--- a/tests/test_approve_all_batch.py
+++ b/tests/test_approve_all_batch.py
@@ -1,0 +1,202 @@
+"""Approving a session's recommended set in one tap (REH-117).
+
+The overview presents the proposals that fit the budget as one set, so the
+callback has to be able to take that set. `approveall:<batch_id>` executes the
+batch's still-pending proposals in the order they were recorded, through the
+same `execute_proposal` the single-tap path uses — a second execute path would
+be the seventh copy of one rule in this repo.
+
+Ordering matters here in a way it does not for a single tap: the set was
+chosen to fit the budget as a whole, and each execution re-validates against
+live state. If a market value moved and the gate refuses one, the rest still
+go — a refusal means "next", not "abandon the set".
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from rehoboam.bid_learner import BidLearner
+from rehoboam.config import Settings
+from rehoboam.kickbase_client import MarketPlayer
+
+LEAGUE = SimpleNamespace(id="1933872", name="PUMARUDEL")
+BATCH = "batch0001"
+
+
+def _settings():
+    return Settings(kickbase_email="test@example.com", kickbase_password="x")
+
+
+def _listing(pid, price):
+    return MarketPlayer(
+        id=pid,
+        first_name="F",
+        last_name=f"P{pid}",
+        position="Midfielder",
+        team_id=f"club{pid}",
+        team_name="",
+        price=price,
+        market_value=price,
+        points=0,
+        average_points=60.0,
+        status=0,
+    )
+
+
+class _Api:
+    def __init__(self, listings, budget=100_000_000):
+        self.listings = list(listings)
+        self.budget = budget
+        self.bought: list[tuple[str, int]] = []
+
+    def get_market(self, league):
+        return list(self.listings)
+
+    def get_squad(self, league):
+        return []
+
+    def get_my_bids(self, league):
+        return []
+
+    def get_team_info(self, league):
+        return {"budget": self.budget, "team_value": 100_000_000}
+
+    def buy_player(self, league, player, price):
+        self.bought.append((player.id, price))
+        self.budget -= price
+        return True
+
+
+@pytest.fixture
+def learner(tmp_path):
+    return BidLearner(db_path=tmp_path / "bid_learning.db")
+
+
+def _record(learner, pid, bid, *, batch_id=BATCH):
+    learner.record_proposal(
+        proposal_id=f"prop{pid}",
+        player_id=pid,
+        player_name=f"P{pid}",
+        bid=bid,
+        market_value=bid,
+        message="m",
+        tier="marginal",
+        batch_id=batch_id,
+    )
+
+
+class TestTheBatchIsPersisted:
+    def test_a_proposal_remembers_its_batch(self, learner):
+        _record(learner, "1", 1_000_000)
+
+        assert learner.get_proposal("prop1")["batch_id"] == BATCH
+
+    def test_pending_proposals_in_a_batch_come_back_in_order(self, learner):
+        _record(learner, "1", 1_000_000)
+        _record(learner, "2", 2_000_000)
+        _record(learner, "3", 3_000_000, batch_id="other")
+
+        rows = learner.pending_in_batch(BATCH)
+
+        assert [r["player_id"] for r in rows] == ["1", "2"]
+
+    def test_a_resolved_proposal_leaves_the_batch(self, learner):
+        _record(learner, "1", 1_000_000)
+        _record(learner, "2", 2_000_000)
+        learner.set_proposal_status("prop1", "rejected")
+
+        assert [r["player_id"] for r in learner.pending_in_batch(BATCH)] == ["2"]
+
+    def test_an_unbatched_proposal_is_never_swept_up(self, learner):
+        """Alternatives and ordinary upgrades keep their own single buttons."""
+        learner.record_proposal(
+            proposal_id="loose",
+            player_id="9",
+            player_name="Loose",
+            bid=1,
+            market_value=1,
+            message="m",
+        )
+
+        assert learner.pending_in_batch(BATCH) == []
+
+
+class TestApprovingTheWholeSet:
+    def _callback(self, batch_id=BATCH):
+        return {"callback_query": {"id": "1", "data": f"approveall:{batch_id}"}}
+
+    def test_every_proposal_in_the_batch_is_bought(self, learner):
+        from rehoboam.notify.approval import handle_callback
+
+        _record(learner, "1", 1_000_000)
+        _record(learner, "2", 2_000_000)
+        api = _Api([_listing("1", 1_000_000), _listing("2", 2_000_000)])
+        settings = _settings()
+
+        reply = handle_callback(
+            self._callback(),
+            settings.telegram_webhook_secret,
+            settings=settings,
+            learner=learner,
+            api=api,
+            league=LEAGUE,
+        )
+
+        assert api.bought == [("1", 1_000_000), ("2", 2_000_000)], reply
+        assert learner.get_proposal("prop1")["status"] == "executed"
+        assert learner.get_proposal("prop2")["status"] == "executed"
+
+    def test_a_refusal_does_not_abandon_the_rest_of_the_set(self, learner):
+        """The set was chosen together; one stale price must not sink it."""
+        from rehoboam.notify.approval import handle_callback
+
+        _record(learner, "1", 90_000_000)  # unaffordable against the live budget
+        _record(learner, "2", 2_000_000)
+        api = _Api([_listing("1", 1_000_000), _listing("2", 2_000_000)], budget=10_000_000)
+        settings = _settings()
+
+        handle_callback(
+            self._callback(),
+            settings.telegram_webhook_secret,
+            settings=settings,
+            learner=learner,
+            api=api,
+            league=LEAGUE,
+        )
+
+        assert api.bought == [("2", 2_000_000)]
+        assert learner.get_proposal("prop1")["status"] == "failed"
+        assert learner.get_proposal("prop2")["status"] == "executed"
+
+    def test_a_second_tap_buys_nothing_more(self, learner):
+        """Telegram retries callbacks; the claim is the replay guard."""
+        from rehoboam.notify.approval import handle_callback
+
+        _record(learner, "1", 1_000_000)
+        api = _Api([_listing("1", 1_000_000)])
+        settings = _settings()
+        args = {"settings": settings, "learner": learner, "api": api, "league": LEAGUE}
+
+        handle_callback(self._callback(), settings.telegram_webhook_secret, **args)
+        handle_callback(self._callback(), settings.telegram_webhook_secret, **args)
+
+        assert api.bought == [("1", 1_000_000)]
+
+    def test_an_empty_batch_says_so(self, learner):
+        from rehoboam.notify.approval import handle_callback
+
+        settings = _settings()
+
+        reply = handle_callback(
+            self._callback("nothing-here"),
+            settings.telegram_webhook_secret,
+            settings=settings,
+            learner=learner,
+            api=_Api([]),
+            league=LEAGUE,
+        )
+
+        assert "nothing" in reply.lower() or "no " in reply.lower()

--- a/tests/test_falling_mv_block.py
+++ b/tests/test_falling_mv_block.py
@@ -1,0 +1,55 @@
+"""A steeply falling market value is not proposed at all (REH-117).
+
+Marco: "the players the bot recommended were mostly garbage and had a falling
+mv trend." Measured over 21 proposals, four were badly falling when sent:
+
+    Trimmel  -20.1%    Ndiaye   -19.5%
+    Itten    -27.0%    Stalmach -32.1%
+
+The bot printed the number and proposed anyway — Itten went out at -27.0%/7d
+with a data-quality-C warning attached.
+
+Two thresholds, deliberately different. Below `FALLING_TREND_PCT` (-10%) the
+overview flags it and still asks, because a mild slide on a good player is a
+judgement call and Marco should get to make it. Below
+`max_falling_trend_pct_to_buy` (-20%) it is not proposed at all: the squad
+buys hold for points across a season, and a market value in free-fall is the
+league's verdict on availability arriving before ours does.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rehoboam.auto_trader import _is_too_falling_to_propose
+from rehoboam.config import Settings
+
+SETTINGS = Settings(kickbase_email="test@example.com", kickbase_password="x")
+
+
+@pytest.mark.parametrize(
+    ("name", "trend"),
+    [("Itten", -27.0), ("Stalmach", -32.1), ("Trimmel", -20.1), ("steep", -99.0)],
+)
+def test_a_steeply_falling_player_is_blocked(name, trend):
+    assert _is_too_falling_to_propose(trend, SETTINGS) is True
+
+
+@pytest.mark.parametrize("trend", [-19.5, -10.0, -3.0, 0.0, 12.0, 121.8])
+def test_everything_shallower_is_still_proposed(trend):
+    """-19.5% (Ndiaye) is flagged in the message, not blocked."""
+    assert _is_too_falling_to_propose(trend, SETTINGS) is False
+
+
+def test_an_unknown_trend_does_not_block():
+    """Most candidates have no MV history at all — absence is not evidence."""
+    assert _is_too_falling_to_propose(None, SETTINGS) is False
+
+
+def test_the_threshold_is_configurable():
+    tighter = Settings(
+        kickbase_email="t@e.com", kickbase_password="x", max_falling_trend_pct_to_buy=-5.0
+    )
+
+    assert _is_too_falling_to_propose(-6.0, tighter) is True
+    assert _is_too_falling_to_propose(-6.0, SETTINGS) is False

--- a/tests/test_proposal_overview.py
+++ b/tests/test_proposal_overview.py
@@ -1,0 +1,192 @@
+"""One message for the whole session, and a set that actually fits (REH-117).
+
+Two complaints, one cause. Proposals were sent one message per player, so
+nothing could show how they interact — and on 2026-08-31 Marco approved Nusa
+and Ebnoutalib, which consumed the wallet, after which Avdullahu, Reis and a
+second Avdullahu all failed on "budget would go negative". Four dead proposals
+in two days, and no way to see it coming from six separate messages.
+
+The other complaint was the content. A real message he received:
+
+    BUY Edmond Tapsoba — EUR 41,702,302
+    WHY THIS PLAYER
+      EP 107.0. unknown club.
+    WHY IT IMPROVES THE LINEUP
+      Displaces the weakest starter (0.0) in the best eleven.
+
+No position — he spotted "no striker" himself and the message never said
+Tapsoba is a defender. "unknown club" on every proposal, because the market
+payload carries `tid` and never `tn`. And with a short squad there is no
+incumbent to displace, so the middle section printed a placeholder and 0.0.
+
+`PlayerScore` already computes position, lineup probability, minutes trend,
+average points and next opponent, and the renderer discarded all of it.
+
+The selection rule is deliberately a walk, not a knapsack: the reader has to
+be able to see why the list is ordered the way it is, and a set that skipped
+the second line to afford the fourth would read as a bug.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rehoboam.notify.overview import (
+    ProposalLine,
+    render_proposal_overview,
+    split_by_budget,
+)
+
+BUDGET = 51_626_013
+
+
+def _line(name, bid, ep, **kw):
+    kw.setdefault("position", "Midfielder")
+    kw.setdefault("club", "Bayern")
+    kw.setdefault("market_value", int(bid / 1.3))
+    return ProposalLine(proposal_id=name.lower(), name=name, bid=bid, ep=ep, marginal_gain=ep, **kw)
+
+
+# The real 2026-09-01 board.
+COUFAL = _line(
+    "Coufal", 31_536_624, 96.0, position="Defender", club="Hoffenheim", is_emergency=True
+)
+CASTELLO = _line("Castello Jr.", 20_089_389, 74.0, is_emergency=True)
+ANDRES = _line("Andrés", 5_968_130, 52.0, position="Forward", club="Mainz", fills_gap=True)
+AVDULLAHU = _line("Avdullahu", 22_040_401, 72.0)
+REIS = _line("Reis", 10_296_969, 61.0, position="Defender")
+
+BOARD = [COUFAL, CASTELLO, ANDRES, AVDULLAHU, REIS]
+
+
+class TestTheRecommendedSetFits:
+    def test_it_never_exceeds_the_budget(self):
+        """The bug in the mockup this was designed from: 57.6m against 51.6m."""
+        recommended, _ = split_by_budget(BOARD, BUDGET)
+
+        assert sum(line.bid for line in recommended) <= BUDGET
+
+    def test_nothing_is_dropped_on_the_floor(self):
+        """Every proposal appears somewhere — Marco asked for all of them."""
+        recommended, alternatives = split_by_budget(BOARD, BUDGET)
+
+        assert sorted(x.name for x in recommended + alternatives) == sorted(x.name for x in BOARD)
+
+    def test_emergency_picks_come_first(self):
+        """They carry the -100, so they outrank a better ordinary upgrade."""
+        recommended, _ = split_by_budget(BOARD, BUDGET)
+
+        assert recommended[0].name == "Coufal"
+        assert {"Coufal", "Castello Jr."} <= {line.name for line in recommended}
+
+    def test_an_unaffordable_line_does_not_block_a_cheaper_one_behind_it(self):
+        """Walking past one that does not fit still fills the slot after it."""
+        recommended, alternatives = split_by_budget(BOARD, BUDGET)
+
+        # Coufal + Castello = 51,626,013 exactly; nothing else can fit.
+        assert sum(line.bid for line in recommended) == 51_626_013
+        assert {a.name for a in alternatives} == {"Andrés", "Avdullahu", "Reis"}
+
+    def test_a_generous_budget_recommends_everything(self):
+        recommended, alternatives = split_by_budget(BOARD, 500_000_000)
+
+        assert len(recommended) == len(BOARD)
+        assert alternatives == []
+
+    def test_no_budget_recommends_nothing(self):
+        recommended, alternatives = split_by_budget(BOARD, 0)
+
+        assert recommended == []
+        assert len(alternatives) == len(BOARD)
+
+
+class TestTheMessageAnswersWhatWasMissing:
+    def _render(self, budget=BUDGET):
+        recommended, alternatives = split_by_budget(BOARD, budget)
+        return render_proposal_overview(
+            squad_size=9,
+            squad_cap=15,
+            budget=budget,
+            recommended=recommended,
+            alternatives=alternatives,
+        )
+
+    def test_it_names_the_position(self):
+        """Marco spotted 'no striker' himself; the message never said."""
+        assert "DEF" in self._render() or "Defender" in self._render()
+
+    def test_it_names_the_club(self):
+        assert "Hoffenheim" in self._render()
+
+    def test_it_never_prints_unknown_club_when_the_club_is_known(self):
+        assert "unknown club" not in self._render()
+
+    def test_it_shows_every_proposal_in_one_message(self):
+        text = self._render()
+
+        for line in BOARD:
+            assert line.name in text
+
+    def test_it_shows_the_total_and_what_is_left(self):
+        text = self._render()
+
+        assert f"{51_626_013:,}" in text
+
+    def test_it_separates_what_fits_from_what_does_not(self):
+        text = self._render().lower()
+
+        assert "recommend" in text
+        assert "alternativ" in text or "needs a sell" in text
+
+    def test_an_empty_slot_is_not_described_as_displacing_anyone(self):
+        """The old message printed 'Displaces the weakest starter (0.0)'."""
+        text = self._render()
+
+        assert "0.0)" not in text
+        assert "weakest starter" not in text
+
+
+class TestTheRiskIsVisible:
+    def test_a_falling_market_value_is_flagged(self):
+        """Itten went out at -27.0%/7d with the number printed and no warning."""
+        falling = _line("Itten", 6_174_557, 44.0, trend_7d_pct=-27.0)
+
+        text = render_proposal_overview(
+            squad_size=9, squad_cap=15, budget=BUDGET, recommended=[falling], alternatives=[]
+        )
+
+        assert "-27.0" in text
+        assert "falling" in text.lower()
+
+    def test_a_rising_market_value_is_not_flagged_as_a_risk(self):
+        rising = _line("Rising", 6_174_557, 44.0, trend_7d_pct=12.0)
+
+        text = render_proposal_overview(
+            squad_size=9, squad_cap=15, budget=BUDGET, recommended=[rising], alternatives=[]
+        )
+
+        assert "falling" not in text.lower()
+
+
+@pytest.mark.parametrize("budget", [0, 1, 5_968_130, 51_626_013, 999_999_999])
+def test_the_recommended_set_always_fits(budget):
+    recommended, _ = split_by_budget(BOARD, budget)
+
+    assert sum(line.bid for line in recommended) <= budget
+
+
+class TestAPositionGapRanksWithAnEmergency:
+    """`emergency_basket._value` counts gap coverage at the slot penalty.
+
+    A position below its formation minimum makes the eleven illegal rather
+    than merely weaker, so the two orderings must agree — otherwise the
+    message recommends a surplus midfielder over the only striker.
+    """
+
+    def test_the_only_forward_outranks_a_higher_ep_surplus_midfielder(self):
+        gap = _line("Striker", 5_000_000, 52.0, position="Forward", fills_gap=True)
+        surplus = _line("Surplus", 5_000_000, 72.0, position="Midfielder")
+
+        recommended, _ = split_by_budget([surplus, gap], 5_000_000)
+
+        assert [x.name for x in recommended] == ["Striker"]

--- a/tests/test_scoring_v2/test_club_name.py
+++ b/tests/test_scoring_v2/test_club_name.py
@@ -1,0 +1,42 @@
+"""The club name reaches the proposal message (REH-117).
+
+`score_player_v2` has `data.team_strength.team_name` in scope and dropped it,
+so every proposal Marco received said "unknown club" — the market payload
+carries `tid` and never `tn`, and nothing downstream had the name.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from rehoboam.scoring.models import PlayerData
+from rehoboam.scoring.v2.adapter import score_player_v2
+from tests.test_scoring_v2.test_adapter import _player
+
+
+def _data(*, team_strength=None, player_details=None) -> PlayerData:
+    return PlayerData(
+        player=_player("1"),
+        performance=None,
+        player_details=player_details,
+        team_strength=team_strength,
+        opponent_strength=None,
+        is_dgw=False,
+    )
+
+
+def test_the_club_comes_from_team_strength():
+    score = score_player_v2(_data(team_strength=SimpleNamespace(team_name="Bayer Leverkusen")))
+
+    assert score.club == "Bayer Leverkusen"
+
+
+def test_it_falls_back_to_player_details():
+    score = score_player_v2(_data(player_details={"tn": "1. FC Union Berlin"}))
+
+    assert score.club == "1. FC Union Berlin"
+
+
+def test_an_unknown_club_is_empty_not_a_guess():
+    """Better blank than wrong — a wrong club actively misleads."""
+    assert score_player_v2(_data()).club == ""


### PR DESCRIPTION
> "instead of a message for each player the overview should include all" — and "numerous accept and decline options but I could not accept all since the budget was reached"

Both are one cause. Proposals went out **one Telegram message per player**, so nothing could show that they compete for a single wallet. On 2026-08-31 you approved Nusa and Ebnoutalib, which consumed the budget, and Avdullahu, Reis and a second Avdullahu then died on `budget would go negative` — four dead proposals in two days, invisible from six separate messages.

## One message, budget-aware

Live against prod:

```
SQUAD 9/15   BUDGET EUR 51,626,013

RECOMMENDED — 4 of 5
  Vladimír Coufal (DEF, Hoffenheim)  EUR 34,966,475
      avg 136/game · EP 117 · next Dortmund
      MV 25,901,093 · bid +35.0% · trend +0.1%/7d
      fills an empty lineup slot (worth +100)

  Stefano Marino (FWD, Paderborn)  EUR 8,581,580
      avg 35/game · EP 55 · next Freiburg
      MV 7,341,580 · bid +16.9% · trend -16.5%/7d  <-- FALLING
      fills an empty lineup slot (worth +100)
  ...
  total EUR 48,207,760   leaves EUR 3,418,253

ALTERNATIVES — need a sell first
  Ludovit Reis (MID, Bremen)  EUR 9,983,711
      ! Data quality C — no fitted history, scored on the position prior.
```

One **`✅ Approve all 4`** button for the set, individual buttons for the alternatives.

`split_by_budget` is a **walk, not a knapsack**. A knapsack fits marginally more money and would sometimes skip the second line to afford the fourth — which, in a list read top to bottom, looks like a bug. Order: slot-filling emergencies and position gaps first (the same argument `emergency_basket._value` makes when it counts gap coverage at the -100), then expected points, take what fits. A line that does not fit is stepped over rather than allowed to strand the rest.

## The content was the other half

What you actually received:

```
BUY Edmond Tapsoba — EUR 41,702,302
WHY THIS PLAYER
  EP 107.0. unknown club.
WHY IT IMPROVES THE LINEUP
  Displaces the weakest starter (0.0) in the best eleven.
```

- **No position.** You spotted "no striker" yourself; the message never said Tapsoba is a defender.
- **"unknown club"** on every proposal — the market payload carries `tid` and never `tn`.
- **A vacuous middle section** — with a short squad there is no incumbent, so it printed a placeholder and a zero.

`PlayerScore` already carried position, lineup probability, minutes trend, average points and next opponent, and the renderer discarded all of it. The club name was genuinely missing, so `score_player_v2` now carries `club` from the team profile it already fetches. Unknown stays **blank rather than guessed** — a wrong club actively misleads.

## Falling market values are now blocked, not just printed

Two thresholds, deliberately different:

| Below | Behaviour |
|---|---|
| **-10%/7d** | flagged `<-- FALLING`, still proposed — a mild slide on a good player is your call |
| **-20%/7d** | not proposed at all (`MAX_FALLING_TREND_PCT_TO_BUY`) |

Of the 21 proposals measured, Itten (-27.0%), Stalmach (-32.1%) and Trimmel (-20.1%) clear the block; Ndiaye (-19.5%) is flagged, not blocked. Profit flips keep their own rules and stay autonomous.

## Verification

- 44 new tests across four files, each watched fail first — including that the recommended set **actually fits** (the mockup this was designed from had a set totalling €57.6m against a €51.6m budget)
- **1546 passed, 1 skipped**; ruff clean; all 19 existing webhook tests green after the callback change
- Replay **27,751 — unchanged**, predicted: this is the notification path
- Live smoke against prod, shown above

`approveall:<batch_id>` runs through the same `execute_proposal` the single tap uses — a second execute path would be the seventh copy of one rule in this repo. Each proposal is claimed individually, so a retried callback finds an empty batch, and a gate refusal on one line does not abandon the set.

`status` collects the board *before* its dry-run exit, so the preview renders the message you would actually receive rather than a line saying one exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgdBR45xMFtj2zTgFL1VEn