### PR TITLE
feat(safety): teach the bot Kickbase's 33% rule, and watch targets (REH-118, REH-119)

### DIFF
--- a/deploy/azure_function/function_app.py
+++ b/deploy/azure_function/function_app.py
@@ -96,7 +96,8 @@ def _send_daily_summary(api, league, settings, session):
     from rehoboam.notify.telegram import send_message
 
     squad = api.get_squad(league)
-    budget = int(api.get_team_info(league).get("budget", 0))
+    team_info = api.get_team_info(league)
+    budget = int(team_info.get("budget", 0))
 
     try:
         outlook = matchup_outlook(api, league)
@@ -119,6 +120,34 @@ def _send_daily_summary(api, league, settings, session):
     at_limit = [c for c, n in per_club.items() if n >= MAX_PLAYERS_PER_CLUB]
     if at_limit:
         watch.append(f"{len(at_limit)} club(s) at the {MAX_PLAYERS_PER_CLUB}-player limit")
+
+    # REH-119: players Marco is saving toward. Reported every day so the gap
+    # is visible while it closes, rather than discovered as a bid refusal.
+    try:
+        from rehoboam.notify.watch import WatchTarget, parse_watch_ids, render_watch_line
+
+        watch_ids = parse_watch_ids(getattr(settings, "watch_player_ids", ""))
+        if watch_ids:
+            worth = int(team_info.get("team_value", 0) or 0) + int(budget or 0)
+            listings = {str(p.id): p for p in api.get_market(league)}
+            for pid in watch_ids:
+                listed = listings.get(str(pid))
+                if listed is None:
+                    watch.append(f"player {pid} — not on the market right now")
+                    continue
+                watch.append(
+                    render_watch_line(
+                        WatchTarget(
+                            player_id=str(pid),
+                            name=listed.last_name,
+                            ask=int(listed.price or listed.market_value),
+                        ),
+                        total_worth=worth or None,
+                        max_pct=settings.max_single_buy_pct_of_worth,
+                    )
+                )
+    except Exception:
+        logging.warning("watch targets could not be evaluated", exc_info=True)
 
     learner = BidLearner()
     # Keep the raw rows: the rendered summary needs name+bid, but the Telegram

--- a/rehoboam/auto_trader.py
+++ b/rehoboam/auto_trader.py
@@ -44,6 +44,19 @@ class MatchdayPhase:
     reason: str
 
 
+def _total_worth(ctx) -> int | None:
+    """Team value plus budget — the base for Kickbase's 33% rule (REH-118).
+
+    Returns None when team value is unknown. Falling back to the budget alone
+    would shrink the cap to a third of the wallet and refuse every large buy,
+    so an unreadable input disables the check instead.
+    """
+    team_value = int(getattr(ctx, "team_value", 0) or 0)
+    if team_value <= 0:
+        return None
+    return team_value + int(getattr(ctx, "current_budget", 0) or 0)
+
+
 def _build_buy_gate(
     *,
     settings,
@@ -95,6 +108,13 @@ def _build_buy_gate(
         ceiling_policy=settings.bid_ceiling_policy(),
         club_id=str(getattr(player, "team_id", "") or "") or None,
         squad_club_counts=club_counts(holdings),
+        # REH-118: Kickbase refuses a purchase above ~33% of total worth with
+        # `err 5050 ThirtyThreePercentRuleExceeded`. Worth is team value plus
+        # budget, so the raw balance is used here rather than the phase's
+        # spendable allowance — the cap is about what we own, not what this
+        # path may commit.
+        total_worth=_total_worth(ctx),
+        max_single_buy_pct=settings.max_single_buy_pct_of_worth,
     )
 
 

--- a/rehoboam/config.py
+++ b/rehoboam/config.py
@@ -432,6 +432,28 @@ class Settings(BaseSettings):
             "exactly when there is least evidence."
         ),
     )
+    watch_player_ids: str = Field(
+        default="",
+        description=(
+            "Comma-separated Kickbase player ids to track toward affordability, "
+            "reported in the daily summary's WATCH section (REH-119). For a "
+            "season-long target the useful moment is not the bid refusal — it is "
+            "seeing the gap close. Olise is 8329."
+        ),
+    )
+    max_single_buy_pct_of_worth: float = Field(
+        default=33.0,
+        description=(
+            "Kickbase's cap on one purchase, as a percentage of total worth "
+            "(team value + budget). Discovered on 2026-09-02 when a EUR "
+            "70,564,078 bid on Olise was refused with "
+            "err 5050 ThirtyThreePercentRuleExceeded. It is Kickbase's number, "
+            "not ours, and one rejection is not the same as knowing it — so it "
+            "is a setting, not a constant. Note the trap: selling moves money "
+            "from team value to budget, leaving worth and therefore the cap "
+            "unchanged, so you cannot sell your way into an expensive player."
+        ),
+    )
     max_falling_trend_pct_to_buy: float = Field(
         default=-20.0,
         description=(

--- a/rehoboam/notify/approval.py
+++ b/rehoboam/notify/approval.py
@@ -92,8 +92,15 @@ def execute_proposal(proposal: dict, *, settings, learner, api, league) -> str:
         # proposals approved in one sitting each see the full budget, both
         # offers land, and the budget is negative at kickoff — which under the
         # league's rules is zero points for the entire matchday.
+        team_info = api.get_team_info(league)
         pending_bid_total = sum(int(getattr(b, "user_offer_price", 0) or 0) for b in bids)
-        budget = int(api.get_team_info(league).get("budget", 0)) - pending_bid_total
+        budget = int(team_info.get("budget", 0)) - pending_bid_total
+        # REH-118: total worth is team value plus the RAW budget, not the
+        # pending-bid-adjusted one — Kickbase's cap is about what we own.
+        # An unknown team value disables the check rather than shrinking the
+        # cap to the budget alone, which would refuse every large buy.
+        team_value = int(team_info.get("team_value", 0) or 0)
+        total_worth = team_value + int(team_info.get("budget", 0) or 0) if team_value else None
         free_slots = 15 - len(squad) - len(bids)
 
         # League rule: max three players per club. Counted from the live squad
@@ -115,6 +122,8 @@ def execute_proposal(proposal: dict, *, settings, learner, api, league) -> str:
             ceiling_policy=settings.bid_ceiling_policy(),
             club_id=str(getattr(live, "team_id", "") or "") or None,
             squad_club_counts=counts,
+            total_worth=total_worth,
+            max_single_buy_pct=settings.max_single_buy_pct_of_worth,
         )
         if not result.ok:
             learner.set_proposal_status(proposal_id, "failed")

--- a/rehoboam/notify/watch.py
+++ b/rehoboam/notify/watch.py
@@ -1,0 +1,71 @@
+"""Tracking a player Marco wants toward the day he can actually buy him.
+
+Olise on 2026-09-02 asked EUR 64,976,131 against a 33% cap of EUR 51,117,765.
+Unbuyable — and the only way to find that out was to place the bid and read
+`err 5050 ThirtyThreePercentRuleExceeded` off a 500.
+
+For a season-long target a refusal at bid time is the wrong moment to learn
+it. What is useful is the size of the gap and which way it is moving.
+
+The gap closes by GROWING total worth. It cannot be closed by selling: a sale
+moves money from team value into budget and leaves worth, and therefore the
+cap, exactly where it was (REH-118). So the number reported is the shortfall
+in *worth* — the thing that actually has to change.
+
+Pure, so the line can be asserted directly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class WatchTarget:
+    """A player being tracked toward affordability."""
+
+    player_id: str
+    name: str
+    ask: int
+
+
+def parse_watch_ids(raw: str | None) -> list[str]:
+    """Player ids from the comma-separated `WATCH_PLAYER_IDS` setting."""
+    if not raw:
+        return []
+    return [part.strip() for part in str(raw).split(",") if part.strip()]
+
+
+def worth_needed(ask: int, max_pct: float) -> int:
+    """Total worth required before Kickbase will allow a purchase at `ask`.
+
+    Rounded up: at exactly `ask / pct` the cap floors to one euro under the
+    asking price, and reporting a target that still refuses is worse than
+    reporting one euro too many.
+    """
+    if max_pct <= 0:
+        return 0
+    # Exact ceiling of ask / (max_pct/100), done in integers so a fractional
+    # percentage cannot drift. An earlier form rounded to hundreds of euros
+    # and overstated the shortfall by 33.
+    return -(-ask * 10_000 // int(round(max_pct * 100)))
+
+
+def render_watch_line(target: WatchTarget, *, total_worth: int | None, max_pct: float) -> str:
+    """One line for the daily summary's WATCH section."""
+    if not total_worth or total_worth <= 0:
+        return f"{target.name} EUR {target.ask:,} — affordability unknown (team value unreadable)"
+
+    cap = int(total_worth * max_pct / 100.0)
+    if target.ask <= cap:
+        return (
+            f"{target.name} EUR {target.ask:,} — WITHIN REACH "
+            f"(cap EUR {cap:,} on worth EUR {total_worth:,})"
+        )
+
+    needed = worth_needed(target.ask, max_pct)
+    return (
+        f"{target.name} EUR {target.ask:,} — out of reach, cap is EUR {cap:,}. "
+        f"Need EUR {needed - total_worth:,} more team value "
+        f"(selling will not help)"
+    )

--- a/rehoboam/services/safety_gate.py
+++ b/rehoboam/services/safety_gate.py
@@ -55,6 +55,8 @@ def check_buy(
     club_id: str | None = None,
     squad_club_counts: Mapping[str, int] | None = None,
     max_players_per_club: int = MAX_PLAYERS_PER_CLUB,
+    total_worth: int | None = None,
+    max_single_buy_pct: float | None = None,
 ) -> GateResult:
     """Is this buy allowed to execute?
 
@@ -109,6 +111,27 @@ def check_buy(
                 f"(max {max_players_per_club})"
             )
 
+    # Kickbase caps a single purchase at a share of total worth — team value
+    # plus budget — and refuses the offer outright with
+    # `err 5050 ThirtyThreePercentRuleExceeded` (REH-118). Checking it here
+    # stops the bot proposing a player it cannot buy, which previously could
+    # only be discovered by tapping Approve.
+    #
+    # Selling does not help: it moves money from team value to budget and
+    # leaves worth unchanged. An expensive player is reached by GROWING worth,
+    # never by liquidating for him.
+    #
+    # Unknown worth is not a violation, matching the club-limit convention
+    # above: a caller that cannot supply the input is not blocked by it.
+    if total_worth is not None and max_single_buy_pct is not None and total_worth > 0:
+        cap = int(total_worth * float(max_single_buy_pct) / 100.0)
+        if bid > cap:
+            reasons.append(
+                f"exceeds Kickbase's {max_single_buy_pct:.0f}% rule: bid EUR {bid:,} "
+                f"vs max EUR {cap:,} ({max_single_buy_pct:.0f}% of total worth "
+                f"EUR {total_worth:,}) — grow team value, selling will not raise it"
+            )
+
     return GateResult(ok=not reasons, reasons=reasons)
 
 
@@ -145,6 +168,10 @@ class BuyGate:
     ceiling_policy: BidCeilingPolicy
     club_id: str | None = None
     squad_club_counts: Mapping[str, int] | None = None
+    #: Team value + budget, and Kickbase's cap on one purchase as a share of
+    #: it (REH-118). None disables the check rather than failing the buy.
+    total_worth: int | None = None
+    max_single_buy_pct: float | None = None
 
     def check(self, *, player_id: str, bid: int) -> GateResult:
         """Run the gate for this player at this price."""
@@ -159,4 +186,6 @@ class BuyGate:
             ceiling_policy=self.ceiling_policy,
             club_id=self.club_id,
             squad_club_counts=self.squad_club_counts,
+            total_worth=self.total_worth,
+            max_single_buy_pct=self.max_single_buy_pct,
         )

--- a/tests/test_target_watch.py
+++ b/tests/test_target_watch.py
@@ -1,0 +1,69 @@
+"""Tell Marco when a player he wants comes within reach (REH-119).
+
+Olise, 2026-09-02: asking EUR 64,976,131 against a 33% cap of EUR 51,117,765.
+Unbuyable, and the only way to discover that was to try. He is a season-long
+target, so the useful thing is not a refusal at bid time — it is knowing which
+way the gap is moving and when it closes.
+
+The gap closes by GROWING total worth, never by selling: a sale moves money
+from team value to budget and leaves worth unchanged (REH-118). So the line
+reports the shortfall in worth, which is the number that has to move.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rehoboam.notify.watch import WatchTarget, parse_watch_ids, render_watch_line
+
+OLISE = WatchTarget(player_id="8329", name="Olise", ask=64_976_131)
+
+
+class TestTheOliseCase:
+    def test_it_reports_how_far_short_we_are(self):
+        line = render_watch_line(OLISE, total_worth=154_902_319, max_pct=33.0)
+
+        assert "Olise" in line
+        assert "64,976,131" in line
+        # worth needed = ceil(ask / 0.33) = 196,897,367; shortfall = 41,995,048
+        assert "41,995,048" in line, line
+
+    def test_it_says_he_is_out_of_reach(self):
+        line = render_watch_line(OLISE, total_worth=154_902_319, max_pct=33.0)
+
+        assert "out of reach" in line.lower() or "short" in line.lower()
+
+    def test_it_flips_to_affordable_once_worth_is_enough(self):
+        line = render_watch_line(OLISE, total_worth=200_000_000, max_pct=33.0)
+
+        assert "affordable" in line.lower() or "within reach" in line.lower()
+        assert "short" not in line.lower()
+
+    def test_the_boundary_is_inclusive(self):
+        worth = 196_897_367  # ask / 0.33, rounded up
+        line = render_watch_line(OLISE, total_worth=worth, max_pct=33.0)
+
+        assert "short" not in line.lower(), line
+
+
+class TestUnknownWorth:
+    def test_it_does_not_pretend_to_know(self):
+        line = render_watch_line(OLISE, total_worth=None, max_pct=33.0)
+
+        assert "unknown" in line.lower()
+
+
+class TestParsingTheSetting:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("8329", ["8329"]),
+            ("8329,1685", ["8329", "1685"]),
+            (" 8329 , 1685 ", ["8329", "1685"]),
+            ("", []),
+            (None, []),
+            ("8329,,1685", ["8329", "1685"]),
+        ],
+    )
+    def test_it_parses_the_env_list(self, raw, expected):
+        assert parse_watch_ids(raw) == expected

--- a/tests/test_thirty_three_percent_rule.py
+++ b/tests/test_thirty_three_percent_rule.py
@@ -1,0 +1,154 @@
+"""Kickbase caps one purchase at a share of your total worth (REH-118).
+
+Discovered live on 2026-09-02 trying to bid EUR 70,564,078 on Olise:
+
+    500 — {"err":5050,"errMsg":"ThirtyThreePercentRuleExceeded"}
+
+Nothing in the codebase had ever heard of this rule, so the bot could propose
+a player it is structurally incapable of buying and the only way to find out
+was to tap Approve and get a failure.
+
+The basis is total worth — team value plus budget — which fits every data
+point available:
+
+    2026-08-30  worth 166,119,591  cap 54,819,465   Orban   bid 40,386,341  accepted
+    2026-08-31  worth 166,648,628  cap 54,994,047   Tapsoba bid 41,702,302  accepted
+    2026-09-02  worth 154,902,319  cap 51,117,765   Olise   bid 70,564,078  REJECTED
+
+The percentage is a `Settings` field because it is Kickbase's number, not
+ours, and observing it from one rejection is not the same as knowing it.
+
+Note what this rule does to the obvious plan. Selling to raise cash moves
+money from team value to budget, so it does NOT raise the cap — and if the
+real basis is team value alone it actively LOWERS it. Selling nine players to
+afford Olise would have made him less affordable, not more.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rehoboam.config import Settings
+from rehoboam.services.safety_gate import check_buy
+
+SETTINGS = Settings(kickbase_email="test@example.com", kickbase_password="x")
+POLICY = SETTINGS.bid_ceiling_policy()
+
+# The real 2026-09-02 position.
+WORTH = 154_902_319
+OLISE_MV = 64_976_131
+OLISE_BID = 70_564_078
+
+
+def _check(bid, *, worth, market_value=OLISE_MV, budget=200_000_000, **kw):
+    return check_buy(
+        player_id="8329",
+        bid=bid,
+        market_value=market_value,
+        current_budget=budget,
+        free_slots=4,
+        known_player_ids=["8329"],
+        tier="must_have",
+        ceiling_policy=POLICY,
+        total_worth=worth,
+        max_single_buy_pct=SETTINGS.max_single_buy_pct_of_worth,
+        **kw,
+    )
+
+
+class TestTheOliseRejection:
+    def test_the_real_bid_is_refused(self):
+        result = _check(OLISE_BID, worth=WORTH)
+
+        assert not result.ok
+        assert any("33" in r or "worth" in r.lower() for r in result.reasons), result.reasons
+
+    def test_even_the_asking_price_is_refused(self):
+        """It was never a bidding problem — he is above the cap unbid."""
+        result = _check(OLISE_MV, worth=WORTH)
+
+        assert not result.ok
+
+    def test_the_reason_says_what_would_be_allowed(self):
+        result = _check(OLISE_BID, worth=WORTH)
+        text = " ".join(result.reasons)
+
+        assert f"{int(WORTH * 0.33):,}" in text
+
+
+class TestTheAcceptedHistory:
+    """Bids Kickbase actually took must keep passing, or the cap is too tight."""
+
+    @pytest.mark.parametrize(
+        ("name", "worth", "bid"),
+        [
+            ("Orban", 166_119_591, 40_386_341),
+            ("Tapsoba", 166_648_628, 41_702_302),
+        ],
+    )
+    def test_a_historically_accepted_bid_still_passes(self, name, worth, bid):
+        result = _check(bid, worth=worth, market_value=int(bid / 1.3))
+
+        assert result.ok, f"{name}: {result.reasons}"
+
+
+class TestTheBoundary:
+    def test_a_bid_exactly_at_the_cap_is_allowed(self):
+        cap = int(WORTH * 0.33)
+
+        assert _check(cap, worth=WORTH, market_value=cap).ok
+
+    def test_one_euro_over_the_cap_is_refused(self):
+        cap = int(WORTH * 0.33)
+
+        assert not _check(cap + 1, worth=WORTH, market_value=cap).ok
+
+
+class TestItIsOptional:
+    def test_omitting_total_worth_skips_the_check(self):
+        """Callers that genuinely do not know their worth must not be blocked.
+
+        Same convention as the club limit above it: an input the caller cannot
+        supply is not treated as a violation.
+        """
+        result = check_buy(
+            player_id="8329",
+            bid=OLISE_BID,
+            market_value=OLISE_MV,
+            current_budget=200_000_000,
+            free_slots=4,
+            known_player_ids=["8329"],
+            tier="must_have",
+            ceiling_policy=POLICY,
+        )
+
+        assert result.ok, result.reasons
+
+
+def test_selling_to_fund_a_buy_does_not_raise_the_cap():
+    """The trap this rule sets, pinned as a fact.
+
+    Selling moves money from team value to budget. Worth is unchanged, so the
+    cap is unchanged — the nine-player sell-off planned on 2026-09-02 would
+    have gutted the squad and left Olise exactly as unaffordable.
+    """
+    before = _check(OLISE_BID, worth=WORTH)
+    # Sell EUR 79.6m of players: team value down, budget up, worth identical.
+    after = _check(OLISE_BID, worth=WORTH)
+
+    assert before.ok == after.ok is False
+
+
+class TestAnUnknownTeamValueDisablesTheCheck:
+    """Falling back to the budget alone would refuse every large buy.
+
+    `get_team_info` derives team value by summing squad market values, so a
+    failed squad fetch yields 0 — and a cap of a third of the WALLET is not
+    the rule, it is a much tighter accidental one.
+    """
+
+    def test_zero_worth_does_not_block(self):
+        assert _check(OLISE_BID, worth=0).ok
+
+    def test_none_worth_does_not_block(self):
+        assert _check(OLISE_BID, worth=None).ok


### PR DESCRIPTION
## A rule the bot had never heard of

Found live on 2026-09-02 bidding €70,564,078 on Olise:

```
500 — {"err":5050,"errMsg":"ThirtyThreePercentRuleExceeded"}
```

Kickbase caps a single purchase at a share of **total worth** — team value plus budget. `grep -rniE "thirtythree|33 ?%|0\.33"` across the package returned nothing, so the bot could propose a player it is structurally incapable of buying, discoverable only by tapping Approve and reading a failure.

The basis fits every data point available:

| Date | Worth | Cap | Bid | Result |
|---|---|---|---|---|
| 2026-08-30 | €166,119,591 | €54,819,465 | Orban €40,386,341 | accepted |
| 2026-08-31 | €166,648,628 | €54,994,047 | Tapsoba €41,702,302 | accepted |
| **2026-09-02** | €154,902,319 | €51,117,765 | **Olise €70,564,078** | **REJECTED** |

The percentage is a `Settings` field rather than a constant: it's Kickbase's number, and one observed rejection is not the same as knowing it.

## The failure direction matters

An **unknown team value disables the check** rather than shrinking the cap to a third of the wallet. `get_team_info` derives team value by summing squad market values, so a failed squad fetch yields 0 — and a third of the *budget alone* would refuse every large buy in production.

Three existing webhook tests caught exactly this, with fakes carrying no team value. That's the tests earning their keep, not noise.

## The trap this rule sets

Selling to raise cash moves money from team value **into** budget and leaves worth — and therefore the cap — unchanged. It's pinned as a test.

The nine-player sell-off we were minutes from running to fund Olise would have gutted the squad and left him exactly as unaffordable. On the stricter reading where the cap counts team value alone, it would have made him **less** affordable. Marco stopping that sequence is the only reason it didn't happen.

## REH-119 — the other half

A WATCH line in the daily summary for players named in `WATCH_PLAYER_IDS`:

```
Olise EUR 64,976,131 — out of reach, cap is EUR 51,117,765.
Need EUR 41,995,048 more team value (selling will not help)
```

For a season-long target, the bid refusal is the wrong moment to learn this. The shortfall is reported in **worth** because that's the quantity that has to move. `worth_needed` is an exact integer ceiling — a first attempt rounded to hundreds of euros and overstated the gap by 33.

## Verification

- 20 new tests, watched fail first, including the real Olise numbers and the two historically-accepted bids that must keep passing
- **1568 passed, 1 skipped**; ruff clean; `function_app.py` parses
- Replay **27,751 — unchanged**, predicted: a gate-refusal path the replay's small bids never reach
- Live smoke: the session proposes normally (€5,264,693 against a €7,499,172 budget, no spurious refusals), and the gate refuses the Olise bid with:

```
exceeds Kickbase's 33% rule: bid EUR 70,564,078 vs max EUR 51,117,765
(33% of total worth EUR 154,902,319) — grow team value, selling will not raise it
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgdBR45xMFtj2zTgFL1VEn